### PR TITLE
[Ballerina to OAS] Fix for listener type casting issue  

### DIFF
--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIEndpointMapper.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIEndpointMapper.java
@@ -158,7 +158,7 @@ public class OpenAPIEndpointMapper {
         if (list.isPresent()) {
             SeparatedNodeList<FunctionArgumentNode> arg = (list.get()).arguments();
             port = arg.get(0).toString();
-            if (arg.size() > 1) {
+            if (arg.size() > 1 && (arg.get(1) instanceof NamedArgumentNode)) {
                 ExpressionNode bLangRecordLiteral = ((NamedArgumentNode) arg.get(1)).expression();
                 if (bLangRecordLiteral instanceof MappingConstructorExpressionNode) {
                     host = extractHost((MappingConstructorExpressionNode) bLangRecordLiteral);


### PR DESCRIPTION
## Purpose
> Currently ballerina to OpenAPI command support for HTTP: listeners and in case it has some another type configurations it will return localhost for the host.
Fix ballerina-platform/ballerina-standard-library#5511 
## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> ballerina-platform/openapi-tools#542

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.