### PR TITLE
 [Client] Support `multipart/form-data` request MIME type

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -149,6 +149,7 @@ public class GeneratorConstants {
     public static final String VENDOR_SPECIFIC_TYPE = "vnd.";
     public static final String APPLICATION_PDF = "application/pdf";
     public static final String IMAGE_PNG = "image/png";
+    public static final String MIME = "mime";
 
     // auth related constants
     public static final String API_KEY = "apikey";
@@ -278,8 +279,8 @@ public class GeneratorConstants {
         typeMap.put("string", "string");
         typeMap.put("boolean", "boolean");
         typeMap.put("array", "[]");
-        typeMap.put("decimal", "decimal");
         typeMap.put("object", "record {}");
+        typeMap.put("decimal", "decimal");
         typeMap.put("number", "decimal");
         typeMap.put("double", "float");
         typeMap.put("float", "float");

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorUtils.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorUtils.java
@@ -623,5 +623,10 @@ public class GeneratorUtils {
         return false;
     }
 
-
+    public static void addImport(List<ImportDeclarationNode> imports, String module) {
+        if (!checkImportDuplicate(imports, module)) {
+            ImportDeclarationNode importModule = GeneratorUtils.getImportDeclarationNode(BALLERINA, module);
+            imports.add(importModule);
+        }
+    }
 }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/MimeFactory.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/MimeFactory.java
@@ -24,6 +24,7 @@ import io.ballerina.openapi.generators.client.mime.AnyType;
 import io.ballerina.openapi.generators.client.mime.CustomType;
 import io.ballerina.openapi.generators.client.mime.JsonType;
 import io.ballerina.openapi.generators.client.mime.MimeType;
+import io.ballerina.openapi.generators.client.mime.MultipartFormData;
 import io.ballerina.openapi.generators.client.mime.OctedStreamType;
 import io.ballerina.openapi.generators.client.mime.UrlEncodedType;
 import io.ballerina.openapi.generators.client.mime.XmlType;
@@ -44,6 +45,7 @@ import static io.ballerina.openapi.generators.GeneratorConstants.VENDOR_SPECIFIC
 import static io.ballerina.openapi.generators.GeneratorConstants.XML;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
+import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
 
 
 /**
@@ -81,6 +83,8 @@ public class MimeFactory {
                 return new UrlEncodedType(ballerinaUtilGenerator);
             } else if (mediaType.equals(APPLICATION_OCTET_STREAM)) {
                 return new OctedStreamType();
+            } else if (mediaType.equals(MULTIPART_FORM_DATA)) {
+                return new MultipartFormData(imports, ballerinaUtilGenerator);
             } else if (mediaType.contains(ANY_TYPE)) {
                 return new AnyType();
             } else {

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/MultipartFormData.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/MultipartFormData.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.openapi.generators.client.mime;
+
+import io.ballerina.compiler.syntax.tree.BuiltinSimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.CaptureBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.ExpressionStatementNode;
+import io.ballerina.compiler.syntax.tree.IdentifierToken;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingFieldNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
+import io.ballerina.compiler.syntax.tree.StatementNode;
+import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.openapi.generators.GeneratorUtils;
+import io.ballerina.openapi.generators.client.BallerinaUtilGenerator;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.media.Encoding;
+import io.swagger.v3.oas.models.media.MediaType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyNodeList;
+import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createIdentifierToken;
+import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createSeparatedNodeList;
+import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createToken;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createBuiltinSimpleNameReferenceNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createCaptureBindingPatternNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createMappingConstructorExpressionNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createRequiredExpressionNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createSimpleNameReferenceNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createSpecificFieldNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createTypedBindingPatternNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createVariableDeclarationNode;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.CLOSE_BRACE_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.COLON_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.COMMA_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.EQUAL_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_BRACE_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
+import static io.ballerina.openapi.generators.GeneratorConstants.MIME;
+import static io.ballerina.openapi.generators.GeneratorUtils.addImport;
+import static io.ballerina.openapi.generators.GeneratorUtils.escapeIdentifier;
+import static io.ballerina.openapi.generators.GeneratorUtils.getValidName;
+
+/**
+ * Defines the payload structure of multipart form-data mime type.
+ */
+public class MultipartFormData extends MimeType {
+
+    BallerinaUtilGenerator ballerinaUtilGenerator;
+    List<ImportDeclarationNode> imports;
+
+    public MultipartFormData(List<ImportDeclarationNode> imports,
+                             BallerinaUtilGenerator ballerinaUtilGenerator) {
+        this.imports = imports;
+        this.ballerinaUtilGenerator = ballerinaUtilGenerator;
+    }
+
+    @Override
+    public void setPayload(List<StatementNode> statementsList, Map.Entry<String, MediaType> mediaTypeEntry) {
+        ballerinaUtilGenerator.setRequestBodyMultipartFormDatafound(true);
+        addImport(imports, MIME);
+        VariableDeclarationNode encodingMap = getMultipartMap(mediaTypeEntry);
+
+        VariableDeclarationNode bodyPartsVariable;
+        if (encodingMap == null) {
+            bodyPartsVariable = GeneratorUtils.getSimpleStatement("mime:Entity[]", "bodyParts",
+                    "check createBodyParts(payload)");
+        } else {
+            statementsList.add(encodingMap);
+            bodyPartsVariable = GeneratorUtils.getSimpleStatement("mime:Entity[]", "bodyParts",
+                    "check createBodyParts(payload, encodingMap)");
+        }
+        statementsList.add(bodyPartsVariable);
+
+        ExpressionStatementNode setPayloadExpression = GeneratorUtils.getSimpleExpressionStatementNode(
+                "request.setBodyParts(bodyParts)");
+        statementsList.add(setPayloadExpression);
+    }
+
+    private VariableDeclarationNode getMultipartMap(Map.Entry<String, MediaType> mediaTypeEntry) {
+        if (mediaTypeEntry.getValue().getEncoding() != null) {
+            List<Node> filedOfMap = new ArrayList<>();
+            BuiltinSimpleNameReferenceNode mapType = createBuiltinSimpleNameReferenceNode(null,
+                    createIdentifierToken("map<Encoding>"));
+            CaptureBindingPatternNode bindingPattern = createCaptureBindingPatternNode(
+                    createIdentifierToken("encodingMap"));
+            TypedBindingPatternNode bindingPatternNode = createTypedBindingPatternNode(mapType, bindingPattern);
+
+            Set<Map.Entry<String, Encoding>> endcodingEntries = mediaTypeEntry.getValue().getEncoding().entrySet();
+            for (Map.Entry<String, Encoding> entry : endcodingEntries) {
+                getEncoding(entry, filedOfMap);
+            }
+
+            filedOfMap.remove(filedOfMap.size() - 1);
+            MappingConstructorExpressionNode initialize = createMappingConstructorExpressionNode(
+                    createToken(OPEN_BRACE_TOKEN), createSeparatedNodeList(filedOfMap), createToken(CLOSE_BRACE_TOKEN));
+            return createVariableDeclarationNode(createEmptyNodeList(), null, bindingPatternNode,
+                    createToken(EQUAL_TOKEN), initialize, createToken(SEMICOLON_TOKEN));
+
+        }
+        return null;
+    }
+
+    private void getEncoding(Map.Entry<String, Encoding> entry, List<Node> filedOfMap) {
+        SpecificFieldNode contentField = null;
+        SpecificFieldNode headersField = null;
+        IdentifierToken fieldName = createIdentifierToken('"' + entry.getKey() + '"');
+        SeparatedNodeList<MappingFieldNode> separatedNodeList = createSeparatedNodeList();
+
+        if (entry.getValue().getContentType() != null) {
+            contentField = createSpecificFieldNode(null,
+                    createIdentifierToken("contentType"), createToken(COLON_TOKEN),
+                    createRequiredExpressionNode(createIdentifierToken('"' +
+                            entry.getValue().getContentType().split(",")[0] + '"')));
+        }
+
+        if (entry.getValue().getHeaders() != null) {
+            headersField =  getHeaderEncoding(entry);
+        }
+
+        if (headersField != null && contentField != null) {
+            separatedNodeList = createSeparatedNodeList(contentField, createToken(COMMA_TOKEN), headersField);
+        } else if (contentField != null) {
+            separatedNodeList = createSeparatedNodeList(contentField);
+        } else if (headersField != null) {
+            separatedNodeList = createSeparatedNodeList(headersField);
+        }
+
+        ExpressionNode expressionNode = createMappingConstructorExpressionNode(
+                createToken(OPEN_BRACE_TOKEN), separatedNodeList, createToken(CLOSE_BRACE_TOKEN));
+        SpecificFieldNode specificFieldNode = createSpecificFieldNode(null, fieldName,
+                createToken(COLON_TOKEN), expressionNode);
+        filedOfMap.add(specificFieldNode);
+        filedOfMap.add(createToken(COMMA_TOKEN));
+    }
+
+    private SpecificFieldNode getHeaderEncoding(Map.Entry<String, Encoding> entry) {
+        List<Node> headerMap = new ArrayList<>();
+        for (Map.Entry<String, Header> header : entry.getValue().getHeaders().entrySet()) {
+            IdentifierToken headerName = createIdentifierToken('"' + header.getKey() + '"');
+            SimpleNameReferenceNode valueExpr = createSimpleNameReferenceNode(
+                    createIdentifierToken(escapeIdentifier(getValidName(header.getKey(), false))));
+            SpecificFieldNode specificFieldNode = createSpecificFieldNode(null,
+                    headerName, createToken(COLON_TOKEN), valueExpr);
+            headerMap.add(specificFieldNode);
+            headerMap.add(createToken(COMMA_TOKEN));
+        }
+        headerMap.remove(headerMap.size() - 1);
+        MappingConstructorExpressionNode initialize = createMappingConstructorExpressionNode(
+                createToken(OPEN_BRACE_TOKEN), createSeparatedNodeList(headerMap),
+                createToken(CLOSE_BRACE_TOKEN));
+        return createSpecificFieldNode(null, createIdentifierToken("headers"),
+                createToken(COLON_TOKEN), initialize);
+    }
+
+}

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/XmlType.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/XmlType.java
@@ -27,9 +27,8 @@ import io.swagger.v3.oas.models.media.MediaType;
 import java.util.List;
 import java.util.Map;
 
-import static io.ballerina.openapi.generators.GeneratorConstants.BALLERINA;
 import static io.ballerina.openapi.generators.GeneratorConstants.XML_DATA;
-import static io.ballerina.openapi.generators.GeneratorUtils.checkImportDuplicate;
+import static io.ballerina.openapi.generators.GeneratorUtils.addImport;
 
 /**
  * Defines the payload structure of xml mime type.
@@ -46,10 +45,8 @@ public class XmlType extends MimeType {
     @Override
     public void setPayload(List<StatementNode> statementsList, Map.Entry<String, MediaType> mediaTypeEntry) {
         payloadName = "xmlBody";
-        ImportDeclarationNode xmlImport = GeneratorUtils.getImportDeclarationNode(BALLERINA, XML_DATA);
-        if (!checkImportDuplicate(imports, XML_DATA)) {
-            imports.add(xmlImport);
-        }
+        addImport(imports, XML_DATA);
+
         VariableDeclarationNode jsonVariable = GeneratorUtils.getSimpleStatement("json",
                 "jsonBody", "check payload.cloneWithType(json)");
         statementsList.add(jsonVariable);

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -122,6 +122,16 @@ public class FunctionBodyNodeTests {
                         "http:Request request = new;" +
                         "request.setPayload(payload, \"image/png\");" +
                         "http:Response response = check self.clientEp->post(path, request);" +
+                        "return response;}"},
+                {"swagger/multipart_formdata_custom.yaml", "/pets", "{string path = string `/pets`;\n" +
+                        "http:Request request = new;\n" +
+                        "map<Encoding> encodingMap = {\"profileImage\": {contentType: \"image/png\", headers: " +
+                        "{\"X-Custom-Header\": xCustomHeader}}, \"id\":{headers: {\"X-Custom-Header\": " +
+                        "xCustomHeader}}, \"address\": {headers:{\"X-Address-Header\":xAddressHeader}}, \"name\":" +
+                        "{contentType:\"text/plain\"}};\n" +
+                        "mime:Entity[] bodyParts = check createBodyParts(payload, encodingMap);\n" +
+                        "request.setBodyParts(bodyParts);\n" +
+                        "http:Response response = check self.clientEp->post(path, request);\n" +
                         "return response;}"}
         };
     }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -177,6 +177,17 @@ public class RequestBodyTests {
         compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
     }
 
+    @Test(description = "Test for generating request body when operation has multipart form-data media type")
+    public void testRequestBodyWithMultipartMediaType() throws IOException, BallerinaOpenApiException {
+        Path expectedPath = RES_DIR.resolve("ballerina/multipart_formdata.bal");
+        CodeGenerator codeGenerator = new CodeGenerator();
+        OpenAPI openAPI = codeGenerator.normalizeOpenAPI(
+                RES_DIR.resolve("utils/swagger/multipart_formdata.yaml"), true);
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(openAPI, filter, false);
+        syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
+    }
+
     @AfterTest
     private void deleteGeneratedFiles() {
         try {

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/UtilGenerationTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/UtilGenerationTests.java
@@ -146,6 +146,29 @@ public class UtilGenerationTests {
         Assert.assertTrue(diagnostics.isEmpty());
     }
 
+    @Test(description = "Validate the util functions generated for OpenAPI definition with multi part request bodies")
+    public void testMultipartBodyParts() throws IOException, BallerinaOpenApiException, FormatterException {
+        CodeGenerator codeGenerator = new CodeGenerator();
+        Path definitionPath = RESDIR.resolve("swagger/multipart_formdata.yaml");
+        OpenAPI openAPI = codeGenerator.normalizeOpenAPI(definitionPath, true);
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(openAPI, filter, false);
+        SyntaxTree clientSyntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        List<Diagnostic> diagnostics = getDiagnostics(clientSyntaxTree, openAPI, ballerinaClientGenerator);
+        Assert.assertTrue(diagnostics.isEmpty());
+    }
+
+    @Test(description = "Validate the util functions generated for OpenAPI definition with multi part " +
+            "request custom bodies")
+    public void testMultipartCustomBodyParts() throws IOException, BallerinaOpenApiException, FormatterException {
+        CodeGenerator codeGenerator = new CodeGenerator();
+        Path definitionPath = RESDIR.resolve("swagger/multipart_formdata_custom.yaml");
+        OpenAPI openAPI = codeGenerator.normalizeOpenAPI(definitionPath, true);
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(openAPI, filter, false);
+        SyntaxTree clientSyntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        List<Diagnostic> diagnostics = getDiagnostics(clientSyntaxTree, openAPI, ballerinaClientGenerator);
+        Assert.assertTrue(diagnostics.isEmpty());
+    }
+
     private boolean checkUtil(List<String> invalidFunctionNames, SyntaxTree utilSyntaxTree) {
         ModulePartNode modulePartNode = utilSyntaxTree.rootNode();
         NodeList<ModuleMemberDeclarationNode> members = modulePartNode.members();

--- a/openapi-cli/src/test/resources/expected_gen/utils.bal
+++ b/openapi-cli/src/test/resources/expected_gen/utils.bal
@@ -1,11 +1,17 @@
 import ballerina/url;
 
+type SimpleBasicType string|boolean|int|float|decimal;
+
 # Represents encoding mechanism details.
 type Encoding record {
     # Defines how multiple values are delimited
     string style = FORM;
     # Specifies whether arrays and objects should generate as separate fields
     boolean explode = true;
+    # Specifies the custom content type
+    string contentType?;
+    # Specifies the custom headers
+    map<any> headers?;
 };
 
 enum EncodingStyle {
@@ -16,8 +22,6 @@ enum EncodingStyle {
 }
 
 final Encoding & readonly defaultEncoding = {};
-
-type SimpleBasicType string|boolean|int|float|decimal;
 
 # Serialize the record according to the deepObject style.
 #

--- a/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata.bal
@@ -1,0 +1,28 @@
+import ballerina/http;
+import ballerina/mime;
+
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + clientConfig - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "http://petstore.{host}.io/v1") returns error? {
+        http:Client httpEp = check new (serviceUrl, clientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Create a pet
+    #
+    # + payload - Pet
+    # + return - Null response
+    remote isolated function createPet(PetsBody payload) returns http:Response|error {
+        string path = string `/pets`;
+        http:Request request = new;
+        mime:Entity[] bodyParts = check createBodyParts(payload);
+        request.setBodyParts(bodyParts);
+        http:Response response = check self.clientEp->post(path, request);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/swagger/multipart_formdata_custom.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/multipart_formdata_custom.yaml
@@ -1,0 +1,71 @@
+# This file contains a post request definition with multipart form data with a custom header
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        description: Pet
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - id
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                  description: ID
+                name:
+                  type: string
+                  description: Name
+                address:
+                  type: object
+                  description: Address
+                  properties:
+                    street:
+                      type: string
+                      description: Street
+                    city:
+                      type: string
+                      description: City
+                profileImage:
+                  type: string
+                  format: binary
+                  description: Image
+            encoding:
+              profileImage:
+                contentType: image/png, image/jpeg
+                headers:
+                  X-Custom-Header:
+                    description: This is a custom header
+                    schema:
+                      type: string
+              id:
+                headers:
+                  X-Custom-Header:
+                    description: This is a custom header
+                    schema:
+                      type: string
+              address:
+                headers:
+                  X-Address-Header:
+                    description: This is a custom header
+                    schema:
+                      type: string
+                    required: true
+              name:
+                contentType: text/plain
+      responses:
+        '201':
+          description: Null response

--- a/openapi-cli/src/test/resources/generators/client/swagger/unsupported_request_body.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/unsupported_request_body.yaml
@@ -48,7 +48,7 @@ paths:
           required: true
       requestBody:
         content:
-          multipart/form-data:
+          multipart/byteranges:  # This mime is not supported for client generation
             schema:
               properties:
                 address:

--- a/openapi-cli/src/test/resources/generators/client/utils/swagger/multipart_formdata.yaml
+++ b/openapi-cli/src/test/resources/generators/client/utils/swagger/multipart_formdata.yaml
@@ -1,0 +1,42 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        description: Pet
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                  description: ID
+                address:
+                  type: object
+                  description: Address
+                  properties:
+                    street:
+                      type: string
+                      description: Street
+                    city:
+                      type: string
+                      description: City
+                profileImage:
+                  type: string
+                  format: binary
+                  description: Image
+      responses:
+        '201':
+          description: Null response

--- a/openapi-cli/src/test/resources/generators/client/utils/swagger/multipart_formdata_custom.yaml
+++ b/openapi-cli/src/test/resources/generators/client/utils/swagger/multipart_formdata_custom.yaml
@@ -1,0 +1,50 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        description: Pet
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                  description: ID
+                address:
+                  type: object
+                  description: Address
+                  properties:
+                    street:
+                      type: string
+                      description: Street
+                    city:
+                      type: string
+                      description: City
+                profileImage:
+                  type: string
+                  format: binary
+                  description: Image
+            encoding:
+              profileImage:
+                contentType: image/png, image/jpeg
+                headers:
+                  X-Custom-Header:
+                    description: This is a custom header
+                    schema:
+                      type: string
+      responses:
+        '201':
+          description: Null response


### PR DESCRIPTION
## Purpose
 Support `multipart/form-data` request MIME type in client request body generation. This is part of https://github.com/ballerina-platform/ballerina-openapi/issues/684 improvement.

## Goals
Fixes https://github.com/ballerina-platform/ballerina-openapi/issues/549

## Automation tests
 - Unit tests 
 Added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/ballerina-platform/ballerina-openapi/pull/692
https://github.com/ballerina-platform/ballerina-openapi/pull/731

## Test environment
JDK 11
 