### PR TITLE
[Client] Support `*/*`, `image/*` and vendor specific request MIME type

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -140,6 +140,7 @@ public class GeneratorConstants {
     public static final String PDF = "pdf";
     public static final String TEXT_PREFIX = "text/";
     public static final String XML_DATA = "xmldata";
+    public static final String IMAGE = "image";
 
     // auth related constants
     public static final String API_KEY = "apikey";

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -141,6 +141,8 @@ public class GeneratorConstants {
     public static final String TEXT_PREFIX = "text/";
     public static final String XML_DATA = "xmldata";
     public static final String IMAGE = "image";
+    public static final String ALL_TYPES = "*/*";
+    public static final String VENDOR_SPECIFIC_TYPE = "vnd.";
 
     // auth related constants
     public static final String API_KEY = "apikey";

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -141,8 +141,10 @@ public class GeneratorConstants {
     public static final String TEXT_PREFIX = "text/";
     public static final String XML_DATA = "xmldata";
     public static final String IMAGE = "image";
-    public static final String ALL_TYPES = "*/*";
+    public static final String ANY_TYPE = "*/*";
     public static final String VENDOR_SPECIFIC_TYPE = "vnd.";
+    public static final String APPLICATION_PDF = "application/pdf";
+    public static final String IMAGE_PNG = "image/png";
 
     // auth related constants
     public static final String API_KEY = "apikey";

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorUtils.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorUtils.java
@@ -71,6 +71,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.ws.rs.core.MediaType;
+
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyNodeList;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createIdentifierToken;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createSeparatedNodeList;
@@ -91,14 +93,18 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_BRACE_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.STRING_KEYWORD;
 import static io.ballerina.openapi.cmd.OpenApiMesseges.BAL_KEYWORDS;
+import static io.ballerina.openapi.generators.GeneratorConstants.ANY_TYPE;
+import static io.ballerina.openapi.generators.GeneratorConstants.APPLICATION_PDF;
 import static io.ballerina.openapi.generators.GeneratorConstants.BALLERINA;
 import static io.ballerina.openapi.generators.GeneratorConstants.DELETE;
 import static io.ballerina.openapi.generators.GeneratorConstants.EXPLODE;
 import static io.ballerina.openapi.generators.GeneratorConstants.GET;
 import static io.ballerina.openapi.generators.GeneratorConstants.HEAD;
+import static io.ballerina.openapi.generators.GeneratorConstants.IMAGE_PNG;
 import static io.ballerina.openapi.generators.GeneratorConstants.OPTIONS;
 import static io.ballerina.openapi.generators.GeneratorConstants.PATCH;
 import static io.ballerina.openapi.generators.GeneratorConstants.PUT;
+import static io.ballerina.openapi.generators.GeneratorConstants.SQUARE_BRACKETS;
 import static io.ballerina.openapi.generators.GeneratorConstants.STYLE;
 import static io.ballerina.openapi.generators.GeneratorConstants.TRACE;
 
@@ -351,19 +357,19 @@ public class GeneratorUtils {
      */
     public static String getBallerinaMediaType(String mediaType) {
         switch (mediaType) {
-            case "*/*":
-            case "application/json":
+            case MediaType.APPLICATION_JSON:
                 return SyntaxKind.JSON_KEYWORD.stringValue();
-            case "application/xml":
+            case MediaType.APPLICATION_XML:
                 return SyntaxKind.XML_KEYWORD.stringValue();
-            case "application/x-www-form-urlencoded":
-            case "text/html":
-            case "text/plain":
+            case MediaType.APPLICATION_FORM_URLENCODED:
+            case MediaType.TEXT_HTML:
+            case MediaType.TEXT_PLAIN:
                 return STRING_KEYWORD.stringValue();
-            case "image/png":
-            case "application/octet-stream":
-            case "application/pdf":
-                return SyntaxKind.BYTE_ARRAY_LITERAL.stringValue() + "[]";
+            case IMAGE_PNG:
+            case MediaType.APPLICATION_OCTET_STREAM:
+            case APPLICATION_PDF:
+            case ANY_TYPE:
+                return SyntaxKind.BYTE_KEYWORD.stringValue() + SQUARE_BRACKETS;
             default:
                 return SyntaxKind.JSON_KEYWORD.stringValue();
             // TODO: fill other types

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionSignatureGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionSignatureGenerator.java
@@ -33,6 +33,7 @@ import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
 import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
@@ -84,11 +85,13 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUESTION_MARK_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.RETURNS_KEYWORD;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
 import static io.ballerina.openapi.ErrorMessages.invalidPathParamType;
+import static io.ballerina.openapi.generators.GeneratorConstants.ANY_TYPE;
 import static io.ballerina.openapi.generators.GeneratorConstants.BINARY;
 import static io.ballerina.openapi.generators.GeneratorConstants.BYTE;
 import static io.ballerina.openapi.generators.GeneratorConstants.NILLABLE;
 import static io.ballerina.openapi.generators.GeneratorConstants.SQUARE_BRACKETS;
 import static io.ballerina.openapi.generators.GeneratorConstants.STRING;
+import static io.ballerina.openapi.generators.GeneratorConstants.VENDOR_SPECIFIC_TYPE;
 import static io.ballerina.openapi.generators.GeneratorConstants.X_BALLERINA_DEPRECATED_REASON;
 import static io.ballerina.openapi.generators.GeneratorUtils.convertOpenAPITypeToBallerina;
 import static io.ballerina.openapi.generators.GeneratorUtils.escapeIdentifier;
@@ -437,7 +440,9 @@ public class FunctionSignatureGenerator {
             Schema schema = next.getValue().getSchema();
             String paramType = "";
             //Take payload type
-            if (schema.get$ref() != null) {
+            if (next.getKey().equals(ANY_TYPE) || next.getKey().contains(VENDOR_SPECIFIC_TYPE)) {
+                paramType = SyntaxKind.BYTE_KEYWORD.stringValue() + "[]";
+            } else if (schema.get$ref() != null) {
                 paramType = getValidName(extractReferenceType(schema.get$ref().trim()), true);
             } else if (schema.getType() != null && !schema.getType().equals("array") && !schema.getType().equals(
                     "object")) {

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/MimeFactory.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/MimeFactory.java
@@ -20,7 +20,7 @@ package io.ballerina.openapi.generators.client;
 
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.openapi.exception.BallerinaOpenApiException;
-import io.ballerina.openapi.generators.client.mime.AllType;
+import io.ballerina.openapi.generators.client.mime.AnyType;
 import io.ballerina.openapi.generators.client.mime.CustomType;
 import io.ballerina.openapi.generators.client.mime.JsonType;
 import io.ballerina.openapi.generators.client.mime.MimeType;
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 
-import static io.ballerina.openapi.generators.GeneratorConstants.ALL_TYPES;
+import static io.ballerina.openapi.generators.GeneratorConstants.ANY_TYPE;
 import static io.ballerina.openapi.generators.GeneratorConstants.IMAGE;
 import static io.ballerina.openapi.generators.GeneratorConstants.JSON;
 import static io.ballerina.openapi.generators.GeneratorConstants.PDF;
@@ -69,7 +69,9 @@ public class MimeFactory {
         if (requestBodySchema.get$ref() != null || requestBodySchema.getType() != null
                 || requestBodySchema.getProperties() != null) {
             String mediaType = mediaTypeEntry.getKey();
-            if (mediaType.contains(JSON) || mediaType.contains(VENDOR_SPECIFIC_TYPE)) {
+            if (mediaType.contains(VENDOR_SPECIFIC_TYPE)) {
+                return new CustomType();
+            } else if (mediaType.contains(JSON)) {
                 return new JsonType();
             } else if (mediaType.startsWith(TEXT_PREFIX) || mediaType.contains(PDF) || mediaType.startsWith(IMAGE)) {
                 return new CustomType();
@@ -79,8 +81,8 @@ public class MimeFactory {
                 return new UrlEncodedType(ballerinaUtilGenerator);
             } else if (mediaType.equals(APPLICATION_OCTET_STREAM)) {
                 return new OctedStreamType();
-            } else if (mediaType.contains(ALL_TYPES)) {
-                return new AllType();
+            } else if (mediaType.contains(ANY_TYPE)) {
+                return new AnyType();
             } else {
                 throw new BallerinaOpenApiException(String.format(UNSUPPORTED_MEDIA_ERROR, mediaType));
             }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/MimeFactory.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/MimeFactory.java
@@ -67,7 +67,7 @@ public class MimeFactory {
             String mediaType = mediaTypeEntry.getKey();
             if (mediaType.contains(JSON)) {
                 return new JsonType();
-            } else if (mediaType.startsWith(TEXT_PREFIX) || mediaType.contains(PDF)) {
+            } else if (mediaType.startsWith(TEXT_PREFIX) || mediaType.contains(PDF) || mediaType.startsWith("image") || mediaType.equals("*/*")) {
                 return new DefaultType();
             } else if (mediaType.contains(XML)) {
                 return new XmlType(imports);

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/MimeFactory.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/MimeFactory.java
@@ -20,7 +20,8 @@ package io.ballerina.openapi.generators.client;
 
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.openapi.exception.BallerinaOpenApiException;
-import io.ballerina.openapi.generators.client.mime.DefaultType;
+import io.ballerina.openapi.generators.client.mime.AllType;
+import io.ballerina.openapi.generators.client.mime.CustomType;
 import io.ballerina.openapi.generators.client.mime.JsonType;
 import io.ballerina.openapi.generators.client.mime.MimeType;
 import io.ballerina.openapi.generators.client.mime.OctedStreamType;
@@ -33,10 +34,13 @@ import java.util.List;
 import java.util.Map;
 
 
+import static io.ballerina.openapi.generators.GeneratorConstants.ALL_TYPES;
+import static io.ballerina.openapi.generators.GeneratorConstants.IMAGE;
 import static io.ballerina.openapi.generators.GeneratorConstants.JSON;
 import static io.ballerina.openapi.generators.GeneratorConstants.PDF;
 import static io.ballerina.openapi.generators.GeneratorConstants.TEXT_PREFIX;
 import static io.ballerina.openapi.generators.GeneratorConstants.UNSUPPORTED_MEDIA_ERROR;
+import static io.ballerina.openapi.generators.GeneratorConstants.VENDOR_SPECIFIC_TYPE;
 import static io.ballerina.openapi.generators.GeneratorConstants.XML;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
@@ -65,21 +69,23 @@ public class MimeFactory {
         if (requestBodySchema.get$ref() != null || requestBodySchema.getType() != null
                 || requestBodySchema.getProperties() != null) {
             String mediaType = mediaTypeEntry.getKey();
-            if (mediaType.contains(JSON)) {
+            if (mediaType.contains(JSON) || mediaType.contains(VENDOR_SPECIFIC_TYPE)) {
                 return new JsonType();
-            } else if (mediaType.startsWith(TEXT_PREFIX) || mediaType.contains(PDF) || mediaType.startsWith("image") || mediaType.equals("*/*")) {
-                return new DefaultType();
+            } else if (mediaType.startsWith(TEXT_PREFIX) || mediaType.contains(PDF) || mediaType.startsWith(IMAGE)) {
+                return new CustomType();
             } else if (mediaType.contains(XML)) {
                 return new XmlType(imports);
             } else if (mediaType.equals(APPLICATION_FORM_URLENCODED)) {
                 return new UrlEncodedType(ballerinaUtilGenerator);
             } else if (mediaType.equals(APPLICATION_OCTET_STREAM)) {
                 return new OctedStreamType();
+            } else if (mediaType.contains(ALL_TYPES)) {
+                return new AllType();
             } else {
                 throw new BallerinaOpenApiException(String.format(UNSUPPORTED_MEDIA_ERROR, mediaType));
             }
         } else {
-            return new DefaultType();
+            return new CustomType();
         }
     }
 }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/AllType.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/AllType.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.openapi.generators.client.mime;
 
+import io.ballerina.compiler.syntax.tree.ExpressionStatementNode;
 import io.ballerina.compiler.syntax.tree.StatementNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
 import io.ballerina.openapi.generators.GeneratorUtils;
@@ -26,23 +27,21 @@ import io.swagger.v3.oas.models.media.MediaType;
 import java.util.List;
 import java.util.Map;
 
-import static io.ballerina.openapi.generators.GeneratorConstants.BYTE;
-
-
 /**
- * Defines the payload structure of "application/octet-stream" mime type.
+ * Defines payload that supports all types structure.
  *
  * @since 2.0.0
  */
-public class OctedStreamType extends MimeType {
+public class AllType extends MimeType {
+
     @Override
     public void setPayload(List<StatementNode> statementsList, Map.Entry<String, MediaType> mediaTypeEntry) {
-        if (mediaTypeEntry.getValue().getSchema().getFormat().equals(BYTE)) {
-            payloadName = "encodedRequestBody";
-            VariableDeclarationNode encodedVariable = GeneratorUtils.getSimpleStatement("string",
-                    payloadName, "payload.toBase64()");
-            statementsList.add(encodedVariable);
-        }
-        setPayload(statementsList, payloadName, javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM);
+        payloadName = "jsonBody";
+        VariableDeclarationNode jsonVariable = GeneratorUtils.getSimpleStatement("json", payloadName
+                , "check payload.cloneWithType(json)");
+        statementsList.add(jsonVariable);
+        ExpressionStatementNode setPayloadExpression = GeneratorUtils.getSimpleExpressionStatementNode(
+                String.format("request.setPayload(%s)", payloadName));
+        statementsList.add(setPayloadExpression);
     }
 }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/AnyType.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/AnyType.java
@@ -20,7 +20,6 @@ package io.ballerina.openapi.generators.client.mime;
 
 import io.ballerina.compiler.syntax.tree.ExpressionStatementNode;
 import io.ballerina.compiler.syntax.tree.StatementNode;
-import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
 import io.ballerina.openapi.generators.GeneratorUtils;
 import io.swagger.v3.oas.models.media.MediaType;
 
@@ -32,16 +31,12 @@ import java.util.Map;
  *
  * @since 2.0.0
  */
-public class AllType extends MimeType {
+public class AnyType extends MimeType {
 
     @Override
     public void setPayload(List<StatementNode> statementsList, Map.Entry<String, MediaType> mediaTypeEntry) {
-        payloadName = "jsonBody";
-        VariableDeclarationNode jsonVariable = GeneratorUtils.getSimpleStatement("json", payloadName
-                , "check payload.cloneWithType(json)");
-        statementsList.add(jsonVariable);
         ExpressionStatementNode setPayloadExpression = GeneratorUtils.getSimpleExpressionStatementNode(
-                String.format("request.setPayload(%s)", payloadName));
+                "request.setPayload(payload)");
         statementsList.add(setPayloadExpression);
     }
 }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/CustomType.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/CustomType.java
@@ -25,12 +25,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Defines default payload structure.
+ * Defines vendor specific payload mime type.
  *
  * @since 2.0.0
  */
-public class DefaultType extends MimeType {
-
+public class CustomType extends MimeType {
     @Override
     public void setPayload(List<StatementNode> statementsList, Map.Entry<String, MediaType> mediaTypeEntry) {
         setPayload(statementsList, payloadName, mediaTypeEntry.getKey());

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/JsonType.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/mime/JsonType.java
@@ -34,11 +34,11 @@ import java.util.Map;
 public class JsonType extends MimeType {
 
     @Override
-    public void setPayload(List<StatementNode> statementsList, Map.Entry<String, MediaType> mediaType) {
+    public void setPayload(List<StatementNode> statementsList, Map.Entry<String, MediaType> mediaTypeEntry) {
         payloadName = "jsonBody";
         VariableDeclarationNode jsonVariable = GeneratorUtils.getSimpleStatement("json", payloadName
                 , "check payload.cloneWithType(json)");
         statementsList.add(jsonVariable);
-        setPayload(statementsList, payloadName, mediaType.getKey());
+        setPayload(statementsList, payloadName, mediaTypeEntry.getKey());
     }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -117,10 +117,26 @@ public class FunctionBodyNodeTests {
                         "http:Request request = new;" +
                         "request.setPayload(payload, \"application/pdf\");" +
                         "http:Response response = check self.clientEp->post(path, request);" +
+                        "return response;}"},
+                {"swagger/image_payload.yaml", "/pets", "{string path = string `/pets`;" +
+                        "http:Request request = new;" +
+                        "request.setPayload(payload, \"image/png\");" +
+                        "http:Response response = check self.clientEp->post(path, request);" +
+                        "return response;}"},
+                {"swagger/all_types_payload.yaml", "/pets", "{string path = string `/pets`;" +
+                        "http:Request request = new;" +
+                        "json jsonBody = check payload.cloneWithType(json);" +
+                        "request.setPayload(jsonBody);" +
+                        "http:Response response = check self.clientEp->post(path, request);" +
+                        "return response;}"},
+                {"swagger/vendor_specific_payload.yaml", "/pets", "{string path = string `/pets`;" +
+                        "http:Request request = new;" +
+                        "json jsonBody = check payload.cloneWithType(json);" +
+                        "request.setPayload(jsonBody, \"application/vnd.ms-excel\");" +
+                        "http:Response response = check self.clientEp->post(path, request);" +
                         "return response;}"}
         };
     }
-    //TODO:Different mediaType
 
     @AfterTest
     private void deleteGeneratedFiles() {

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -122,18 +122,6 @@ public class FunctionBodyNodeTests {
                         "http:Request request = new;" +
                         "request.setPayload(payload, \"image/png\");" +
                         "http:Response response = check self.clientEp->post(path, request);" +
-                        "return response;}"},
-                {"swagger/all_types_payload.yaml", "/pets", "{string path = string `/pets`;" +
-                        "http:Request request = new;" +
-                        "json jsonBody = check payload.cloneWithType(json);" +
-                        "request.setPayload(jsonBody);" +
-                        "http:Response response = check self.clientEp->post(path, request);" +
-                        "return response;}"},
-                {"swagger/vendor_specific_payload.yaml", "/pets", "{string path = string `/pets`;" +
-                        "http:Request request = new;" +
-                        "json jsonBody = check payload.cloneWithType(json);" +
-                        "request.setPayload(jsonBody, \"application/vnd.ms-excel\");" +
-                        "http:Response response = check self.clientEp->post(path, request);" +
                         "return response;}"}
         };
     }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -133,6 +133,28 @@ public class RequestBodyTests {
         compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
     }
 
+    @Test(description = "Test for generating request body when operation has */* media type")
+    public void testRequestBodyWithAllTypeMediaType() throws IOException, BallerinaOpenApiException {
+        Path expectedPath = RES_DIR.resolve("ballerina/any_types_payload.bal");
+        CodeGenerator codeGenerator = new CodeGenerator();
+        OpenAPI openAPI = codeGenerator.normalizeOpenAPI(
+                RES_DIR.resolve("swagger/any_types_payload.yaml"), true);
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(openAPI, filter, false);
+        syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
+    }
+
+    @Test(description = "Test for generating request body when operation has vendor specific media type")
+    public void testRequestBodyWithVendorSpecificMimeType() throws IOException, BallerinaOpenApiException {
+        Path expectedPath = RES_DIR.resolve("ballerina/vendor_specific_payload.bal");
+        CodeGenerator codeGenerator = new CodeGenerator();
+        OpenAPI openAPI = codeGenerator.normalizeOpenAPI(
+                RES_DIR.resolve("swagger/vendor_specific_payload.yaml"), true);
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(openAPI, filter, false);
+        syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
+    }
+
     @AfterTest
     private void deleteGeneratedFiles() {
         try {

--- a/openapi-cli/src/test/resources/generators/client/ballerina/any_types_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/any_types_payload.bal
@@ -1,0 +1,26 @@
+import ballerina/http;
+
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + clientConfig - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "http://petstore.{host}.io/v1") returns error? {
+        http:Client httpEp = check new (serviceUrl, clientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Create a pet
+    #
+    # + return - Null response
+    remote isolated function createPet(byte[] payload) returns http:Response|error {
+        string path = string `/pets`;
+        http:Request request = new;
+        request.setPayload(payload);
+        http:Response response = check self.clientEp->post(path, request);
+        return response;
+    }
+}
+

--- a/openapi-cli/src/test/resources/generators/client/ballerina/vendor_specific_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/vendor_specific_payload.bal
@@ -1,0 +1,25 @@
+import ballerina/http;
+
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + clientConfig - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "http://petstore.{host}.io/v1") returns error? {
+        http:Client httpEp = check new (serviceUrl, clientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Create a pet
+    #
+    # + return - Null response
+    remote isolated function createPet(byte[] payload) returns http:Response|error {
+        string path = string `/pets`;
+        http:Request request = new;
+        request.setPayload(payload, "application/vnd.ms-excel");
+        http:Response response = check self.clientEp->post(path, request);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/swagger/all_types_payload.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/all_types_payload.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        content:
+          "*/*":
+            schema:
+              properties:
+                name:
+                  type: string
+                type: object
+      responses:
+        '201':
+          description: Null response

--- a/openapi-cli/src/test/resources/generators/client/swagger/any_types_payload.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/any_types_payload.yaml
@@ -16,10 +16,9 @@ paths:
         content:
           "*/*":
             schema:
-              properties:
-                name:
-                  type: string
-                type: object
+              type: array
+              items:
+                type: string
       responses:
         '201':
           description: Null response

--- a/openapi-cli/src/test/resources/generators/client/swagger/image_payload.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/image_payload.yaml
@@ -1,0 +1,23 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        content:
+          image/png:
+            schema:
+              format: binary
+              type: string
+      responses:
+        '201':
+          description: Null response

--- a/openapi-cli/src/test/resources/generators/client/swagger/vendor_specific_payload.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/vendor_specific_payload.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        content:
+          application/vnd.ms-excel:
+            schema:
+              properties:
+                name:
+                  type: string
+                type: object
+      responses:
+        '201':
+          description: Null response

--- a/openapi-cli/src/test/resources/generators/client/swagger/vendor_specific_payload.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/vendor_specific_payload.yaml
@@ -19,7 +19,6 @@ paths:
               properties:
                 name:
                   type: string
-                type: object
       responses:
         '201':
           description: Null response


### PR DESCRIPTION
## Purpose
Support `*/*`, `image/*` and vendor specific request MIME type in client request body generation. This is part of https://github.com/ballerina-platform/ballerina-openapi/issues/684 improvement.

## Goals
Fixes https://github.com/ballerina-platform/openapi-tools/issues/621
Fixes https://github.com/ballerina-platform/openapi-tools/issues/675

## Automation tests
 - Unit tests 
 Added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
