### PR TITLE
[Client] Fix picking first response type

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionReturnType.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionReturnType.java
@@ -39,7 +39,6 @@ import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -90,11 +89,12 @@ public class FunctionReturnType {
         String returnType = "http:Response|error";
         if (operation.getResponses() != null) {
             ApiResponses responses = operation.getResponses();
-            Collection<ApiResponse> values = responses.values();
-            Iterator<ApiResponse> iteratorRes = values.iterator();
+            Iterator<Map.Entry<String, ApiResponse>> iteratorRes = responses.entrySet().iterator();
             while (iteratorRes.hasNext()) {
-                ApiResponse response = iteratorRes.next();
-                if (response.getContent() != null) {
+                Map.Entry<String, ApiResponse> entry = iteratorRes.next();
+                String statusCode = entry.getKey();
+                ApiResponse response = entry.getValue();
+                if (statusCode.startsWith("2") && response.getContent() != null) {
                     Content content = response.getContent();
                     Set<Map.Entry<String, MediaType>> mediaTypes = content.entrySet();
                     for (Map.Entry<String, MediaType> media : mediaTypes) {
@@ -114,9 +114,8 @@ public class FunctionReturnType {
                         // Currently support for first media type
                         break;
                     }
+                    break;
                 }
-                // Currently support for first response.
-                break;
             }
         }
         return returnType;

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -103,6 +103,9 @@ public class FunctionBodyNodeTests {
                         "xml? xmlBody = check xmldata:fromJson(jsonBody);" +
                         "request.setPayload(xmlBody);" +
                         "http:Response response = check self.clientEp->post(path, request, targetType=http:Response);" +
+                        "return response;}"},
+                {"swagger/response_type_order.yaml", "/pet/{petId}", "{string path = string `/pet/${petId}`;" +
+                        "Pet response = check self.clientEp->get(path, targetType = Pet);" +
                         "return response;}"}
         };
     }

--- a/openapi-cli/src/test/resources/generators/client/swagger/response_type_order.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/response_type_order.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.1
+info:
+  title: Swagger Petstore
+  description: 'This is a sample server Petstore server.'
+  version: 1.0.0
+servers:
+  - url: https://petstore.swagger.io/v2
+paths:
+  /pet/{petId}:
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+      responses:
+        400:
+          description: Invalid ID supplied
+          content: {}
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        404:
+          description: Pet not found
+          content: {}
+components:
+  schemas:
+    Pet:
+      required:
+        - name
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string


### PR DESCRIPTION
## Purpose
When there are multiple response type for a function, pick the `2xx` status code response type as target type.

## Goals
Fixes https://github.com/ballerina-platform/ballerina-openapi/issues/625

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
