### PR TITLE
[Client] Add support when RequestBody given without schema

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -151,6 +151,7 @@ public class GeneratorConstants {
     public static final String IMAGE_PNG = "image/png";
     public static final String MIME = "mime";
     public static final String HTTP_HEADERS = "httpHeaders";
+    public static final String ARRAY = "array";
 
     // auth related constants
     public static final String API_KEY = "apikey";

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
@@ -617,13 +617,13 @@ public class FunctionBodyGenerator {
         VariableDeclarationNode requestVariable = GeneratorUtils.getSimpleStatement("http:Request",
                 "request", "new");
         statementsList.add(requestVariable);
-        if (next.getValue().getSchema() != null) {
+        if (next.getValue() != null) {
             genStatementsForRequestMediaType(statementsList, next);
             // TODO:Fill with other mime type
         } else {
             // Add default value comment
             ExpressionStatementNode expressionStatementNode = GeneratorUtils.getSimpleExpressionStatementNode(
-                    "TODO: Update the request as needed");
+                    "// TODO: Update the request as needed");
             statementsList.add(expressionStatementNode);
         }
         // POST, PUT, PATCH, DELETE, EXECUTE

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/MimeFactory.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/MimeFactory.java
@@ -68,8 +68,8 @@ public class MimeFactory {
                                 BallerinaUtilGenerator ballerinaUtilGenerator, List<ImportDeclarationNode> imports)
             throws BallerinaOpenApiException {
         Schema requestBodySchema = mediaTypeEntry.getValue().getSchema();
-        if (requestBodySchema.get$ref() != null || requestBodySchema.getType() != null
-                || requestBodySchema.getProperties() != null) {
+        if (requestBodySchema != null && (requestBodySchema.get$ref() != null || requestBodySchema.getType() != null
+                || requestBodySchema.getProperties() != null)) {
             String mediaType = mediaTypeEntry.getKey();
             if (mediaType.contains(VENDOR_SPECIFIC_TYPE)) {
                 return new CustomType();

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -188,6 +188,17 @@ public class RequestBodyTests {
         compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
     }
 
+    @Test(description = "Test for generating request body when schema is empty")
+    public void testRequestBodyWithoutSchema() throws IOException, BallerinaOpenApiException {
+        Path expectedPath = RES_DIR.resolve("ballerina/request_body_without_schema.bal");
+        CodeGenerator codeGenerator = new CodeGenerator();
+        OpenAPI openAPI = codeGenerator.normalizeOpenAPI(
+                RES_DIR.resolve("swagger/request_body_without_schema.yaml"), true);
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(openAPI, filter, false);
+        syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
+    }
+
     @AfterTest
     private void deleteGeneratedFiles() {
         try {

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_without_schema.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_without_schema.bal
@@ -1,0 +1,28 @@
+import ballerina/http;
+
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + clientConfig - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
+        http:Client httpEp = check new (serviceUrl, clientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # List all pets
+    #
+    # + 'limit - How many items to return at one time (max 100)
+    # + payload - Pet
+    remote isolated function listPets(json payload, int? 'limit = ()) returns json|error {
+        string path = string `/pets`;
+        map<anydata> queryParam = {"limit": 'limit};
+        path = path + check getPathForQueryParam(queryParam);
+        http:Request request = new;
+        request.setPayload(payload, "application/json");
+        json response = check self.clientEp->post(path, request);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/swagger/request_body_without_schema.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/request_body_without_schema.yaml
@@ -1,0 +1,58 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets:
+    post:
+      summary: List all pets
+      description: Show a list of pets in the system
+      operationId: listPets
+      tags:
+        - pets
+        - list
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        description: Pet
+        content:
+          application/json: {}
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json: {}


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/ballerina-platform/openapi-tools/issues/724

## Goals

**Sample OpenAPI**
```yaml
/pets:
    post:
      summary: List all pets
      description: Show a list of pets in the system
      operationId: listPets
      tags:
        - pets
        - list
      parameters:
        - name: limit
          in: query
          description: How many items to return at one time (max 100)
          required: false
          schema:
            type: integer
            format: int32
      requestBody:
        description: Pet
        content:
          application/json: {}
      responses:
        '200':
          description: ''
          content:
            application/json: {}
```
**Suggested code implementation** 

```bal
remote isolated function listPets(json payload, int? 'limit = ()) returns json|error {
        string path = string `/pets`;
        map<anydata> queryParam = {"limit": 'limit};
        path = path + check getPathForQueryParam(queryParam);
        http:Request request = new;
        request.setPayload(payload, "application/json");
        json response = check self.clientEp->post(path, request);
        return response;
    }
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes