### PR TITLE
Fix location and name of duplicated test.bal and Config.toml files

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/CodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/CodeGenerator.java
@@ -109,6 +109,7 @@ import static io.ballerina.openapi.generators.GeneratorConstants.TYPE_NAME;
 import static io.ballerina.openapi.generators.GeneratorConstants.UNTITLED_SERVICE;
 import static io.ballerina.openapi.generators.GeneratorConstants.UTIL_FILE_NAME;
 import static io.ballerina.openapi.generators.GeneratorUtils.getValidName;
+import static io.ballerina.openapi.generators.GeneratorUtils.setGeneratedFileName;
 
 /**
  * This class generates Ballerina Services/Clients for a provided OAS definition.
@@ -389,7 +390,10 @@ public class CodeGenerator {
                     CodegenUtils.writeFile(filePath, fileContent);
                 }
             } else {
-                if (file.getFileName().equals(TEST_FILE_NAME) || file.getFileName().equals(CONFIG_FILE_NAME)) {
+                boolean isDuplicatedFileInTests = file.getFileName().matches("test.+[0-9]+.bal") ||
+                        file.getFileName().matches("Config.+[0-9]+.toml");
+                if (file.getFileName().equals(TEST_FILE_NAME) || file.getFileName().equals(CONFIG_FILE_NAME) ||
+                        isDuplicatedFileInTests) {
                     // Create test directory if not exists in the path. If exists do not throw an error
                     Files.createDirectories(Paths.get(srcPath + OAS_PATH_SEPARATOR + TEST_DIR));
                     filePath = Paths.get(srcPath.resolve(TEST_DIR + OAS_PATH_SEPARATOR +
@@ -415,27 +419,6 @@ public class CodeGenerator {
         while (iterator.hasNext()) {
             outStream.println("-- " + iterator.next().getFileName());
         }
-    }
-
-    /**
-     * This method for setting the file name for generated file.
-     *
-     * @param listFiles      generated files
-     * @param gFile          GenSrcFile object
-     * @param duplicateCount add the tag with duplicate number if file already exist
-     */
-    private void setGeneratedFileName(List<File> listFiles, GenSrcFile gFile, int duplicateCount) {
-
-        for (File listFile : listFiles) {
-            String listFileName = listFile.getName();
-            if (listFileName.contains(".") && ((listFileName.split("\\.")).length >= 2)
-                    && (listFileName.split("\\.")[0]
-                    .equals(gFile.getFileName().split("\\.")[0]))) {
-                duplicateCount = 1 + duplicateCount;
-            }
-        }
-        gFile.setFileName(gFile.getFileName().split("\\.")[0] + "." + (duplicateCount) +
-                ".bal");
     }
 
     /**

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorUtils.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorUtils.java
@@ -40,6 +40,7 @@ import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
 import io.ballerina.openapi.ErrorMessages;
+import io.ballerina.openapi.cmd.model.GenSrcFile;
 import io.ballerina.openapi.converter.Constants;
 import io.ballerina.openapi.exception.BallerinaOpenApiException;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -55,6 +56,7 @@ import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -613,5 +615,24 @@ public class GeneratorUtils {
         Minutiae whitespace = AbstractNodeFactory.createWhitespaceMinutiae(" ");
         MinutiaeList leading = AbstractNodeFactory.createMinutiaeList(whitespace);
         return leading;
+    }
+
+    /**
+     * This method for setting the file name for generated file.
+     *
+     * @param listFiles      generated files
+     * @param gFile          GenSrcFile object
+     * @param duplicateCount add the tag with duplicate number if file already exist
+     */
+    public static void setGeneratedFileName(List<File> listFiles, GenSrcFile gFile, int duplicateCount) {
+        for (File listFile : listFiles) {
+            String listFileName = listFile.getName();
+            if (listFileName.contains(".") && ((listFileName.split("\\.")).length >= 2) &&
+                    (listFileName.split("\\.")[0].equals(gFile.getFileName().split("\\.")[0]))) {
+                duplicateCount = 1 + duplicateCount;
+            }
+        }
+        gFile.setFileName(gFile.getFileName().split("\\.")[0] + "." + (duplicateCount) + "." +
+                gFile.getFileName().split("\\.")[1]);
     }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
@@ -38,8 +38,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.ballerina.openapi.cmd.model.GenSrcFile.GenFileType.GEN_SRC;
+import static io.ballerina.openapi.generators.GeneratorConstants.CLIENT_FILE_NAME;
+import static io.ballerina.openapi.generators.GeneratorConstants.CONFIG_FILE_NAME;
 import static io.ballerina.openapi.generators.GeneratorConstants.GenType.GEN_CLIENT;
+import static io.ballerina.openapi.generators.GeneratorConstants.TEST_FILE_NAME;
+import static io.ballerina.openapi.generators.GeneratorConstants.TYPE_FILE_NAME;
 import static io.ballerina.openapi.generators.GeneratorConstants.USER_DIR;
+import static io.ballerina.openapi.generators.GeneratorConstants.UTIL_FILE_NAME;
 
 /**
  * Unit tests for {@link CodeGenerator}.
@@ -98,6 +104,35 @@ public class CodeGeneratorTest {
         } finally {
             deleteGeneratedFiles("client.bal");
         }
+    }
+
+    @Test(description = "Test duplicated files generation")
+    public void generateDuplicatedFiles() {
+        List<File> duplicatedFileList = new ArrayList<>();
+        duplicatedFileList.add(new File(TEST_FILE_NAME));
+        duplicatedFileList.add(new File(CONFIG_FILE_NAME));
+        duplicatedFileList.add(new File(CLIENT_FILE_NAME));
+        duplicatedFileList.add(new File(UTIL_FILE_NAME));
+        duplicatedFileList.add(new File(TYPE_FILE_NAME));
+
+        String testPackageName = "testDuplicatedFiles";
+        GenSrcFile duplicatedTestFile = new GenSrcFile(GEN_SRC, testPackageName, TEST_FILE_NAME, "");
+        GenSrcFile duplicatedConfigFile = new GenSrcFile(GEN_SRC, testPackageName, CONFIG_FILE_NAME, "");
+        GenSrcFile duplicatedClientFile = new GenSrcFile(GEN_SRC, testPackageName, CLIENT_FILE_NAME, "");
+        GenSrcFile duplicatedUtilsFile = new GenSrcFile(GEN_SRC, testPackageName, UTIL_FILE_NAME, "");
+        GenSrcFile duplicatedTypesFile = new GenSrcFile(GEN_SRC, testPackageName, TYPE_FILE_NAME, "");
+
+        GeneratorUtils.setGeneratedFileName(duplicatedFileList, duplicatedTestFile, 0);
+        GeneratorUtils.setGeneratedFileName(duplicatedFileList, duplicatedConfigFile, 0);
+        GeneratorUtils.setGeneratedFileName(duplicatedFileList, duplicatedClientFile, 0);
+        GeneratorUtils.setGeneratedFileName(duplicatedFileList, duplicatedUtilsFile, 0);
+        GeneratorUtils.setGeneratedFileName(duplicatedFileList, duplicatedTypesFile, 0);
+
+        Assert.assertEquals(duplicatedTestFile.getFileName(), "test.1.bal");
+        Assert.assertEquals(duplicatedConfigFile.getFileName(), "Config.1.toml");
+        Assert.assertEquals(duplicatedClientFile.getFileName(), "client.1.bal");
+        Assert.assertEquals(duplicatedUtilsFile.getFileName(), "utils.1.bal");
+        Assert.assertEquals(duplicatedTypesFile.getFileName(), "types.1.bal");
     }
 
     @Test(description = "Test Ballerina client generation with doc comments in class init function")


### PR DESCRIPTION
## Purpose
- Fix https://github.com/ballerina-platform/ballerina-openapi/issues/631
- Fix https://github.com/ballerina-platform/ballerina-openapi/issues/680

## Goals
- Add duplicated test.bal and Config.toml files within the tests directory (earlier it was created in the same level with client.bal)
- Add correct name for duplicated Config.toml file (earlier it was adding `.bal` extension)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
