### PR TITLE
[Client] Add return statement to client init 

### DIFF
--- a/module-ballerina-openapi/build.gradle
+++ b/module-ballerina-openapi/build.gradle
@@ -177,10 +177,10 @@ task ballerinaBuild {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/bal.bat build --skip-tests -c && exit " +
+                commandLine 'cmd', '/c', "$distributionBinPath/bal.bat build -c && exit " +
                         "%%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "${distributionBinPath}"+'/bal build --skip-tests -c'
+                commandLine 'sh', '-c', "${distributionBinPath}"+'/bal build -c'
             }
         }
 

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
@@ -39,6 +39,7 @@ import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
 import io.ballerina.compiler.syntax.tree.OptionalTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.ParameterNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.ReturnStatementNode;
 import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
@@ -88,6 +89,7 @@ import static io.ballerina.compiler.syntax.tree.NodeFactory.createModulePartNode
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createObjectFieldNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createOptionalTypeDescriptorNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createQualifiedNameReferenceNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createReturnStatementNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createReturnTypeDescriptorNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createSimpleNameReferenceNode;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.CLASS_KEYWORD;
@@ -107,6 +109,7 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_PAREN_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.PUBLIC_KEYWORD;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUESTION_MARK_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.RETURNS_KEYWORD;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.RETURN_KEYWORD;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
 import static io.ballerina.openapi.generators.GeneratorConstants.DEFAULT_API_KEY_DESC;
 import static io.ballerina.openapi.generators.GeneratorConstants.HTTP;
@@ -325,6 +328,9 @@ public class BallerinaClientGenerator {
             apiKeyNames.addAll(ballerinaAuthConfigGenerator.getQueryApiKeyNameList().values());
             setApiKeyNameList(apiKeyNames);
         }
+        ReturnStatementNode returnStatementNode = createReturnStatementNode(createToken(
+                RETURN_KEYWORD), null, createToken(SEMICOLON_TOKEN));
+        assignmentNodes.add(returnStatementNode);
         NodeList<StatementNode> statementList = createNodeList(assignmentNodes);
         return createFunctionBodyBlockNode(createToken(OPEN_BRACE_TOKEN),
                 null, statementList, createToken(CLOSE_BRACE_TOKEN));

--- a/openapi-cli/src/test/resources/expected_gen/client_filtered_by_tags.bal
+++ b/openapi-cli/src/test/resources/expected_gen/client_filtered_by_tags.bal
@@ -10,6 +10,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # List all pets
     #

--- a/openapi-cli/src/test/resources/expected_gen/generate_client.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generate_client.bal
@@ -10,6 +10,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # List all pets
     #

--- a/openapi-cli/src/test/resources/expected_gen/generate_client_requestbody.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generate_client_requestbody.bal
@@ -11,6 +11,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # Creates a new user.
     #

--- a/openapi-cli/src/test/resources/expected_gen/generated_client_with_license.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generated_client_with_license.bal
@@ -13,6 +13,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # List all pets
     #

--- a/openapi-cli/src/test/resources/expected_gen/x_init_description.bal
+++ b/openapi-cli/src/test/resources/expected_gen/x_init_description.bal
@@ -17,6 +17,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "http://api.nytimes.com/svc/movies/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # Get movie reviews that are critics' picks. You can either specify the reviewer name or use "all", "full-time", or "part-time".
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/client_template.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/client_template.bal
@@ -13,6 +13,7 @@ public isolated client class Client {
     returns error?{
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     remote isolated function listPets(int? 'limit) returns Pets|error {
         string  path = string `/pets`;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/deprecated_functions.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/deprecated_functions.bal
@@ -10,6 +10,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # List all pets
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/deprecated_mix_params.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/deprecated_mix_params.bal
@@ -15,6 +15,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://api.soundcloud.com") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # Returns the comments posted on the track(track_id).
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/display_and_deprecated.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/display_and_deprecated.bal
@@ -10,6 +10,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # List all pets
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_optional.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_optional.bal
@@ -21,6 +21,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Provide weather forecast for any geographical coordinates
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_param_with_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_param_with_default_value.bal
@@ -21,6 +21,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Provide weather forecast for any geographical coordinates
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_parameter.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_parameter.bal
@@ -18,6 +18,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Info for a specific pet
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_without_parameter.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_without_parameter.bal
@@ -18,6 +18,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Info for a specific pet
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/missing_server_url.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/missing_server_url.bal
@@ -13,6 +13,7 @@ public isolated client class Client {
     public isolated function init(string serviceUrl, http:ClientConfiguration clientConfig =  {}) returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # Provide weather forecast for any geographical coordinates
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/openapi_display_annotation.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/openapi_display_annotation.bal
@@ -21,6 +21,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Call current weather data for one location
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/operation_get.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/operation_get.bal
@@ -12,6 +12,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration  clientConfig =  {}, string serviceUrl = "http://localhost:9090/petstore/v1") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     remote isolated function  pet() returns http:Response | error {
         string  path = string `/pet`;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/operation_id.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/operation_id.bal
@@ -10,6 +10,7 @@ public isolated client class Client {
     public isolated function init(string serviceUrl = "http://localhost:9090/petstore/v1", http:ClientConfiguration  httpClientConfig =  {}) returns error? {
         http:Client httpEp = check new (serviceUrl, httpClientConfig);
         self.clientEp = httpEp;
+        return;
     }
     remote isolated function  pet() returns http:Response | error {
         string  path = string `/pet`;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/operation_post.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/operation_post.bal
@@ -11,6 +11,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration  clientConfig =  {}, string serviceUrl = "http://localhost:9090/petstore/v1") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     remote isolated function  pet(Pet payload) returns http:Response | error {
         string  path = string `/pet`;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_param_duplicated_name.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_param_duplicated_name.bal
@@ -10,6 +10,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "localhost:9090/payloadV") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     #
     # + 'version - Version Id

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_param_with_ref_schema.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_param_with_ref_schema.bal
@@ -11,6 +11,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "localhost:9090/payloadV") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     #
     # + id - id value

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_valid.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_valid.bal
@@ -11,6 +11,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "localhost:9090/payloadV") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # op1
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_with_special_name.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_with_special_name.bal
@@ -10,6 +10,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "localhost:9090/payloadV") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     #
     # + 'version - Version Id

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_default_value.bal
@@ -21,6 +21,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Provide weather forecast for any geographical coordinates
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_ref_schema.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_ref_schema.bal
@@ -21,6 +21,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Provide weather forecast for any geographical coordinates
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_without_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_without_default_value.bal
@@ -21,6 +21,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Provide weather forecast for any geographical coordinates
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_allOf_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_allOf_scenarios.bal
@@ -12,6 +12,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig = {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new(serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # Request Body has allOf with specific properties.
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_basic_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_basic_scenarios.bal
@@ -12,6 +12,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # 02 Example for rb has inline requestbody.
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_oneOf_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_oneOf_scenarios.bal
@@ -11,6 +11,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # Request Body has nested allOf.
     #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/salesforce.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/salesforce.bal
@@ -12,6 +12,7 @@ public isolated client class Client {
                                   {}) returns error? {
         http:Client httpEp = check new (serviceUrl, httpClientConfig);
         self.clientEp = httpEp;
+        return;
     }
     remote isolated function products(decimal latitude, decimal longitude) returns ProductArr|error {
         string path = string `/products`;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/test.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/test.bal
@@ -14,6 +14,7 @@ public client class openapiClient {
             config.clientConfig.cache});
         self.clientEp = httpEp;
         self.config = config;
+        return;
     }
 
     //1.service with query parameters limit , 'limit

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/api2pdf.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/api2pdf.bal
@@ -22,6 +22,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Convert raw HTML to PDF
     #

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/bitbucket.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/bitbucket.bal
@@ -20,6 +20,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeys = apiKeyConfig.apiKeys.cloneReadOnly();
+        return;
     }
     # Product Types
     #

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/covid19_openapi.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/covid19_openapi.bal
@@ -15,6 +15,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://api-cov19.now.sh/") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # Returns information about all countries
     #

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/display_annotation.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/display_annotation.bal
@@ -12,6 +12,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io/v2") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # Update an existing pet
     #

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/jira_openapi.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/jira_openapi.bal
@@ -62,6 +62,7 @@ public isolated client class Client {
     public isolated function init(string serviceUrl = "https://your-domain.atlassian.com", http:ClientConfiguration  httpClientConfig =  {}) returns error? {
         http:Client httpEp = check new (serviceUrl, httpClientConfig);
         self.clientEp = httpEp;
+        return;
     }
     remote isolated function updateCustomFieldValue(string fieldIdOrKey, CustomFieldValueUpdateRequest payload) returns json|error {
         string  path = string `/rest/api/2/app/field/${fieldIdOrKey}/value`;

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/multiple_pathparam.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/multiple_pathparam.bal
@@ -11,6 +11,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     #
     # + 'version - test

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/openapi_weather_api.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/openapi_weather_api.bal
@@ -21,6 +21,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Call current weather data for one location
     #

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/operation.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/operation.bal
@@ -11,6 +11,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://api-cov19.now.sh/") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # List of all countries with COVID-19 cases
     #

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/tag.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/tag.bal
@@ -11,6 +11,7 @@ public isolated client class Client {
     public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://api-cov19.now.sh/") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # Returns information about all countries
     #

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/uber_openapi.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/uber_openapi.bal
@@ -20,6 +20,7 @@ public isolated client class Client {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         self.apiKeyConfig = apiKeyConfig.cloneReadOnly();
+        return;
     }
     # Product Types
     #


### PR DESCRIPTION
## Purpose
- Add `return` statement for client `init` function
- Remove `--skip-tests` command line option due to the change [here](https://github.com/ballerina-platform/ballerina-release/pull/1239/files)
> Resolves https://github.com/ballerina-platform/ballerina-extended-library/issues/117

