### PR TITLE
[Client] Support combination of `apiKey` and `httpOrOAuth` authentication

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -140,6 +140,7 @@ public class GeneratorConstants {
     public static final String API_KEY_CONFIG_RECORD_FIELD = "apiKeys";
     public static final String AUTH = "auth";
     public static final String AUTH_CONFIG = "authConfig";
+    public static final String AUTH_CONFIG_RECORD = "AuthConfig";
     public static final String BASIC = "basic";
     public static final String BEARER = "bearer";
     public static final String REFRESH_TOKEN = "refresh_token";

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/auth/OAuth2Tests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/auth/OAuth2Tests.java
@@ -99,17 +99,17 @@ public class OAuth2Tests {
         };
     }
 
-    @Test(description = "Generate Client with apiKey and OAuth security schemes",
-            expectedExceptions = BallerinaOpenApiException.class,
-            expectedExceptionsMessageRegExp =
-                    "Unsupported combination of security schemes.")
-    public void unsupportedSecuritySchemaCombination() throws IOException, BallerinaOpenApiException {
-        BallerinaAuthConfigGenerator ballerinaAuthConfigGenerator = new BallerinaAuthConfigGenerator(true,
-                true);
-        GeneratorUtils generatorUtils = new GeneratorUtils();
-        Path definitionPath = RES_DIR.resolve("scenarios/oauth2/unsupported_security_schema.yaml");
-        OpenAPI openAPI = generatorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
-        String generatedConfigRecord = Objects.requireNonNull(
-                ballerinaAuthConfigGenerator.getConfigRecord(openAPI)).toString();
-    }
+//    @Test(description = "Generate Client with apiKey and OAuth security schemes",
+//            expectedExceptions = BallerinaOpenApiException.class,
+//            expectedExceptionsMessageRegExp =
+//                    "Unsupported combination of security schemes.")
+//    public void unsupportedSecuritySchemaCombination() throws IOException, BallerinaOpenApiException {
+//        BallerinaAuthConfigGenerator ballerinaAuthConfigGenerator = new BallerinaAuthConfigGenerator(true,
+//                true);
+//        GeneratorUtils generatorUtils = new GeneratorUtils();
+//        Path definitionPath = RES_DIR.resolve("scenarios/oauth2/unsupported_security_schema.yaml");
+//        OpenAPI openAPI = generatorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+//        String generatedConfigRecord = Objects.requireNonNull(
+//                ballerinaAuthConfigGenerator.getConfigRecord(openAPI)).toString();
+//    }
 }


### PR DESCRIPTION
## Purpose
- Fix https://github.com/ballerina-platform/ballerina-openapi/issues/464

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes