### PR TITLE
Fix for changing `ballerina-openapi` name usage into `openapi-tools`

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -42,13 +42,13 @@ jobs:
           ./gradlew -Pversion=${VERSION} publish -x test -PpublishToCentral=true
       - name: Create Github release from the release tag
         run: |
-          curl --request POST 'https://api.github.com/repos/ballerina-platform/ballerina-openapi/releases' \
+          curl --request POST 'https://api.github.com/repos/ballerina-platform/openapi-tools/releases' \
           --header 'Accept: application/vnd.github.v3+json' \
           --header 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}' \
           --header 'Content-Type: application/json' \
           --data-raw '{
               "tag_name": "v'"$VERSION"'",
-              "name": "ballerina-openapi-v'"$VERSION"'"
+              "name": "openapi-tools-v'"$VERSION"'"
           }'
       - name: Post release PR
         env:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ballerina-OpenAPI
- [![Build master](https://github.com/ballerina-platform/ballerina-openapi/actions/workflows/build-timestamped-master.yml/badge.svg)](https://github.com/ballerina-platform/ballerina-openapi/actions/workflows/build-timestamped-master.yml)
- [![Daily build](https://github.com/ballerina-platform/ballerina-openapi/workflows/Daily%20build/badge.svg)](https://github.com/ballerina-platform/ballerina-openapi/actions?query=workflow%3A%22Daily+build%22)
- [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/ballerina-openapi.svg)](https://github.com/ballerina-platform/ballerina-openapi/commits/master)
- [![codecov](https://codecov.io/gh/ballerina-platform/ballerina-openapi/branch/master/graph/badge.svg)](https://codecov.io/gh/ballerina-platform/ballerina-openapi)
+ [![Build master](https://github.com/ballerina-platform/openapi-tools/actions/workflows/build-timestamped-master.yml/badge.svg)](https://github.com/ballerina-platform/openapi-tools/actions/workflows/build-timestamped-master.yml)
+ [![Daily build](https://github.com/ballerina-platform/openapi-tools/workflows/Daily%20build/badge.svg)](https://github.com/ballerina-platform/openapi-tools/actions?query=workflow%3A%22Daily+build%22)
+ [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/openapi-tools.svg)](https://github.com/ballerina-platform/openapi-tools/commits/master)
+ [![codecov](https://codecov.io/gh/ballerina-platform/openapi-tools/branch/master/graph/badge.svg)](https://codecov.io/gh/ballerina-platform/openapi-tools)
  
 The OpenAPI Specification is a specification, which creates a RESTFUL contract for APIs detailing all of its resources 
 and operations in both human and machine-readable format for easy development, discovery, and integration. Ballerina
@@ -56,7 +56,7 @@ Execute the commands below to build from the source.
 
 As an open-source project, Ballerina welcomes contributions from the community. 
 
-You can also check for [open issues](https://github.com/ballerina-platform/ballerina-openapi/issues) that
+You can also check for [open issues](https://github.com/ballerina-platform/openapi-tools/issues) that
  interest you. We look forward to receiving your contributions.
 
 For more information, go to the [contribution guidelines](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md).

--- a/module-ballerina-openapi/CompilerPlugin.toml
+++ b/module-ballerina-openapi/CompilerPlugin.toml
@@ -1,5 +1,5 @@
 [plugin]
-id = "ballerina-openapi"
+id = "openapi-tools"
 class = "io.ballerina.openapi.validator.OpenAPIValidatorPlugin"
 
 [[dependency]]

--- a/module-ballerina-openapi/Package.md
+++ b/module-ballerina-openapi/Package.md
@@ -9,7 +9,7 @@ allow you to validate a service implementation against an OpenAPI contract durin
 ensures that the implementation of a service does not deviate from its OpenAPI contract.
 
 ### Report Issues
-To report bugs, request new features, start new discussions, etc., go to the [open issues](https://github.com/ballerina-platform/ballerina-openapi/issues).
+To report bugs, request new features, start new discussions, etc., go to the [open issues](https://github.com/ballerina-platform/openapi-tools/issues).
 
 ### Useful Links
 

--- a/module-ballerina-openapi/build.gradle
+++ b/module-ballerina-openapi/build.gradle
@@ -294,7 +294,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/ballerina-platform/ballerina-openapi")
+            url = uri("https://maven.pkg.github.com/ballerina-platform/openapi-tools")
             credentials {
                 username = System.getenv("packageUser")
                 password = System.getenv("packagePAT")

--- a/openapi-validator/src/test/resources/project-based-tests/CompilerPlugin.toml
+++ b/openapi-validator/src/test/resources/project-based-tests/CompilerPlugin.toml
@@ -1,5 +1,5 @@
 [plugin]
-id = "ballerina-openapi"
+id = "openapi-tools"
 class = "org.ballerinalang.openapi.validator.OpenAPIValidatorPlugin"
 
 [[dependency]]

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@
 plugins {
     id "com.gradle.enterprise" version "3.5"
 }
-rootProject.name = 'ballerina-openapi'
+rootProject.name = 'openapi-tools'
 include(':config:checkstyle')
 include(':module-ballerina-openapi')
 include(':openapi-bal-service')


### PR DESCRIPTION
## Purpose
> Change the repository name usage with a new repository name.