### PR TITLE
Add command-line option to generate test cases

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/CodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/CodeGenerator.java
@@ -117,6 +117,7 @@ import static io.ballerina.openapi.generators.GeneratorUtils.setGeneratedFileNam
 public class CodeGenerator {
     private String srcPackage;
     private String licenseHeader = "";
+    private boolean includeTestFiles;
 
     private static final PrintStream outStream = System.err;
     private static final Logger LOGGER = LoggerFactory.getLogger(BallerinaUtilGenerator.class);
@@ -461,15 +462,18 @@ public class CodeGenerator {
         }
 
         // Generate test boilerplate code for test cases
-        BallerinaTestGenerator ballerinaTestGenerator = new BallerinaTestGenerator(ballerinaClientGenerator);
-        String testContent = Formatter.format(ballerinaTestGenerator.generateSyntaxTree()).toString();
-        sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, srcPackage, TEST_FILE_NAME, testContent));
+        if (this.includeTestFiles) {
+            BallerinaTestGenerator ballerinaTestGenerator = new BallerinaTestGenerator(ballerinaClientGenerator);
+            String testContent = Formatter.format(ballerinaTestGenerator.generateSyntaxTree()).toString();
+            sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, srcPackage, TEST_FILE_NAME, testContent));
 
-        String configContent = ballerinaTestGenerator.getConfigTomlFile();
-        if (!configContent.isBlank()) {
-            sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, srcPackage,
-                    GeneratorConstants.CONFIG_FILE_NAME, configContent));
+            String configContent = ballerinaTestGenerator.getConfigTomlFile();
+            if (!configContent.isBlank()) {
+                sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, srcPackage,
+                        GeneratorConstants.CONFIG_FILE_NAME, configContent));
+            }
         }
+
         return sourceFiles;
     }
 
@@ -698,5 +702,14 @@ public class CodeGenerator {
      */
     public void setLicenseHeader(String licenseHeader) {
         this.licenseHeader = licenseHeader;
+    }
+
+    /**
+     * set whether to add test files or not.
+     *
+     * @param includeTestFiles value received from command line by "--with tests"
+     */
+    public void setIncludeTestFiles(boolean includeTestFiles) {
+        this.includeTestFiles = includeTestFiles;
     }
 }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/OpenApiCmd.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/OpenApiCmd.java
@@ -95,6 +95,9 @@ public class OpenApiCmd implements BLauncherCmd {
     @CommandLine.Option(names = {"--json"}, description = "Generate json file")
     private boolean generatedFileType;
 
+    @CommandLine.Option(names = {"--with-tests"}, hidden = true, description = "Generate test files")
+    private boolean includeTestFiles;
+
     @CommandLine.Parameters
     private List<String> argList;
 
@@ -219,6 +222,7 @@ public class OpenApiCmd implements BLauncherCmd {
     private void openApiToBallerina(String fileName, Filter filter) throws IOException {
         CodeGenerator generator = new CodeGenerator();
         generator.setLicenseHeader(this.setLicenseHeader());
+        generator.setIncludeTestFiles(this.includeTestFiles);
         final File openApiFile = new File(fileName);
         String serviceName;
         if (generatedServiceName != null) {

--- a/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
@@ -238,6 +238,7 @@ public class CodeGeneratorTest {
         CodeGenerator generator = new CodeGenerator();
         try {
             String expectedConfigContent = getStringFromGivenBalFile(expectedServiceFile, "api_key_config.toml");
+            generator.setIncludeTestFiles(true);
             generator.generateClient(definitionPath, clientName, resourcePath.toString(), filter, true);
 
             if (Files.exists(resourcePath.resolve("tests/Config.toml"))) {
@@ -265,9 +266,9 @@ public class CodeGeneratorTest {
         listTags.add("dogs");
         Filter filterCustom = new Filter(listTags, list2);
         try {
-            String expectedSchemaContent = getStringFromGivenBalFile(expectedServiceFile, "type_filtered_by_tags.bal");
-            generator.generateClient(definitionPath, clientName, resourcePath.toString(),
-                    filterCustom, false);
+            String expectedSchemaContent = getStringFromGivenBalFile(expectedServiceFile, 
+                "type_filtered_by_tags.bal");          
+            generator.generateClient(definitionPath, clientName, resourcePath.toString(), filterCustom, false);
             if (Files.exists(resourcePath.resolve("types.bal")) && Files.exists(resourcePath.resolve("types.bal"))) {
                 String generatedSchema = getStringFromGivenBalFile(resourcePath, "types.bal");
                 generatedSchema = (generatedSchema.trim()).replaceAll("\\s+", "");
@@ -340,7 +341,7 @@ public class CodeGeneratorTest {
         CodeGenerator generator = new CodeGenerator();
 
         try {
-            String expectedServiceContent = getStringFromGivenBalFile(expectedServiceFile, "generated_bal.bal");
+            String expectedServiceContent = getStringFromGivenBalFile(expectedServiceFile, "generated_bal.bal");       
             generator.generateService(definitionPath, serviceName, resourcePath.toString(), filter, false);
             if (Files.exists(resourcePath.resolve("openapipetstore_service.bal"))) {
                 String generatedService = getStringFromGivenBalFile(resourcePath, "openapipetstore_service.bal");

--- a/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
@@ -90,8 +90,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         }
         if (Files.exists(this.tmpDir.resolve("client.bal")) &&
                 Files.exists(this.tmpDir.resolve("petstore_service.bal")) &&
-                Files.exists(this.tmpDir.resolve("types.bal")) &&
-                Files.exists(this.tmpDir.resolve("tests/test.bal"))) {
+                Files.exists(this.tmpDir.resolve("types.bal"))) {
             //Compare schema contents
             String generatedSchema = "";
             try (Stream<String> generatedSchemaLines = Files.lines(this.tmpDir.resolve("types.bal"))) {
@@ -131,8 +130,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         }
         if (Files.exists(this.tmpDir.resolve("client.bal")) &&
                 Files.exists(this.tmpDir.resolve("petstore_type_service.bal")) &&
-                Files.exists(this.tmpDir.resolve("types.bal")) &&
-                Files.exists(this.tmpDir.resolve("tests/test.bal"))) {
+                Files.exists(this.tmpDir.resolve("types.bal"))) {
             //Compare schema contents
             String generatedSchema = "";
             try (Stream<String> generatedSchemaLines = Files.lines(this.tmpDir.resolve("types.bal"))) {
@@ -173,8 +171,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         }
         if (Files.exists(this.tmpDir.resolve("client.bal")) &&
                 Files.exists(this.tmpDir.resolve("petstore_service.bal")) &&
-                Files.exists(this.tmpDir.resolve("types.bal")) &&
-                Files.exists(this.tmpDir.resolve("tests/test.bal"))) {
+                Files.exists(this.tmpDir.resolve("types.bal"))) {
             //Compare schema contents
             String generatedSchema = "";
             try (Stream<String> generatedSchemaLines = Files.lines(this.tmpDir.resolve("types.bal"))) {
@@ -186,11 +183,12 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
             expectedSchemaContent = (expectedSchemaContent.trim()).replaceAll("\\s+", "");
             if (expectedSchemaContent.equals(generatedSchema)) {
                 Assert.assertTrue(true);
+                deleteGeneratedFiles(false);
             } else {
                 Assert.fail("Expected content and actual generated content is mismatched for: "
                         + petstoreYaml.toString());
+                deleteGeneratedFiles(false);
             }
-            deleteGeneratedFiles(false);
         } else {
             Assert.fail("Code generation failed. : " + readOutput(true));
         }
@@ -215,8 +213,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         }
         if (Files.exists(this.tmpDir.resolve("client.bal")) &&
                 Files.exists(this.tmpDir.resolve("petstore_service.bal")) &&
-                Files.exists(this.tmpDir.resolve("types.bal")) &&
-                Files.exists(this.tmpDir.resolve("tests/test.bal"))) {
+                Files.exists(this.tmpDir.resolve("types.bal"))) {
             //Compare schema contents
             String generatedClientContent = "";
             try (Stream<String> generatedClientLines = Files.lines(this.tmpDir.resolve("client.bal"))) {
@@ -257,8 +254,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         }
         if (Files.exists(this.tmpDir.resolve("client.bal")) &&
                 Files.exists(this.tmpDir.resolve("utils.bal")) &&
-                Files.exists(this.tmpDir.resolve("types.bal")) &&
-                Files.exists(this.tmpDir.resolve("tests/test.bal"))) {
+                Files.exists(this.tmpDir.resolve("types.bal"))) {
             //Compare client contents
             String generatedClientContent = "";
             try (Stream<String> generatedClientLines = Files.lines(this.tmpDir.resolve("client.bal"))) {
@@ -286,7 +282,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         Path petstoreYaml = resourceDir.resolve(Paths.get("petstore_with_oauth.yaml"));
         Path licenseHeader = resourceDir.resolve(Paths.get("license.txt"));
         String[] args = {"--input", petstoreYaml.toString(), "-o", this.tmpDir.toString(), "--license",
-                licenseHeader.toString()};
+                licenseHeader.toString(), "--with-tests"};
         OpenApiCmd cmd = new OpenApiCmd(printStream, tmpDir, false);
         new CommandLine(cmd).parseArgs(args);
         cmd.execute();
@@ -338,6 +334,36 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         Assert.assertTrue(output.contains("Invalid license file path : "));
     }
 
+    @Test(description = "Test generation without including test files")
+    public void testClientGenerationWithoutIncludeTestFilesOption() throws IOException, BallerinaOpenApiException {
+        Path petstoreYaml = resourceDir.resolve(Paths.get("petstore_with_oauth.yaml"));
+        Path licenseHeader = resourceDir.resolve(Paths.get("license.txt"));
+        String[] args = {"--input", petstoreYaml.toString(), "-o", this.tmpDir.toString(), "--license",
+                licenseHeader.toString()};
+        OpenApiCmd cmd = new OpenApiCmd(printStream, tmpDir, false);
+        new CommandLine(cmd).parseArgs(args);
+        cmd.execute();
+        Path expectedConfigFilePath = resourceDir.resolve(Paths.get("expected_gen",
+                "bearer_config.toml"));
+        String expectedConfig = "";
+        try (Stream<String> expectedSchemaLines = Files.lines(expectedConfigFilePath)) {
+            expectedConfig = expectedSchemaLines.collect(Collectors.joining(LINE_SEPARATOR));
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+        if (Files.exists(this.tmpDir.resolve("client.bal")) &&
+                Files.exists(this.tmpDir.resolve("petstore_with_oauth_service.bal")) &&
+                Files.exists(this.tmpDir.resolve("types.bal")) &&
+                !Files.exists(this.tmpDir.resolve("tests/Config.toml")) &&
+                !Files.exists(this.tmpDir.resolve("tests/test.bal"))) {
+
+                Assert.assertTrue(true);
+                deleteGeneratedFiles(true);
+        } else {
+            Assert.fail("Code generation failed. : " + readOutput(true));
+        }
+    }
+
     @Test(description = "Test openapi gen-service for .yml file service generation")
     public void testSuccessfulServiceGenerationForYML() throws IOException {
         Path petstoreYaml = resourceDir.resolve(Paths.get("petstore.yml"));
@@ -357,8 +383,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         }
         if (Files.exists(this.tmpDir.resolve("client.bal")) &&
                 Files.exists(this.tmpDir.resolve("petstore_service.bal")) &&
-                Files.exists(this.tmpDir.resolve("types.bal")) &&
-                Files.exists(this.tmpDir.resolve("tests/test.bal"))) {
+                Files.exists(this.tmpDir.resolve("types.bal"))) {
             //Compare schema contents
             String generatedSchema = "";
             try (Stream<String> generatedSchemaLines = Files.lines(this.tmpDir.resolve("types.bal"))) {

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/testcases/BallerinaTestGeneratorTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/testcases/BallerinaTestGeneratorTests.java
@@ -68,6 +68,7 @@ public class BallerinaTestGeneratorTests {
         Files.createDirectories(Paths.get(PROJECT_DIR + OAS_PATH_SEPARATOR + TEST_DIR));
         Path definitionPath = RES_DIR.resolve("sample_yamls/" + yamlFile);
         CodeGenerator codeGenerator = new CodeGenerator();
+        codeGenerator.setIncludeTestFiles(true);
         OpenAPI openAPI = codeGenerator.normalizeOpenAPI(definitionPath, true);
         BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(openAPI, filter, false);
         BallerinaSchemaGenerator schemaGenerator = new BallerinaSchemaGenerator(openAPI);


### PR DESCRIPTION
## Purpose
Added "--with-tests" option to add test files to the generated code.
Fixes https://github.com/ballerina-platform/ballerina-openapi/issues/673

## Approach
Added new option "--with-tests"

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 11, Ballerina Swan Lake Beta3
 