### PR TITLE
[Client]Fix reserved keyword support in function signatures

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionSignatureGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionSignatureGenerator.java
@@ -381,10 +381,12 @@ public class FunctionSignatureGenerator {
             }
             BuiltinSimpleNameReferenceNode typeName = createBuiltinSimpleNameReferenceNode(null,
                     createIdentifierToken(type));
-            IdentifierToken paramName = createIdentifierToken(getValidName(parameter.getName().trim(), false));
+            IdentifierToken paramName = createIdentifierToken(escapeIdentifier(getValidName(parameter.getName().trim(),
+                    false)));
             return createRequiredParameterNode(parameterAnnotationNodeList, typeName, paramName);
         } else {
-            IdentifierToken paramName = createIdentifierToken(getValidName(parameter.getName().trim(), false));
+            IdentifierToken paramName = createIdentifierToken(escapeIdentifier(getValidName(parameter.getName().trim(),
+                    false)));
             if (schema.getDefault() != null) {
                 BuiltinSimpleNameReferenceNode typeName = createBuiltinSimpleNameReferenceNode(null,
                         createIdentifierToken(convertOpenAPITypeToBallerina(


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-openapi/issues/555

## Goals
Improve the reserved keyword support in remote function signatures.

## Approach
1. Added `escapeIdentifier` function to related codes of the function signature generation in openapi-cli

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

## Test environment
> JDK 11, Ballerina Swan Lake Beta3
 