### PR TITLE
Improve error message at missing operation ids

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/CodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/CodeGenerator.java
@@ -93,12 +93,14 @@ import static io.ballerina.openapi.generators.GeneratorConstants.CONFIG_FILE_NAM
 import static io.ballerina.openapi.generators.GeneratorConstants.DEFAULT_CLIENT_PKG;
 import static io.ballerina.openapi.generators.GeneratorConstants.DEFAULT_MOCK_PKG;
 import static io.ballerina.openapi.generators.GeneratorConstants.DELETE;
+import static io.ballerina.openapi.generators.GeneratorConstants.DOUBLE_LINE_SEPARATOR;
 import static io.ballerina.openapi.generators.GeneratorConstants.ESCAPE_PATTERN;
 import static io.ballerina.openapi.generators.GeneratorConstants.GET;
 import static io.ballerina.openapi.generators.GeneratorConstants.GenType.GEN_CLIENT;
 import static io.ballerina.openapi.generators.GeneratorConstants.GenType.GEN_SERVICE;
 import static io.ballerina.openapi.generators.GeneratorConstants.HEAD;
 import static io.ballerina.openapi.generators.GeneratorConstants.IDENTIFIER;
+import static io.ballerina.openapi.generators.GeneratorConstants.LINE_SEPARATOR;
 import static io.ballerina.openapi.generators.GeneratorConstants.OAS_PATH_SEPARATOR;
 import static io.ballerina.openapi.generators.GeneratorConstants.TEMPLATES_DIR_PATH_KEY;
 import static io.ballerina.openapi.generators.GeneratorConstants.TEMPLATES_SUFFIX;
@@ -646,16 +648,23 @@ public class CodeGenerator {
      * @throws BallerinaOpenApiException When operationId is missing in any path
      */
     private void validateOperationIds(Set<Map.Entry<String, PathItem>> paths) throws BallerinaOpenApiException {
+        List<String> errorList = new ArrayList<>();
         for (Map.Entry<String, PathItem> entry : paths) {
-            for (Operation operation : entry.getValue().readOperations()) {
-                if (operation.getOperationId() != null) {
-                    String operationId = getValidName(operation.getOperationId(), false);
-                    operation.setOperationId(operationId);
+            for (Map.Entry<PathItem.HttpMethod, Operation> operation :
+                    entry.getValue().readOperationsMap().entrySet()) {
+                if (operation.getValue().getOperationId() != null) {
+                    String operationId = getValidName(operation.getValue().getOperationId(), false);
+                    operation.getValue().setOperationId(operationId);
                 } else {
-                    throw new BallerinaOpenApiException("OperationId is missing for the resource path: "
-                            + entry.getKey());
+                    errorList.add(String.format("OperationId is missing in the resource path: %s(%s)", entry.getKey(),
+                            operation.getKey()));
                 }
             }
+        }
+        if (!errorList.isEmpty()) {
+            throw new BallerinaOpenApiException(
+                    "OpenAPI definition has errors: " +
+                            DOUBLE_LINE_SEPARATOR + String.join(LINE_SEPARATOR, errorList));
         }
     }
 
@@ -682,9 +691,9 @@ public class CodeGenerator {
         }
 
         if (!errorList.isEmpty()) {
-            StringBuilder errorMessage = new StringBuilder("OpenAPI definition has errors: \n\n");
+            StringBuilder errorMessage = new StringBuilder("OpenAPI definition has errors: " + DOUBLE_LINE_SEPARATOR);
             for (String message : errorList) {
-                errorMessage.append(message).append("\n");
+                errorMessage.append(message).append(LINE_SEPARATOR);
             }
             throw new BallerinaOpenApiException(errorMessage.toString());
         }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -279,4 +279,8 @@ public class GeneratorConstants {
 
     //Error related
     public static final String UNSUPPORTED_MEDIA_ERROR = "Unsupported media type '%s' is given in the request body";
+
+    // OS specific line separator
+    public static final String LINE_SEPARATOR = System.lineSeparator();
+    public static final String DOUBLE_LINE_SEPARATOR = LINE_SEPARATOR + LINE_SEPARATOR;
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RemoteFunctionNameValidationTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RemoteFunctionNameValidationTests.java
@@ -30,7 +30,8 @@ public class RemoteFunctionNameValidationTests {
 
     @Test(description = "When path parameter has given unmatch data type in ballerina",
             expectedExceptions = BallerinaOpenApiException.class,
-            expectedExceptionsMessageRegExp = "OperationId is missing for the resource path: .*")
+            expectedExceptionsMessageRegExp = "OpenAPI definition has errors: " +
+                    "\\R\\ROperationId is missing in the resource path: .*")
     public void testMissionOperationId() throws IOException, BallerinaOpenApiException {
         CodeGenerator codeGenerator = new CodeGenerator();
         Path definitionPath = RESDIR.resolve("petstore_without_operation_id.yaml");


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/ballerina-platform/openapi-tools/issues/759

## Goals
> Following error will be thrown when operations with missing `operationId` are found. 
```
OpenAPI definition has errors: 

OperationId is missing in the resource path: /pets(GET)
OperationId is missing in the resource path: /pets(POST)
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes