### PR TITLE
[Client ] Rename path variable to to resourcePath in remote functions

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -151,6 +151,7 @@ public class GeneratorConstants {
     public static final String IMAGE_PNG = "image/png";
     public static final String MIME = "mime";
     public static final String HTTP_HEADERS = "httpHeaders";
+    public static final String RESOURCE_PATH = "resourcePath";
 
     // auth related constants
     public static final String API_KEY = "apikey";

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
@@ -113,6 +113,7 @@ import static io.ballerina.openapi.generators.GeneratorConstants.POST;
 import static io.ballerina.openapi.generators.GeneratorConstants.PUT;
 import static io.ballerina.openapi.generators.GeneratorConstants.QUERY;
 import static io.ballerina.openapi.generators.GeneratorConstants.QUERY_PARAM;
+import static io.ballerina.openapi.generators.GeneratorConstants.RESOURCE_PATH;
 import static io.ballerina.openapi.generators.GeneratorConstants.RESPONSE;
 import static io.ballerina.openapi.generators.GeneratorConstants.SELF;
 import static io.ballerina.openapi.generators.GeneratorUtils.extractReferenceType;
@@ -353,11 +354,12 @@ public class FunctionBodyGenerator {
         if (queryParamEncodingMap != null) {
             statementsList.add(queryParamEncodingMap);
             ExpressionStatementNode updatedPath = GeneratorUtils.getSimpleExpressionStatementNode(
-                    "path = path + check getPathForQueryParam(queryParam, queryParamEncoding)");
+                    RESOURCE_PATH + " = " + RESOURCE_PATH + " + check getPathForQueryParam(queryParam, " +
+                            "queryParamEncoding)");
             statementsList.add(updatedPath);
         } else {
             ExpressionStatementNode updatedPath = GeneratorUtils.getSimpleExpressionStatementNode(
-                    "path = path + check getPathForQueryParam(queryParam)");
+                    RESOURCE_PATH + " = " + RESOURCE_PATH + " + check getPathForQueryParam(queryParam)");
             statementsList.add(updatedPath);
         }
     }
@@ -506,14 +508,16 @@ public class FunctionBodyGenerator {
                 ExpressionStatementNode expressionStatementNode = GeneratorUtils.getSimpleExpressionStatementNode(
                         "//TODO: Update the request as needed");
                 statementsList.add(expressionStatementNode);
-                clientCallStatement = "check self.clientEp->" + method + "(path, request, headers = " +
-                            "" + HTTP_HEADERS + ")";
+                clientCallStatement = "check self.clientEp->" + method + "(" + RESOURCE_PATH +
+                        ", request, headers = " + HTTP_HEADERS + ")";
 
             } else {
                 if (method.equals(HEAD)) {
-                    clientCallStatement = "check self.clientEp->" + method + "(path, " + HTTP_HEADERS + ")";
+                    clientCallStatement = "check self.clientEp->" + method + "(" + RESOURCE_PATH + ", " +
+                            HTTP_HEADERS + ")";
                 } else {
-                    clientCallStatement = "check self.clientEp->" + method + "(path, " + HTTP_HEADERS + ")";
+                    clientCallStatement = "check self.clientEp->" + method + "(" + RESOURCE_PATH + ", " +
+                            HTTP_HEADERS + ")";
                 }
             }
         } else if (isMethod) {
@@ -524,9 +528,9 @@ public class FunctionBodyGenerator {
                     "//TODO: Update the request as needed");
             statementsList.add(expressionStatementNode);
             clientCallStatement =
-                        "check self.clientEp-> " + method + "(path, request)";
+                        "check self.clientEp-> " + method + "(" + RESOURCE_PATH + ", request)";
         } else {
-            clientCallStatement = "check self.clientEp->" + method + "(path)";
+            clientCallStatement = "check self.clientEp->" + method + "(" + RESOURCE_PATH + ")";
         }
         //Return Variable
         VariableDeclarationNode clientCall = GeneratorUtils.getSimpleStatement(returnType, RESPONSE,
@@ -552,8 +556,8 @@ public class FunctionBodyGenerator {
     private VariableDeclarationNode getPathStatement(String path, NodeList<AnnotationNode> annotationNodes) {
 
         TypedBindingPatternNode typedBindingPatternNode = createTypedBindingPatternNode(createSimpleNameReferenceNode(
-                createIdentifierToken("string")), createCaptureBindingPatternNode(
-                createIdentifierToken("path")));
+                createToken(STRING_KEYWORD)), createCaptureBindingPatternNode(
+                createIdentifierToken(RESOURCE_PATH)));
         // Create initializer
         // Content  should decide with /pet and /pet/{pet}
         path = generatePathWithPathParameter(path);
@@ -629,12 +633,13 @@ public class FunctionBodyGenerator {
         // POST, PUT, PATCH, DELETE, EXECUTE
         VariableDeclarationNode requestStatement =
                 GeneratorUtils.getSimpleStatement(returnType, RESPONSE, "check self.clientEp->"
-                        + method + "(path," + " request)");
+                        + method + "(" + RESOURCE_PATH + ", request)");
         if (isHeader) {
             if (method.equals(POST) || method.equals(PUT) || method.equals(PATCH) || method.equals(DELETE)
                     || method.equals(EXECUTE)) {
                 requestStatement = GeneratorUtils.getSimpleStatement(returnType, RESPONSE,
-                        "check self.clientEp->" + method + "(path, request, headers = " + HTTP_HEADERS + ")");
+                        "check self.clientEp->" + method + "(" + RESOURCE_PATH + ", request, headers = " +
+                                HTTP_HEADERS + ")");
                 statementsList.add(requestStatement);
                 Token returnKeyWord = createIdentifierToken("return");
                 SimpleNameReferenceNode returns = createSimpleNameReferenceNode(createIdentifierToken(RESPONSE));

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -35,7 +35,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,8 +48,6 @@ public class FunctionBodyNodeTests {
     private static final Path RESDIR = Paths.get("src/test/resources/generators/client").toAbsolutePath();
     private static final Path clientPath = RESDIR.resolve("ballerina_project/client.bal");
     private static final Path schemaPath = RESDIR.resolve("ballerina_project/types.bal");
-    List<String> list1 = new ArrayList<>();
-    List<String> list2 = new ArrayList<>();
 
     @Test(description = "Tests functionBodyNodes including statements according to the different scenarios",
             dataProvider = "dataProviderForFunctionBody")
@@ -73,57 +70,60 @@ public class FunctionBodyNodeTests {
     @DataProvider(name = "dataProviderForFunctionBody")
     public Object[][] dataProviderForFunctionBody() {
         return new Object[][]{
-                {"diagnostic_files/header_parameter.yaml", "/pets", "{stringpath=string`/pets`;map<any>headerValues=" +
+                {"diagnostic_files/header_parameter.yaml", "/pets", "{string resourcePath=string`/pets`;" +
+                        "map<any>headerValues=" +
                         "{\"X-Request-ID\":xRequestId,\"X-Request-Client\":xRequestClient};map<string|string[]>" +
                         "httpHeaders=getMapForHeaders(headerValues);http:Response response =checkself.clientEp->get" +
-                        "(path,httpHeaders); return response;}"},
-                {"diagnostic_files/head_operation.yaml", "/{filesystem}", "{string path=string`/${filesystem}`;" +
+                        "(resourcePath,httpHeaders); return response;}"},
+                {"diagnostic_files/head_operation.yaml", "/{filesystem}",
+                        "{string resourcePath=string`/${filesystem}`;" +
                         "map<anydata>queryParam={\"resource\":'resource,\"timeout\":timeout};" +
-                        "path = path + check getPathForQueryParam(queryParam);" +
+                        "resourcePath = resourcePath + check getPathForQueryParam(queryParam);" +
                         "map<any>headerValues={\"x-ms-client-request-id\":xMsClientRequestId," +
                         "\"x-ms-date\":xMsDate,\"x-ms-version\":xMsVersion};map<string|string[]> " +
                         "httpHeaders = getMapForHeaders(headerValues);" +
-                        "http:Responseresponse=check self.clientEp-> head(path, httpHeaders);returnresponse;}"},
-                {"diagnostic_files/operation_delete.yaml", "/pets/{petId}", "{string  path = string `/pets/${petId}`;" +
-                        "http:Response response = check self.clientEp-> delete(path);" +
+                        "http:Responseresponse=check self.clientEp-> head(resourcePath, httpHeaders);returnresponse;}"},
+                {"diagnostic_files/operation_delete.yaml", "/pets/{petId}", "{string resourcePath = " +
+                        "string `/pets/${petId}`;" +
+                        "http:Response response = check self.clientEp-> delete(resourcePath);" +
                         "return response;}"},
-                {"diagnostic_files/json_payload.yaml", "/pets", "{string  path = string `/pets`;" +
+                {"diagnostic_files/json_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new; request.setPayload(payload, \"application/json\"); " +
                         "http:Response response = check self.clientEp->" +
-                        "post(path, request); " +
+                        "post(resourcePath, request); " +
                         "return response;}"},
-                {"diagnostic_files/xml_payload.yaml", "/pets", "{string  path = string `/pets`; " +
+                {"diagnostic_files/xml_payload.yaml", "/pets", "{string resourcePath = string `/pets`; " +
                         "http:Request request = new;" +
                         "request.setPayload(payload, \"application/xml\"); " +
-                        "http:Response response = check self.clientEp->post(path, request);" +
+                        "http:Response response = check self.clientEp->post(resourcePath, request);" +
                         "return response;}"},
-                {"diagnostic_files/xml_payload_with_ref.yaml", "/pets", "{string  path = string `/pets`;" +
+                {"diagnostic_files/xml_payload_with_ref.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new;" +
                         "json jsonBody = check payload.cloneWithType(json);" +
                         "xml? xmlBody = check xmldata:fromJson(jsonBody);" +
                         "request.setPayload(xmlBody, \"application/xml\");" +
-                        "http:Response response = check self.clientEp->post(path, request);" +
+                        "http:Response response = check self.clientEp->post(resourcePath, request);" +
                         "return response;}"},
-                {"swagger/response_type_order.yaml", "/pet/{petId}", "{string path = string `/pet/${petId}`;" +
-                        "Pet response = check self.clientEp->get(path);" +
+                {"swagger/response_type_order.yaml", "/pet/{petId}", "{string resourcePath = string `/pet/${petId}`;" +
+                        "Pet response = check self.clientEp->get(resourcePath);" +
                         "return response;}"},
-                {"swagger/text_request_payload.yaml", "/pets", "{string path = string `/pets`;" +
+                {"swagger/text_request_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new;" +
                         "json jsonBody = check payload.cloneWithType(json);" +
                         "request.setPayload(jsonBody, \"text/json\");" +
-                        "json response = check self.clientEp->post(path, request);" +
+                        "json response = check self.clientEp->post(resourcePath, request);" +
                         "return response;}"},
-                {"swagger/pdf_payload.yaml", "/pets", "{string path = string `/pets`;" +
+                {"swagger/pdf_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new;" +
                         "request.setPayload(payload, \"application/pdf\");" +
-                        "http:Response response = check self.clientEp->post(path, request);" +
+                        "http:Response response = check self.clientEp->post(resourcePath, request);" +
                         "return response;}"},
-                {"swagger/image_payload.yaml", "/pets", "{string path = string `/pets`;" +
+                {"swagger/image_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new;" +
                         "request.setPayload(payload, \"image/png\");" +
-                        "http:Response response = check self.clientEp->post(path, request);" +
+                        "http:Response response = check self.clientEp->post(resourcePath, request);" +
                         "return response;}"},
-                {"swagger/multipart_formdata_custom.yaml", "/pets", "{string path = string `/pets`;\n" +
+                {"swagger/multipart_formdata_custom.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
                         "http:Request request = new;\n" +
                         "map<Encoding> encodingMap = {\"profileImage\": {contentType: \"image/png\", headers: " +
                         "{\"X-Custom-Header\": xCustomHeader}}, \"id\":{headers: {\"X-Custom-Header\": " +
@@ -131,7 +131,7 @@ public class FunctionBodyNodeTests {
                         "{contentType:\"text/plain\"}};\n" +
                         "mime:Entity[] bodyParts = check createBodyParts(payload, encodingMap);\n" +
                         "request.setBodyParts(bodyParts);\n" +
-                        "http:Response response = check self.clientEp->post(path, request);\n" +
+                        "http:Response response = check self.clientEp->post(resourcePath, request);\n" +
                         "return response;}"}
         };
     }

--- a/openapi-cli/src/test/resources/expected_gen/client_filtered_by_tags.bal
+++ b/openapi-cli/src/test/resources/expected_gen/client_filtered_by_tags.bal
@@ -17,20 +17,20 @@ public isolated client class Client {
     # + 'limit - How many items to return at one time (max 100)
     # + return - An paged array of pets
     remote isolated function listPets(int? 'limit = ()) returns Pets|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         map<anydata> queryParam = {"limit": 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        Pets response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Pets response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Create a pet
     #
     # + return - Null response
     remote isolated function createPet() returns http:Response|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> post(path, request);
+        http:Response response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Info for a specific pet
@@ -38,8 +38,8 @@ public isolated client class Client {
     # + petId - The id of the pet to retrieve
     # + return - Expected response to a valid request
     remote isolated function showPetById(string petId) returns Pets|error {
-        string  path = string `/pets/${petId}`;
-        Pets response = check self.clientEp-> get(path);
+        string resourcePath = string `/pets/${petId}`;
+        Pets response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Info for a specific pet
@@ -47,8 +47,8 @@ public isolated client class Client {
     # + dogId - The id of the pet to retrieve
     # + return - Expected response to a valid request
     remote isolated function getDogs(string dogId) returns Dog|error {
-        string  path = string `/pets/dogs/${dogId}`;
-        Dog response = check self.clientEp-> get(path);
+        string resourcePath = string `/pets/dogs/${dogId}`;
+        Dog response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/expected_gen/generate_client.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generate_client.bal
@@ -17,20 +17,20 @@ public isolated client class Client {
     # + 'limit - How many items to return at one time (max 100)
     # + return - An paged array of pets
     remote isolated function listPets(int? 'limit = ()) returns Pets|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         map<anydata> queryParam = {"limit": 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        Pets response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Pets response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Create a pet
     #
     # + return - Null response
     remote isolated function  createPet() returns http:Response|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> post(path, request);
+        http:Response response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Info for a specific pet
@@ -38,8 +38,8 @@ public isolated client class Client {
     # + petId - The id of the pet to retrieve
     # + return - Expected response to a valid request
     remote isolated function showPetById(string petId) returns Pets|error {
-        string  path = string `/pets/${petId}`;
-        Pets response = check self.clientEp-> get(path);
+        string resourcePath = string `/pets/${petId}`;
+        Pets response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/expected_gen/generate_client_requestbody.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generate_client_requestbody.bal
@@ -17,11 +17,11 @@ public isolated client class Client {
     #
     # + return - OK
     remote isolated function createUser(User payload) returns http:Response|error {
-        string  path = string `/requestBody`;
+        string resourcePath = string `/requestBody`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp-> post(path, request);
+        http:Response response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/expected_gen/generated_client_with_license.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generated_client_with_license.bal
@@ -20,20 +20,20 @@ public isolated client class Client {
     # + 'limit - How many items to return at one time (max 100)
     # + return - An paged array of pets
     remote isolated function listPets(int? 'limit = ()) returns Pets|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         map<anydata> queryParam = {"limit": 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        Pets response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Pets response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Create a pet
     #
     # + return - Null response
     remote isolated function  createPet() returns http:Response|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> post(path, request);
+        http:Response response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Info for a specific pet
@@ -41,8 +41,8 @@ public isolated client class Client {
     # + petId - The id of the pet to retrieve
     # + return - Expected response to a valid request
     remote isolated function showPetById(string petId) returns Pets|error {
-        string  path = string `/pets/${petId}`;
-        Pets response = check self.clientEp-> get(path);
+        string resourcePath = string `/pets/${petId}`;
+        Pets response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/expected_gen/x_init_description.bal
+++ b/openapi-cli/src/test/resources/expected_gen/x_init_description.bal
@@ -23,8 +23,8 @@ public isolated client class Client {
     #
     # + return - An array of Movie Critics
     remote isolated function criticsPicks() returns InlineResponse200|error {
-        string  path = string `/`;
-        InlineResponse200 response = check self.clientEp-> get(path);
+        string resourcePath = string `/`;
+        InlineResponse200 response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/any_types_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/any_types_payload.bal
@@ -16,10 +16,10 @@ public isolated client class Client {
     #
     # + return - Null response
     remote isolated function createPet(byte[] payload) returns http:Response|error {
-        string path = string `/pets`;
+        string resourcePath = string `/pets`;
         http:Request request = new;
         request.setPayload(payload);
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/binary_format_octet_stream_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/binary_format_octet_stream_payload.bal
@@ -16,10 +16,10 @@ public isolated client class Client {
     #
     # + return - Null response
     remote isolated function createPet(byte[] payload) returns http:Response|error {
-        string path = string `/pets`;
+        string resourcePath = string `/pets`;
         http:Request request = new;
         request.setPayload(payload, "application/octet-stream");
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/byte_format_octet_stream_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/byte_format_octet_stream_payload.bal
@@ -16,11 +16,11 @@ public isolated client class Client {
     #
     # + return - Null response
     remote isolated function createPet(byte[] payload) returns http:Response|error {
-        string path = string `/pets`;
+        string resourcePath = string `/pets`;
         http:Request request = new;
         string encodedRequestBody = payload.toBase64();
         request.setPayload(encodedRequestBody, "application/octet-stream");
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/client_template.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/client_template.bal
@@ -16,15 +16,15 @@ public isolated client class Client {
         return;
     }
     remote isolated function listPets(int? 'limit) returns Pets|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         map<anydata> queryParam = {'limit: 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        Pets response = check self.clientEp->get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Pets response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function showPetById(string petId) returns Pets|error {
-        string  path = string `/pets/${petId}`;
-        Pets response = check self.clientEp->get(path);
+        string resourcePath = string `/pets/${petId}`;
+        Pets response = check self.clientEp->get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/combination_of_apikey_and_http_oauth.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/combination_of_apikey_and_http_oauth.bal
@@ -40,34 +40,34 @@ public isolated client class Client {
     # + headerX - Header X
     # + return - Expected response to a valid request
     remote isolated function getPetInfo(string petId, string headerX) returns Pet|error {
-        string path = string `/pets/management`;
+        string resourcePath = string `/pets/management`;
         map<any> headerValues = {"headerX": headerX};
         map<anydata> queryParam = {"petId": petId};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["api-key"] = self.apiKeyConfig?.apiKey;
             queryParam["api-key-2"] = self.apiKeyConfig?.apiKey2;
         }
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        Pet response = check self.clientEp->get(path, httpHeaders);
+        Pet response = check self.clientEp->get(resourcePath, httpHeaders);
         return response;
     }
     # Vote for a pet
     #
     # + return - Expected response to a valid request
     remote isolated function votePet() returns Pet|error {
-        string path = string `/pets/management`;
+        string resourcePath = string `/pets/management`;
         map<any> headerValues = {};
         map<anydata> queryParam = {};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["api-key"] = self.apiKeyConfig?.apiKey;
             queryParam["api-key-2"] = self.apiKeyConfig?.apiKey2;
         }
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
         http:Request request = new;
         //TODO: Update the request as needed;
-        Pet response = check self.clientEp->post(path, request, headers = httpHeaders);
+        Pet response = check self.clientEp->post(resourcePath, request, headers = httpHeaders);
         return response;
     }
     # Delete a pet
@@ -75,16 +75,16 @@ public isolated client class Client {
     # + petId - The id of the pet to delete
     # + return - Expected response to a valid request
     remote isolated function deletePetInfo(string petId) returns Pet|error {
-        string path = string `/pets/management`;
+        string resourcePath = string `/pets/management`;
         map<any> headerValues = {};
         map<anydata> queryParam = {"petId": petId};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["api-key"] = self.apiKeyConfig?.apiKey;
             queryParam["api-key-2"] = self.apiKeyConfig?.apiKey2;
         }
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        Pet response = check self.clientEp->delete(path, httpHeaders);
+        Pet response = check self.clientEp->delete(resourcePath, httpHeaders);
         return response;
     }
     # Delete a pet 2
@@ -92,16 +92,16 @@ public isolated client class Client {
     # + petId - The id of the pet to delete
     # + return - Expected response to a valid request
     remote isolated function deletePetInfo2(string petId) returns Pet|error {
-        string path = string `/pets/management2`;
+        string resourcePath = string `/pets/management2`;
         map<any> headerValues = {"petId": petId};
         map<anydata> queryParam = {};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["api-key"] = self.apiKeyConfig?.apiKey;
             queryParam["api-key-2"] = self.apiKeyConfig?.apiKey2;
         }
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        Pet response = check self.clientEp->delete(path, httpHeaders);
+        Pet response = check self.clientEp->delete(resourcePath, httpHeaders);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/deprecated_functions.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/deprecated_functions.bal
@@ -21,20 +21,20 @@ public isolated client class Client {
     # This methods has deprecated since the Pet has deprecated
     @deprecated
     remote isolated function listPets(int? 'limit = ()) returns Pets|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         map<anydata> queryParam = {"limit": 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        Pets response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Pets response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Create a pet
     #
     # + return - Null response
     remote isolated function createPet() returns http:Response|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> post(path, request);
+        http:Response response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Info for a specific pet
@@ -48,10 +48,10 @@ public isolated client class Client {
     # # Deprecated
     @deprecated
     remote isolated function showPetById(string petId, @deprecated string 'limit) returns Pets|error {
-        string  path = string `/pets/${petId}`;
+        string resourcePath = string `/pets/${petId}`;
         map<anydata> queryParam = {"limit": 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        Pets response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Pets response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/deprecated_mix_params.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/deprecated_mix_params.bal
@@ -27,10 +27,10 @@ public isolated client class Client {
     # + offset -
     # + return - Success
     remote isolated function getCommentsOnTrack(int trackId, int 'limit = 50, @deprecated int offset = 0, boolean? linkedPartitioning = ()) returns InlineResponse200|error {
-        string path = string `/tracks/${trackId}/comments`;
+        string resourcePath = string `/tracks/${trackId}/comments`;
         map<anydata> queryParam = {"limit": 'limit, "offset": offset, "linked_partitioning": linkedPartitioning};
-        path = path + check getPathForQueryParam(queryParam);
-        InlineResponse200 response = check self.clientEp->get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        InlineResponse200 response = check self.clientEp->get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/display_and_deprecated.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/display_and_deprecated.bal
@@ -22,20 +22,20 @@ public isolated client class Client {
     @display {label: "List Pets"}
     @deprecated
     remote isolated function listPets(int? 'limit = ()) returns Pets|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         map<anydata> queryParam = {"limit": 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        Pets response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Pets response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Create a pet
     #
     # + return - Null response
     remote isolated function createPet() returns http:Response|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> post(path, request);
+        http:Response response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Info for a specific pet
@@ -49,10 +49,10 @@ public isolated client class Client {
     # # Deprecated
     @deprecated
     remote isolated function showPetById(string petId, @display {label: "Result limit"} @deprecated string 'limit) returns Pets|error {
-        string  path = string `/pets/${petId}`;
+        string resourcePath = string `/pets/${petId}`;
         map<anydata> queryParam = {"limit": 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        Pets response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Pets response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_optional.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_optional.bal
@@ -34,12 +34,12 @@ public isolated client class Client {
     # + return - Successful response
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string? exclude = (), @display {label: "Units"} int? units = (), @display {label: "ID List"} int[]? idList = (), @display {label: "Location List"} Location[]? locationList = ()) returns WeatherForecast|error {
-        string  path = string `/onecall`;
+        string resourcePath = string `/onecall`;
         map<anydata> queryParam = {"lat": lat, "lon": lon, "appid": self.apiKeyConfig.appid};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         map<any> headerValues = {"exclude": exclude, "units": units, "idList": idList, "locationList": locationList};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        WeatherForecast response = check self.clientEp-> get(path, httpHeaders);
+        WeatherForecast response = check self.clientEp-> get(resourcePath, httpHeaders);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_param_with_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_param_with_default_value.bal
@@ -32,12 +32,12 @@ public isolated client class Client {
     # + return - Successful response
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string exclude = "current", @display {label: "Units"} int units = 12) returns WeatherForecast|error {
-        string  path = string `/onecall`;
+        string resourcePath = string `/onecall`;
         map<anydata> queryParam = {"lat": lat, "lon": lon, "appid": self.apiKeyConfig.appid};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         map<any> headerValues = {"exclude": exclude, "units": units};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        WeatherForecast response = check self.clientEp-> get(path, httpHeaders);
+        WeatherForecast response = check self.clientEp-> get(resourcePath, httpHeaders);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_parameter.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_parameter.bal
@@ -27,10 +27,10 @@ public isolated client class Client {
     # + xRequestPet - Tests header 03
     # + return - Expected response to a valid request
     remote isolated function showPetById(string xRequestId, string[] xRequestClient, Pet[] xRequestPet) returns http:Response|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         map<any> headerValues = {"X-Request-ID": xRequestId, "X-Request-Client": xRequestClient, "X-Request-Pet": xRequestPet, "X-API-KEY": self.apiKeyConfig.xApiKey};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        http:Response response = check self.clientEp-> get(path, httpHeaders);
+        http:Response response = check self.clientEp-> get(resourcePath, httpHeaders);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/header_without_parameter.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/header_without_parameter.bal
@@ -24,10 +24,10 @@ public isolated client class Client {
     #
     # + return - Expected response to a valid request
     remote isolated function showPetById() returns http:Response|error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         map<any> headerValues = {"X-API-KEY": self.apiKeyConfig.xApiKey};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        http:Response response = check self.clientEp-> get(path, httpHeaders);
+        http:Response response = check self.clientEp-> get(resourcePath, httpHeaders);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/missing_server_url.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/missing_server_url.bal
@@ -24,10 +24,10 @@ public isolated client class Client {
     # + return - Successful response
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string? exclude = (), @display {label: "Units"} int? units = ()) returns WeatherForecast|error {
-        string  path = string `/onecall`;
+        string resourcePath = string `/onecall`;
         map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units};
-        path = path + check getPathForQueryParam(queryParam);
-        WeatherForecast response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        WeatherForecast response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata.bal
@@ -18,11 +18,11 @@ public isolated client class Client {
     # + payload - Pet
     # + return - Null response
     remote isolated function createPet(PetsBody payload) returns http:Response|error {
-        string path = string `/pets`;
+        string resourcePath = string `/pets`;
         http:Request request = new;
         mime:Entity[] bodyParts = check createBodyParts(payload);
         request.setBodyParts(bodyParts);
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/openapi_display_annotation.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/openapi_display_annotation.bal
@@ -36,10 +36,10 @@ public isolated client class Client {
     # + return - Successful response
     @display {label: "Current weather"}
     remote isolated function currentWeatherData(@display {label: "City name"} string? q = (), string? id = (), string? lat = (), string? lon = (), string? zip = (), string units = "imperial", string lang = "en", string mode = "json") returns CurrentWeatherDataResponse|error {
-        string  path = string `/weather`;
+        string resourcePath = string `/weather`;
         map<anydata> queryParam = {"q": q, "id": id, "lat": lat, "lon": lon, "zip": zip, "units": units, "lang": lang, "mode": mode, "appid": self.apiKeyConfig.appid};
-        path = path + check getPathForQueryParam(queryParam);
-        CurrentWeatherDataResponse response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        CurrentWeatherDataResponse response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/operation_get.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/operation_get.bal
@@ -15,45 +15,45 @@ public isolated client class Client {
         return;
     }
     remote isolated function  pet() returns http:Response | error {
-        string  path = string `/pet`;
-        http:Response  response = check self.clientEp->get(path );
+        string resourcePath = string `/pet`;
+        http:Response  response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function getPetId(string petId) returns http:Response | error {
-        string  path = string `/pets/${petId}`;
-        http:Response  response = check self.clientEp->get(path );
+        string resourcePath = string `/pets/${petId}`;
+        http:Response  response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function  ImageByimageId(int petId, string imageId) returns http:Response | error {
-        string  path = string `/pets/${petId}/Image/${imageId}`;
-        http:Response  response = check self.clientEp->get(path );
+        string resourcePath = string `/pets/${petId}/Image/${imageId}`;
+        http:Response  response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function  pets(int offset) returns http:Response | error {
-        string  path = string `/pets`;
+        string resourcePath = string `/pets`;
         map<anydata> queryParam = {offset: offset};
-        path = path + check getPathForQueryParam(queryParam);
-        http:Response  response = check self.clientEp->get(path );
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        http:Response  response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function  users(string[]? offset) returns http:Response | error {
-        string  path = string `/users`;
+        string resourcePath = string `/users`;
         map<anydata> queryParam = {offset: offset};
-        path = path + getPathForQueryParam(queryParam);
-        http:Response  response = check self.clientEp->get(path );
+        resourcePath = resourcePath + getPathForQueryParam(queryParam);
+        http:Response  response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function getImage(string? tag, int? 'limit) returns http:Response | error {
-        string  path = string `/image`;
+        string resourcePath = string `/image`;
         map<anydata> queryParam = {tag: tag, 'limit: 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        http:Response  response = check self.clientEp->get(path );
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        http:Response  response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function  header(string XClient) returns http:Response | error {
-        string  path = string `/header`;
+        string resourcePath = string `/header`;
         map<string|string[]> httpHeaders = {XClient: XClient};
-        http:Response  response = check self.clientEp->get(path, httpHeaders );
+        http:Response  response = check self.clientEp->get(resourcePath, httpHeaders);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/operation_id.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/operation_id.bal
@@ -13,33 +13,33 @@ public isolated client class Client {
         return;
     }
     remote isolated function  pet() returns http:Response | error {
-        string  path = string `/pet`;
-        http:Response  response = check self.clientEp-> get(path);
+        string resourcePath = string `/pet`;
+        http:Response  response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createPet(Pet payload) returns http:Response | error {
-        string  path = string `/pet`;
+        string resourcePath = string `/pet`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response  response = check self.clientEp->post(path, request);
+        http:Response  response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getpetsBypetId(string petId) returns Pet|error {
-        string  path = string `/pets/${petId}`;
-        Pet response = check self.clientEp-> get(path);
+        string resourcePath = string `/pets/${petId}`;
+        Pet response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function deletepetsBypetId(int petId) returns http:Response | error {
-        string  path = string `/pets/${petId}`;
+        string resourcePath = string `/pets/${petId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request);
+        http:Response  response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function  Image(int petId) returns http:Response | error {
-        string  path = string `/pets/${petId}/Image`;
-        http:Response  response = check self.clientEp-> get(path);
+        string resourcePath = string `/pets/${petId}/Image`;
+        http:Response  response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/operation_post.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/operation_post.bal
@@ -14,24 +14,24 @@ public isolated client class Client {
         return;
     }
     remote isolated function  pet(Pet payload) returns http:Response | error {
-        string  path = string `/pet`;
+        string resourcePath = string `/pet`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response  response = check self.clientEp->post(path, request);
+        http:Response  response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getPetId(string petId, string payload) returns http:Response | error {
-        string  path = string `/pets/${petId}`;
+        string resourcePath = string `/pets/${petId}`;
         http:Request request = new;
         request.setPayload(payload);
-        http:Response  response = check self.clientEp->post(path, request);
+        http:Response  response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function  ImageByimageId(int petId, string imageId) returns http:Response | error {
-        string  path = string `/pets/${petId}/Image/${imageId}`;
-        http:Response  response = check self.clientEp-> get(path );
+        string resourcePath = string `/pets/${petId}/Image/${imageId}`;
+        http:Response  response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_param_duplicated_name.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_param_duplicated_name.bal
@@ -17,8 +17,8 @@ public isolated client class Client {
     # + versionName - Version Name
     # + return - Ok
     remote isolated function operationId04(int 'version, string versionName) returns string|error {
-        string  path = string `/v1/${'version}/version-name/${versionName}`;
-        string response = check self.clientEp-> get(path);
+        string resourcePath = string `/v1/${'version}/version-name/${versionName}`;
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_param_with_ref_schema.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_param_with_ref_schema.bal
@@ -17,8 +17,8 @@ public isolated client class Client {
     # + id - id value
     # + return - Ok
     remote isolated function operationId03(Id id) returns string|error {
-        string  path = string `/v1/${id}`;
-        string response = check self.clientEp-> get(path);
+        string resourcePath = string `/v1/${id}`;
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_valid.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_valid.bal
@@ -17,17 +17,17 @@ public isolated client class Client {
     #
     # + return - Ok
     remote isolated function operationId01() returns string|error {
-        string  path = string `/`;
-        string response = check self.clientEp-> get(path);
+        string resourcePath = string `/`;
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
     #
     # + return - Ok
     remote isolated function operationId02() returns string|error {
-        string  path = string `/`;
+        string resourcePath = string `/`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        string response = check self.clientEp-> post(path, request);
+        string response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # op2
@@ -35,29 +35,29 @@ public isolated client class Client {
     # + id - id value
     # + return - Ok
     remote isolated function operationId03(int id) returns string|error {
-        string  path = string `/v1/${id}`;
-        string response = check self.clientEp-> get(path);
+        string resourcePath = string `/v1/${id}`;
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
     #
     # + return - Ok
     remote isolated function operationId04(int 'version, string name) returns string|error {
-        string  path = string `/v1/${'version}/v2/${name}`;
-        string response = check self.clientEp-> get(path);
+        string resourcePath = string `/v1/${'version}/v2/${name}`;
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
     #
     # + return - Ok
     remote isolated function operationId05(int 'version, int 'limit) returns string|error {
-        string  path = string `/v1/${'version}/v2/${'limit}`;
-        string response = check self.clientEp-> get(path);
+        string resourcePath = string `/v1/${'version}/v2/${'limit}`;
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
     #
     # + return - Ok
     remote isolated function operationId06(int age, string name) returns string|error {
-        string  path = string `/v1/${age}/v2/${name}`;
-        string response = check self.clientEp-> get(path);
+        string resourcePath = string `/v1/${age}/v2/${name}`;
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_with_special_name.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_with_special_name.bal
@@ -17,8 +17,8 @@ public isolated client class Client {
     # + versionName - Version Name
     # + return - Ok
     remote isolated function operationId04(int 'version, string versionName) returns string|error {
-        string  path = string `/v1/${'version}/v2/${versionName}`;
-        string response = check self.clientEp-> get(path);
+        string resourcePath = string `/v1/${'version}/v2/${versionName}`;
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
     #
@@ -26,8 +26,8 @@ public isolated client class Client {
     # + versionLimit - Version Limit
     # + return - Ok
     remote isolated function operationId05(int versionId, int versionLimit) returns string|error {
-        string  path = string `/v1/${versionId}/v2/${versionLimit}`;
-        string response = check self.clientEp-> get(path);
+        string resourcePath = string `/v1/${versionId}/v2/${versionLimit}`;
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_default_value.bal
@@ -32,10 +32,10 @@ public isolated client class Client {
     # + return - Successful response
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string exclude = "current", @display {label: "Units"} int units = 12) returns WeatherForecast|error {
-        string  path = string `/onecall`;
+        string resourcePath = string `/onecall`;
         map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, "appid": self.apiKeyConfig.appid};
-        path = path + check getPathForQueryParam(queryParam);
-        WeatherForecast response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        WeatherForecast response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_ref_schema.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_with_ref_schema.bal
@@ -32,10 +32,10 @@ public isolated client class Client {
     # + return - Successful response
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} Latitude lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string exclude = "current", @display {label: "Units"} int units = 12) returns json|error {
-        string  path = string `/onecall`;
+        string resourcePath = string `/onecall`;
         map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, "appid": self.apiKeyConfig.appid};
-        path = path + check getPathForQueryParam(queryParam);
-        json response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        json response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/query_param_without_default_value.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/query_param_without_default_value.bal
@@ -32,10 +32,10 @@ public isolated client class Client {
     # + return - Successful response
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string? exclude = (), @display {label: "Units"} int? units = ()) returns WeatherForecast|error {
-        string  path = string `/onecall`;
+        string resourcePath = string `/onecall`;
         map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, "appid": self.apiKeyConfig.appid};
-        path = path + check getPathForQueryParam(queryParam);
-        WeatherForecast response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        WeatherForecast response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_allOf_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_allOf_scenarios.bal
@@ -18,35 +18,35 @@ public isolated client class Client {
     #
     # + return - OK
     remote isolated function updateXMLUser(Path01Body payload) returns http:Response|error {
-        string path = string `/path01`;
+        string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->put(path, request);
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Request Body has nested allOf.
     #
     # + return - OK
     remote isolated function postXMLUser(Path01Body1 payload) returns http:Response|error {
-        string path = string `/path01`;
+        string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Request Body has Array type AllOf.
     #
     # + return - OK
     remote isolated function postXMLUserInLineArray(CompoundArrayItemPostXMLUserInLineArrayRequest payload) returns http:Response|error {
-        string path = string `/path02`;
+        string resourcePath = string `/path02`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_array.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_array.bal
@@ -17,11 +17,11 @@ public isolated client class Client {
     #
     # + return - OK
     remote isolated function updateUser(string[] payload) returns http:Response|error {
-        string path = string `/path01`;
+        string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(path, request);
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_basic_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_basic_scenarios.bal
@@ -18,22 +18,22 @@ public isolated client class Client {
     #
     # + return - OK
     remote isolated function updateUser(Path01Body payload) returns http:Response|error {
-        string  path = string `/path01`;
+        string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(path, request);
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # 01 Request body with reference.
     #
     # + return - OK
     remote isolated function postUser(User payload) returns http:Response|error {
-        string  path = string `/path01`;
+        string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # 04 Example for rb has inline requestbody.
@@ -41,58 +41,58 @@ public isolated client class Client {
     # + payload - A JSON object containing pet information
     # + return - OK
     remote isolated function updateNewUser(User payload) returns http:Response|error {
-        string  path = string `/path02`;
+        string resourcePath = string `/path02`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(path, request);
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # 03 Request body with record reference.
     #
     # + return - OK
     remote isolated function postNewUser(User[] payload) returns http:Response|error {
-        string  path = string `/path02`;
+        string resourcePath = string `/path02`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # 06 Example for rb has array inline requestbody.
     #
     # + return - OK
     remote isolated function updateXMLUser(Path03Body payload) returns http:Response|error {
-        string  path = string `/path03`;
+        string resourcePath = string `/path03`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->put(path, request);
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # 05 Example for rb has array inline requestbody.
     #
     # + return - OK
     remote isolated function postXMLUser(Path03Body1 payload) returns http:Response|error {
-        string  path = string `/path03`;
+        string resourcePath = string `/path03`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # 07 Example for rb has array inline requestbody.
     #
     # + return - OK
     remote isolated function postXMLUserInLineArray(Path04Body[] payload) returns http:Response|error {
-        string  path = string `/path04`;
+        string resourcePath = string `/path04`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_empty_array.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_empty_array.bal
@@ -17,11 +17,11 @@ public isolated client class Client {
     #
     # + return - OK
     remote isolated function updateUser(json[] payload) returns http:Response|error {
-        string path = string `/path01`;
+        string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(path, request);
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_oneOf_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_oneOf_scenarios.bal
@@ -18,11 +18,11 @@ public isolated client class Client {
     # + payload - A JSON object containing pet information
     # + return - OK
     remote isolated function postXMLUser(Path01Body payload) returns http:Response|error {
-        string  path = string `/path01`;
+        string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/salesforce.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/salesforce.bal
@@ -15,51 +15,51 @@ public isolated client class Client {
         return;
     }
     remote isolated function products(decimal latitude, decimal longitude) returns ProductArr|error {
-        string path = string `/products`;
+        string resourcePath = string `/products`;
         map<anydata> queryParam = {
             latitude: latitude,
             longitude: longitude
         };
-        path = path + check getPathForQueryParam(queryParam);
-        ProductArr response = check self.clientEp->get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ProductArr response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function price(decimal start_latitude, decimal start_longitude, decimal end_latitude,
                                    decimal end_longitude) returns PriceEstimateArr|error {
-        string path = string `/estimates/price`;
+        string resourcePath = string `/estimates/price`;
         map<anydata> queryParam = {
             start_latitude: start_latitude,
             start_longitude: start_longitude,
             end_latitude: end_latitude,
             end_longitude: end_longitude
         };
-        path = path + check getPathForQueryParam(queryParam);
-        PriceEstimateArr response = check self.clientEp->get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PriceEstimateArr response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function time(decimal start_latitude, decimal start_longitude, string? customer_uuid,
                                   string? product_id) returns ProductArr|error {
-        string path = string `/estimates/time`;
+        string resourcePath = string `/estimates/time`;
         map<anydata> queryParam = {
             start_latitude: start_latitude,
             start_longitude: start_longitude,
             customer_uuid: customer_uuid,
             product_id: product_id
         };
-        path = path + check getPathForQueryParam(queryParam);
-        ProductArr response = check self.clientEp->get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ProductArr response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function me() returns Profile|error {
-        string path = string `/me`;
-        Profile response = check self.clientEp->get(path);
+        string resourcePath = string `/me`;
+        Profile response = check self.clientEp->get(resourcePath);
         return response;
     }
     remote isolated function history(int? offset, int? 'limit) returns Activities|error {
-        string path = string `/history`;
+        string resourcePath = string `/history`;
         map<anydata> queryParam = {offset: offset, 'limit: 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        Activities response = check self.clientEp->get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Activities response = check self.clientEp->get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/url_encoded_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/url_encoded_payload.bal
@@ -18,8 +18,8 @@ public isolated client class Client {
     # + paymentMethod - Payment Method
     # + return - Successful response.
     remote isolated function getPaymentMethodsPaymentMethod(string paymentMethod) returns json|error {
-        string path = string `/v1/payment_methods/${paymentMethod}`;
-        json response = check self.clientEp->get(path);
+        string resourcePath = string `/v1/payment_methods/${paymentMethod}`;
+        json response = check self.clientEp->get(resourcePath);
         return response;
     }
     # <p>Creates a new customer object.</p>
@@ -28,11 +28,11 @@ public isolated client class Client {
     # + payload - Customer Details
     # + return - Successful response.
     remote isolated function postCustomers(string customer, CustomerCustomerBody payload) returns Customer|error {
-        string path = string `/v1/customer/${customer}`;
+        string resourcePath = string `/v1/customer/${customer}`;
         http:Request request = new;
         string encodedRequestBody = createFormURLEncodedRequestBody(payload);
         request.setPayload(encodedRequestBody, "application/x-www-form-urlencoded");
-        Customer response = check self.clientEp->post(path, request);
+        Customer response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/vendor_specific_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/vendor_specific_payload.bal
@@ -16,10 +16,10 @@ public isolated client class Client {
     #
     # + return - Null response
     remote isolated function createPet(byte[] payload) returns http:Response|error {
-        string path = string `/pets`;
+        string resourcePath = string `/pets`;
         http:Request request = new;
         request.setPayload(payload, "application/vnd.ms-excel");
-        http:Response response = check self.clientEp->post(path, request);
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/api2pdf.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/api2pdf.bal
@@ -29,13 +29,13 @@ public isolated client class Client {
     # + payload - A JSON object as a payload is required within the body of the request. The following attributes of the JSON object are detailed below:
     # + return - A JSON object containing the url to the PDF and other meta data
     remote isolated function chromeFromHtmlPost(ChromeHtmlToPdfRequest payload) returns ApiResponseSuccess|error {
-        string  path = string `/chrome/html`;
+        string resourcePath = string `/chrome/html`;
         map<any> headerValues = {"Authorization": self.apiKeyConfig.authorization};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ApiResponseSuccess response = check self.clientEp->post(path, request, headers = httpHeaders);
+        ApiResponseSuccess response = check self.clientEp->post(resourcePath, request, headers = httpHeaders);
         return response;
     }
     # Convert URL to PDF
@@ -44,10 +44,10 @@ public isolated client class Client {
     # + output - Specify output=json to receive a JSON output. Defaults to PDF file.
     # + return - A PDF file or a JSON object depending on the `output` query parameter
     remote isolated function chromeFromUrlGET(string url, string? output = ()) returns ApiResponseSuccess|error {
-        string  path = string `/chrome/url`;
+        string resourcePath = string `/chrome/url`;
         map<anydata> queryParam = {"url": url, "output": output, "apikey": self.apiKeyConfig.apikey};
-        path = path + check getPathForQueryParam(queryParam);
-        ApiResponseSuccess response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ApiResponseSuccess response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Convert URL to PDF
@@ -55,13 +55,13 @@ public isolated client class Client {
     # + payload - A JSON object as a payload is required within the body of the request. The following attributes of the JSON object are detailed below:
     # + return - A JSON object containing the url to the PDF and other meta data
     remote isolated function chromeFromUrlPost(ChromeUrlToPdfRequest payload) returns ApiResponseSuccess|error {
-        string  path = string `/chrome/url`;
+        string resourcePath = string `/chrome/url`;
         map<any> headerValues = {"Authorization": self.apiKeyConfig.authorization};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ApiResponseSuccess response = check self.clientEp->post(path, request, headers = httpHeaders);
+        ApiResponseSuccess response = check self.clientEp->post(resourcePath, request, headers = httpHeaders);
         return response;
     }
     # Convert office document or image to PDF
@@ -69,13 +69,13 @@ public isolated client class Client {
     # + payload - A JSON object as a payload is required within the body of the request. The following attributes of the JSON object are detailed below:
     # + return - A JSON object containing the url to the PDF and other meta data
     remote isolated function libreConvertPost(LibreOfficeConvertRequest payload) returns ApiResponseSuccess|error {
-        string  path = string `/libreoffice/convert`;
+        string resourcePath = string `/libreoffice/convert`;
         map<any> headerValues = {"Authorization": self.apiKeyConfig.authorization};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ApiResponseSuccess response = check self.clientEp->post(path, request, headers = httpHeaders);
+        ApiResponseSuccess response = check self.clientEp->post(resourcePath, request, headers = httpHeaders);
         return response;
     }
     # Merge multiple PDFs together
@@ -83,13 +83,13 @@ public isolated client class Client {
     # + payload - A JSON object as a payload is required within the body of the request. The following attributes of the JSON object are detailed below:
     # + return - A JSON object containing the url to the PDF and other meta data
     remote isolated function mergePost(MergeRequest payload) returns ApiResponseSuccess|error {
-        string  path = string `/merge`;
+        string resourcePath = string `/merge`;
         map<any> headerValues = {"Authorization": self.apiKeyConfig.authorization};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ApiResponseSuccess response = check self.clientEp->post(path, request, headers = httpHeaders);
+        ApiResponseSuccess response = check self.clientEp->post(resourcePath, request, headers = httpHeaders);
         return response;
     }
     # Convert raw HTML to PDF
@@ -97,13 +97,13 @@ public isolated client class Client {
     # + payload - A JSON object as a payload is required within the body of the request. The following attributes of the JSON object are detailed below:
     # + return - A JSON object containing the url to the PDF and other meta data
     remote isolated function wkhtmltopdfFromHtmlPost(WkHtmlToPdfHtmlToPdfRequest payload) returns ApiResponseSuccess|error {
-        string  path = string `/wkhtmltopdf/html`;
+        string resourcePath = string `/wkhtmltopdf/html`;
         map<any> headerValues = {"Authorization": self.apiKeyConfig.authorization};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ApiResponseSuccess response = check self.clientEp->post(path, request, headers = httpHeaders);
+        ApiResponseSuccess response = check self.clientEp->post(resourcePath, request, headers = httpHeaders);
         return response;
     }
     # Convert URL to PDF
@@ -112,10 +112,10 @@ public isolated client class Client {
     # + output - Specify output=json to receive a JSON output. Defaults to PDF file.
     # + return - A PDF file or a JSON object depending on the `output` query parameter
     remote isolated function wkhtmltopdfFromUrlGET(string url, string? output = ()) returns ApiResponseSuccess|error {
-        string  path = string `/wkhtmltopdf/url`;
+        string resourcePath = string `/wkhtmltopdf/url`;
         map<anydata> queryParam = {"url": url, "output": output, "apikey": self.apiKeyConfig.apikey};
-        path = path + check getPathForQueryParam(queryParam);
-        ApiResponseSuccess response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ApiResponseSuccess response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Convert URL to PDF
@@ -123,13 +123,13 @@ public isolated client class Client {
     # + payload - A JSON object as a payload is required within the body of the request. The following attributes of the JSON object are detailed below:
     # + return - A JSON object containing the url to the PDF and other meta data
     remote isolated function wkhtmltopdfFromUrlPost(WkHtmlToPdfUrlToPdfRequest payload) returns ApiResponseSuccess|error {
-        string  path = string `/wkhtmltopdf/url`;
+        string resourcePath = string `/wkhtmltopdf/url`;
         map<any> headerValues = {"Authorization": self.apiKeyConfig.authorization};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ApiResponseSuccess response = check self.clientEp->post(path, request, headers = httpHeaders);
+        ApiResponseSuccess response = check self.clientEp->post(resourcePath, request, headers = httpHeaders);
         return response;
     }
     # Generate bar codes and QR codes with ZXING.
@@ -141,10 +141,10 @@ public isolated client class Client {
     # + width - Width of the barcode generated image
     # + return - An image of the generated barcode or QR code
     remote isolated function zebraGET(string format, string value, boolean? showlabel = (), int? height = (), int? width = ()) returns string|error {
-        string  path = string `/zebra`;
+        string resourcePath = string `/zebra`;
         map<anydata> queryParam = {"format": format, "value": value, "showlabel": showlabel, "height": height, "width": width, "apikey": self.apiKeyConfig.apikey};
-        path = path + check getPathForQueryParam(queryParam);
-        string response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/bitbucket.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/bitbucket.bal
@@ -28,10 +28,10 @@ public isolated client class Client {
     # + longitude - Longitude component of location.
     # + return - An array of products
     remote isolated function  products(float latitude, float longitude) returns ProductArr|error {
-        string  path = string `/products`;
+        string resourcePath = string `/products`;
         map<anydata> queryParam = {"latitude": latitude, "longitude": longitude, server_token: self.apiKeys["server_token"]};
-        path = path + check getPathForQueryParam(queryParam);
-        ProductArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ProductArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Price Estimates
@@ -42,10 +42,10 @@ public isolated client class Client {
     # + endLongitude - Longitude component of end location.
     # + return - An array of price estimates by product
     remote isolated function  price(float start_latitude, float start_longitude, float end_latitude, float end_longitude) returns PriceEstimateArr|error {
-        string  path = string `/estimates/price`;
+        string resourcePath = string `/estimates/price`;
         map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "end_latitude": endLatitude, "end_longitude": endLongitude, server_token: self.apiKeys["server_token"]};
-        path = path + check getPathForQueryParam(queryParam);
-        PriceEstimateArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PriceEstimateArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Time Estimates
@@ -56,20 +56,20 @@ public isolated client class Client {
     # + productId - Unique identifier representing a specific product for a given latitude & longitude.
     # + return - An array of products
     remote isolated function  time(float start_latitude, float start_longitude, string? customer_uuid = (), string? product_id = ()) returns ProductArr|error {
-        string  path = string `/estimates/time`;
+        string resourcePath = string `/estimates/time`;
         map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "customer_uuid": customerUuid, "product_id": productId, server_token: self.apiKeys["server_token"]};
-        path = path + check getPathForQueryParam(queryParam);
-        ProductArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ProductArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # User Profile
     #
     # + return - Profile information for a user
     remote isolated function  me() returns Profile|error {
-        string  path = string `/me`;
+        string resourcePath = string `/me`;
         map<anydata> queryParam = {server_token: self.apiKeys["server_token"]};
-        path = path + check getPathForQueryParam(queryParam);
-        Profile response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Profile response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # User Activity
@@ -78,10 +78,10 @@ public isolated client class Client {
     # + limit - Number of items to retrieve. Default is 5, maximum is 100.
     # + return - History information for the given user
     remote isolated function  history(int? offset = (), int? 'limit = ()) returns Activities|error {
-        string  path = string `/history`;
+        string resourcePath = string `/history`;
         map<anydata> queryParam = {"offset": offset, "limit": 'limit, server_token: self.apiKeys["server_token"]};
-        path = path + check getPathForQueryParam(queryParam);
-        Activities response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Activities response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/covid19_openapi.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/covid19_openapi.bal
@@ -21,16 +21,16 @@ public isolated client class Client {
     #
     # + return - A list of countries with all informtion included.
     remote isolated function getCovidinAllCountries() returns CountriesArr|error {
-        string  path = string `/api`;
-        CountriesArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/api`;
+        CountriesArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # List of all countries with COVID-19 cases
     #
     # + return - Default response with array of strings
     remote isolated function getCountryList() returns CountryInfoArr|error {
-        string  path = string `/api/v1/countries/list/`;
-        CountryInfoArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/api/v1/countries/list/`;
+        CountryInfoArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Returns information about country. Pass country name as a parameter. Country name is case insensitive. For example – https://api-cov19.now.sh/api/countries/netherlands
@@ -38,8 +38,8 @@ public isolated client class Client {
     # + country - String Name of the country to get
     # + return - A list of countries with all informtion included.
     remote isolated function getCountryByName(string country) returns Country|error {
-        string  path = string `/api/countries/${country}`;
-        Country response = check self.clientEp-> get(path);
+        string resourcePath = string `/api/countries/${country}`;
+        Country response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/display_annotation.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/display_annotation.bal
@@ -19,11 +19,11 @@ public isolated client class Client {
     # + payload - Pet object that needs to be added to the store
     # + return - Invalid ID supplied
     remote isolated function updatePet(Pet payload) returns http:Response|error {
-        string  path = string `/pet`;
+        string resourcePath = string `/pet`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(path, request);
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/jira_openapi.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/jira_openapi.bal
@@ -65,2979 +65,2979 @@ public isolated client class Client {
         return;
     }
     remote isolated function updateCustomFieldValue(string fieldIdOrKey, CustomFieldValueUpdateRequest payload) returns json|error {
-        string  path = string `/rest/api/2/app/field/${fieldIdOrKey}/value`;
+        string resourcePath = string `/rest/api/2/app/field/${fieldIdOrKey}/value`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getApplicationProperty(string? 'key, string? permissionLevel, string? keyFilter) returns ApplicationPropertyArr|error {
-        string  path = string `/rest/api/2/application-properties`;
+        string resourcePath = string `/rest/api/2/application-properties`;
         map<anydata> queryParam = {'key: 'key, permissionLevel: permissionLevel, keyFilter: keyFilter};
-        path = path + check check getPathForQueryParam(queryParam);
-        ApplicationPropertyArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check check getPathForQueryParam(queryParam);
+        ApplicationPropertyArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAdvancedSettings() returns ApplicationPropertyArr|error {
-        string  path = string `/rest/api/2/application-properties/advanced-settings`;
-        ApplicationPropertyArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/application-properties/advanced-settings`;
+        ApplicationPropertyArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setApplicationProperty(string id, SimpleApplicationPropertyBean payload) returns ApplicationProperty|error {
-        string  path = string `/rest/api/2/application-properties/${id}`;
+        string resourcePath = string `/rest/api/2/application-properties/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ApplicationProperty response = check self.clientEp->put(path, request);
+        ApplicationProperty response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getAllApplicationRoles() returns ApplicationRoleArr|error {
-        string  path = string `/rest/api/2/applicationrole`;
-        ApplicationRoleArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/applicationrole`;
+        ApplicationRoleArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getApplicationRole(string 'key) returns ApplicationRole|error {
-        string  path = string `/rest/api/2/applicationrole/${'key}`;
-        ApplicationRole response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/applicationrole/${'key}`;
+        ApplicationRole response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAttachmentMeta() returns AttachmentSettings|error {
-        string  path = string `/rest/api/2/attachment/meta`;
-        AttachmentSettings response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/attachment/meta`;
+        AttachmentSettings response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAttachment(string id) returns AttachmentMetadata|error {
-        string  path = string `/rest/api/2/attachment/${id}`;
-        AttachmentMetadata response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/attachment/${id}`;
+        AttachmentMetadata response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function removeAttachment(string id) returns http:Response | error {
-        string  path = string `/rest/api/2/attachment/${id}`;
+        string resourcePath = string `/rest/api/2/attachment/${id}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function expandAttachmentForHumans(string id) returns AttachmentArchiveMetadataReadable|error {
-        string  path = string `/rest/api/2/attachment/${id}/expand/human`;
-        AttachmentArchiveMetadataReadable response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/attachment/${id}/expand/human`;
+        AttachmentArchiveMetadataReadable response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function expandAttachmentForMachines(string id) returns AttachmentArchiveImpl|error {
-        string  path = string `/rest/api/2/attachment/${id}/expand/raw`;
-        AttachmentArchiveImpl response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/attachment/${id}/expand/raw`;
+        AttachmentArchiveImpl response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAuditRecords(int? offset, int? 'limit, string? filter, string? 'from, string? to) returns AuditRecords|error {
-        string  path = string `/rest/api/2/auditing/record`;
+        string resourcePath = string `/rest/api/2/auditing/record`;
         map<anydata> queryParam = {offset: offset, 'limit: 'limit, filter: filter, 'from: 'from, to: to};
-        path = path + check check getPathForQueryParam(queryParam);
-        AuditRecords response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check check getPathForQueryParam(queryParam);
+        AuditRecords response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllSystemAvatars(string 'type) returns SystemAvatars|error {
-        string  path = string `/rest/api/2/avatar/${'type}/system`;
-        SystemAvatars response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/avatar/${'type}/system`;
+        SystemAvatars response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getCommentsByIds(string? expand, IssueCommentListRequestBean payload) returns PageBeanComment|error {
-        string  path = string `/rest/api/2/comment/list`;
+        string resourcePath = string `/rest/api/2/comment/list`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        PageBeanComment response = check self.clientEp->post(path, request);
+        PageBeanComment response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getCommentPropertyKeys(string commentId) returns PropertyKeys|error {
-        string  path = string `/rest/api/2/comment/${commentId}/properties`;
-        PropertyKeys response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/comment/${commentId}/properties`;
+        PropertyKeys response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getCommentProperty(string commentId, string propertyKey) returns EntityProperty|error {
-        string  path = string `/rest/api/2/comment/${commentId}/properties/${propertyKey}`;
-        EntityProperty response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/comment/${commentId}/properties/${propertyKey}`;
+        EntityProperty response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setCommentProperty(string commentId, string propertyKey, json payload) returns json|error {
-        string  path = string `/rest/api/2/comment/${commentId}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/comment/${commentId}/properties/${propertyKey}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteCommentProperty(string commentId, string propertyKey) returns http:Response | error {
-        string  path = string `/rest/api/2/comment/${commentId}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/comment/${commentId}/properties/${propertyKey}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function createComponent(Component payload) returns Component|error {
-        string  path = string `/rest/api/2/component`;
+        string resourcePath = string `/rest/api/2/component`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Component response = check self.clientEp->post(path, request);
+        Component response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getComponent(string id) returns Component|error {
-        string  path = string `/rest/api/2/component/${id}`;
-        Component response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/component/${id}`;
+        Component response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateComponent(string id, Component payload) returns Component|error {
-        string  path = string `/rest/api/2/component/${id}`;
+        string resourcePath = string `/rest/api/2/component/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Component response = check self.clientEp->put(path, request);
+        Component response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteComponent(string id, string? moveIssuesTo) returns http:Response | error {
-        string  path = string `/rest/api/2/component/${id}`;
+        string resourcePath = string `/rest/api/2/component/${id}`;
         map<anydata> queryParam = {moveIssuesTo: moveIssuesTo};
-        path = path + check check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getComponentRelatedIssues(string id) returns ComponentIssuesCount|error {
-        string  path = string `/rest/api/2/component/${id}/relatedIssueCounts`;
-        ComponentIssuesCount response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/component/${id}/relatedIssueCounts`;
+        ComponentIssuesCount response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getConfiguration() returns Configuration|error {
-        string  path = string `/rest/api/2/configuration`;
-        Configuration response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/configuration`;
+        Configuration response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getSelectedTimeTrackingImplementation() returns TimeTrackingProvider|error {
-        string  path = string `/rest/api/2/configuration/timetracking`;
-        TimeTrackingProvider response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/configuration/timetracking`;
+        TimeTrackingProvider response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function selectTimeTrackingImplementation(TimeTrackingProvider payload) returns json|error {
-        string  path = string `/rest/api/2/configuration/timetracking`;
+        string resourcePath = string `/rest/api/2/configuration/timetracking`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getAvailableTimeTrackingImplementations() returns TimeTrackingProviderArr|error {
-        string  path = string `/rest/api/2/configuration/timetracking/list`;
-        TimeTrackingProviderArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/configuration/timetracking/list`;
+        TimeTrackingProviderArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getSharedTimeTrackingConfiguration() returns TimeTrackingConfiguration|error {
-        string  path = string `/rest/api/2/configuration/timetracking/options`;
-        TimeTrackingConfiguration response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/configuration/timetracking/options`;
+        TimeTrackingConfiguration response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setSharedTimeTrackingConfiguration(TimeTrackingConfiguration payload) returns TimeTrackingConfiguration|error {
-        string  path = string `/rest/api/2/configuration/timetracking/options`;
+        string resourcePath = string `/rest/api/2/configuration/timetracking/options`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        TimeTrackingConfiguration response = check self.clientEp->put(path, request);
+        TimeTrackingConfiguration response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getOptionsForField(int fieldId, int? startAt, int? maxResults) returns PageBeanCustomFieldOptionDetails|error {
-        string  path = string `/rest/api/2/customField/${fieldId}/option`;
+        string resourcePath = string `/rest/api/2/customField/${fieldId}/option`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check check getPathForQueryParam(queryParam);
-        PageBeanCustomFieldOptionDetails response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check check getPathForQueryParam(queryParam);
+        PageBeanCustomFieldOptionDetails response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateCustomFieldOptions(int fieldId, UpdateCustomFieldOption payload) returns json|error {
-        string  path = string `/rest/api/2/customField/${fieldId}/option`;
+        string resourcePath = string `/rest/api/2/customField/${fieldId}/option`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function createCustomFieldOptions(int fieldId, BulkCreateCustomFieldOptionRequest payload) returns json|error {
-        string  path = string `/rest/api/2/customField/${fieldId}/option`;
+        string resourcePath = string `/rest/api/2/customField/${fieldId}/option`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->post(path, request);
+        json response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getCustomFieldOption(string id) returns CustomFieldOption|error {
-        string  path = string `/rest/api/2/customFieldOption/${id}`;
-        CustomFieldOption response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/customFieldOption/${id}`;
+        CustomFieldOption response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllDashboards(string? filter, int? startAt, int? maxResults) returns PageOfDashboards|error {
-        string  path = string `/rest/api/2/dashboard`;
+        string resourcePath = string `/rest/api/2/dashboard`;
         map<anydata> queryParam = {filter: filter, startAt: startAt, maxResults: maxResults};
-        path = path + check check getPathForQueryParam(queryParam);
-        PageOfDashboards response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check check getPathForQueryParam(queryParam);
+        PageOfDashboards response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createDashboard(DashboardDetails payload) returns Dashboard|error {
-        string  path = string `/rest/api/2/dashboard`;
+        string resourcePath = string `/rest/api/2/dashboard`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Dashboard response = check self.clientEp->post(path, request);
+        Dashboard response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getDashboardsPaginated(string? dashboardName, string? accountId, string? owner, string? groupname, int? projectId, string? orderBy, int? startAt, int? maxResults, string? expand) returns PageBeanDashboard|error {
-        string  path = string `/rest/api/2/dashboard/search`;
+        string resourcePath = string `/rest/api/2/dashboard/search`;
         map<anydata> queryParam = {dashboardName: dashboardName, accountId: accountId, owner: owner, groupname: groupname, projectId: projectId, orderBy: orderBy, startAt: startAt, maxResults: maxResults, expand: expand};
-        path = path + check check getPathForQueryParam(queryParam);
-        PageBeanDashboard response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check check getPathForQueryParam(queryParam);
+        PageBeanDashboard response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getDashboardItemPropertyKeys(string dashboardId, string itemId) returns PropertyKeys|error {
-        string  path = string `/rest/api/2/dashboard/${dashboardId}/items/${itemId}/properties`;
-        PropertyKeys response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/dashboard/${dashboardId}/items/${itemId}/properties`;
+        PropertyKeys response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getDashboardItemProperty(string dashboardId, string itemId, string propertyKey) returns EntityProperty|error {
-        string  path = string `/rest/api/2/dashboard/${dashboardId}/items/${itemId}/properties/${propertyKey}`;
-        EntityProperty response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/dashboard/${dashboardId}/items/${itemId}/properties/${propertyKey}`;
+        EntityProperty response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setDashboardItemProperty(string dashboardId, string itemId, string propertyKey, json payload) returns json|error {
-        string  path = string `/rest/api/2/dashboard/${dashboardId}/items/${itemId}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/dashboard/${dashboardId}/items/${itemId}/properties/${propertyKey}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteDashboardItemProperty(string dashboardId, string itemId, string propertyKey) returns http:Response | error {
-        string  path = string `/rest/api/2/dashboard/${dashboardId}/items/${itemId}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/dashboard/${dashboardId}/items/${itemId}/properties/${propertyKey}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getDashboard(string id) returns Dashboard|error {
-        string  path = string `/rest/api/2/dashboard/${id}`;
-        Dashboard response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/dashboard/${id}`;
+        Dashboard response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateDashboard(string id, DashboardDetails payload) returns Dashboard|error {
-        string  path = string `/rest/api/2/dashboard/${id}`;
+        string resourcePath = string `/rest/api/2/dashboard/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Dashboard response = check self.clientEp->put(path, request);
+        Dashboard response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteDashboard(string id) returns http:Response | error {
-        string  path = string `/rest/api/2/dashboard/${id}`;
+        string resourcePath = string `/rest/api/2/dashboard/${id}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function copyDashboard(string id, DashboardDetails payload) returns Dashboard|error {
-        string  path = string `/rest/api/2/dashboard/${id}/copy`;
+        string resourcePath = string `/rest/api/2/dashboard/${id}/copy`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Dashboard response = check self.clientEp->post(path, request);
+        Dashboard response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function analyseExpression(string? 'check, JiraExpressionForAnalysis payload) returns JiraExpressionsAnalysis|error {
-        string  path = string `/rest/api/2/expression/analyse`;
+        string resourcePath = string `/rest/api/2/expression/analyse`;
         map<anydata> queryParam = {'check: 'check};
-        path = path + check check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        JiraExpressionsAnalysis response = check self.clientEp->post(path, request);
+        JiraExpressionsAnalysis response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function evaluateJiraExpression(string? expand, JiraExpressionEvalRequestBean payload) returns JiraExpressionResult|error {
-        string  path = string `/rest/api/2/expression/eval`;
+        string resourcePath = string `/rest/api/2/expression/eval`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        JiraExpressionResult response = check self.clientEp->post(path, request);
+        JiraExpressionResult response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getFields() returns FieldDetailsArr|error {
-        string  path = string `/rest/api/2/field`;
-        FieldDetailsArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/field`;
+        FieldDetailsArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createCustomField(CustomFieldDefinitionJsonBean payload) returns FieldDetails|error {
-        string  path = string `/rest/api/2/field`;
+        string resourcePath = string `/rest/api/2/field`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        FieldDetails response = check self.clientEp->post(path, request);
+        FieldDetails response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getFieldsPaginated(int? startAt, int? maxResults, string[]? 'type, string[]? id, string? query, string? orderBy, string? expand) returns PageBeanField|error {
-        string  path = string `/rest/api/2/field/search`;
+        string resourcePath = string `/rest/api/2/field/search`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, 'type: 'type, id: id, query: query, orderBy: orderBy, expand: expand};
-        path = path + check check getPathForQueryParam(queryParam);
-        PageBeanField response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check check getPathForQueryParam(queryParam);
+        PageBeanField response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateCustomField(string fieldId, UpdateCustomFieldDetails payload) returns json|error {
-        string  path = string `/rest/api/2/field/${fieldId}`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getContextsForField(string fieldId, boolean? isAnyIssueType, boolean? isGlobalContext, int[]? contextId, int? startAt, int? maxResults) returns PageBeanCustomFieldContext|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context`;
         map<anydata> queryParam = {isAnyIssueType: isAnyIssueType, isGlobalContext: isGlobalContext, contextId: contextId, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanCustomFieldContext response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanCustomFieldContext response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createCustomFieldContext(string fieldId, CreateCustomFieldContext payload) returns CreateCustomFieldContext|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        CreateCustomFieldContext response = check self.clientEp->post(path, request);
+        CreateCustomFieldContext response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getDefaultValues(string fieldId, int[]? contextId, int? startAt, int? maxResults) returns PageBeanCustomFieldContextDefaultValue|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/defaultValue`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/defaultValue`;
         map<anydata> queryParam = {contextId: contextId, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanCustomFieldContextDefaultValue response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanCustomFieldContextDefaultValue response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setDefaultValues(string fieldId, CustomFieldContextDefaultValueUpdate payload) returns json|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/defaultValue`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/defaultValue`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getIssueTypeMappingsForContexts(string fieldId, int[]? contextId, int? startAt, int? maxResults) returns PageBeanIssueTypeToContextMapping|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/issuetypemapping`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/issuetypemapping`;
         map<anydata> queryParam = {contextId: contextId, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueTypeToContextMapping response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueTypeToContextMapping response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getCustomFieldContextsForProjectsAndIssueTypes(string fieldId, int? startAt, int? maxResults, ProjectIssueTypeMappings payload) returns PageBeanContextForProjectAndIssueType|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/mapping`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/mapping`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        PageBeanContextForProjectAndIssueType response = check self.clientEp->post(path, request);
+        PageBeanContextForProjectAndIssueType response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getProjectContextMapping(string fieldId, int[]? contextId, int? startAt, int? maxResults) returns PageBeanCustomFieldContextProjectMapping|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/projectmapping`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/projectmapping`;
         map<anydata> queryParam = {contextId: contextId, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanCustomFieldContextProjectMapping response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanCustomFieldContextProjectMapping response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateCustomFieldContext(string fieldId, int contextId, CustomFieldContextUpdateDetails payload) returns json|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteCustomFieldContext(string fieldId, int contextId) returns json|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> delete(path, request);
+        json response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function addIssueTypesToContext(string fieldId, int contextId, IssueTypeIds payload) returns json|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}/issuetype`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}/issuetype`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function removeIssueTypesFromContext(string fieldId, int contextId, IssueTypeIds payload) returns json|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}/issuetype/remove`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}/issuetype/remove`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->post(path, request);
+        json response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getOptionsForContext(string fieldId, int contextId, int? optionId, boolean? onlyOptions, int? startAt, int? maxResults) returns PageBeanCustomFieldContextOption|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}/option`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}/option`;
         map<anydata> queryParam = {optionId: optionId, onlyOptions: onlyOptions, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanCustomFieldContextOption response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanCustomFieldContextOption response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateCustomFieldOption(string fieldId, int contextId, BulkCustomFieldOptionUpdateRequest payload) returns CustomFieldUpdatedContextOptionsList|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}/option`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}/option`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        CustomFieldUpdatedContextOptionsList response = check self.clientEp->put(path, request);
+        CustomFieldUpdatedContextOptionsList response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function createCustomFieldOption(string fieldId, int contextId, BulkCustomFieldOptionCreateRequest payload) returns CustomFieldCreatedContextOptionsList|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}/option`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}/option`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        CustomFieldCreatedContextOptionsList response = check self.clientEp->post(path, request);
+        CustomFieldCreatedContextOptionsList response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function reorderCustomFieldOptions(string fieldId, int contextId, OrderOfCustomFieldOptions payload) returns json|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}/option/move`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}/option/move`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteCustomFieldOption(string fieldId, int contextId, int optionId) returns http:Response | error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}/option/${optionId}`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}/option/${optionId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request);
+        http:Response  response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function assignProjectsToCustomFieldContext(string fieldId, int contextId, ProjectIds payload) returns json|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}/project`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}/project`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function removeCustomFieldContextFromProjects(string fieldId, int contextId, ProjectIds payload) returns json|error {
-        string  path = string `/rest/api/2/field/${fieldId}/context/${contextId}/project/remove`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/context/${contextId}/project/remove`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->post(path, request);
+        json response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getContextsForFieldDeprecated(string fieldId, int? startAt, int? maxResults) returns PageBeanContext|error {
-        string  path = string `/rest/api/2/field/${fieldId}/contexts`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/contexts`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanContext response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanContext response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getScreensForField(string fieldId, int? startAt, int? maxResults, string? expand) returns PageBeanScreenWithTab|error {
-        string  path = string `/rest/api/2/field/${fieldId}/screens`;
+        string resourcePath = string `/rest/api/2/field/${fieldId}/screens`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanScreenWithTab response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanScreenWithTab response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllIssueFieldOptions(int? startAt, int? maxResults, string fieldKey) returns PageBeanIssueFieldOption|error {
-        string  path = string `/rest/api/2/field/${fieldKey}/option`;
+        string resourcePath = string `/rest/api/2/field/${fieldKey}/option`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueFieldOption response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueFieldOption response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createIssueFieldOption(string fieldKey, IssueFieldOptionCreateBean payload) returns IssueFieldOption|error {
-        string  path = string `/rest/api/2/field/${fieldKey}/option`;
+        string resourcePath = string `/rest/api/2/field/${fieldKey}/option`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        IssueFieldOption response = check self.clientEp->post(path, request);
+        IssueFieldOption response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getSelectableIssueFieldOptions(int? startAt, int? maxResults, int? projectId, string fieldKey) returns PageBeanIssueFieldOption|error {
-        string  path = string `/rest/api/2/field/${fieldKey}/option/suggestions/edit`;
+        string resourcePath = string `/rest/api/2/field/${fieldKey}/option/suggestions/edit`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, projectId: projectId};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueFieldOption response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueFieldOption response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getVisibleIssueFieldOptions(int? startAt, int? maxResults, int? projectId, string fieldKey) returns PageBeanIssueFieldOption|error {
-        string  path = string `/rest/api/2/field/${fieldKey}/option/suggestions/search`;
+        string resourcePath = string `/rest/api/2/field/${fieldKey}/option/suggestions/search`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, projectId: projectId};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueFieldOption response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueFieldOption response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getIssueFieldOption(string fieldKey, int optionId) returns IssueFieldOption|error {
-        string  path = string `/rest/api/2/field/${fieldKey}/option/${optionId}`;
-        IssueFieldOption response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/field/${fieldKey}/option/${optionId}`;
+        IssueFieldOption response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateIssueFieldOption(string fieldKey, int optionId, IssueFieldOption payload) returns IssueFieldOption|error {
-        string  path = string `/rest/api/2/field/${fieldKey}/option/${optionId}`;
+        string resourcePath = string `/rest/api/2/field/${fieldKey}/option/${optionId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        IssueFieldOption response = check self.clientEp->put(path, request);
+        IssueFieldOption response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteIssueFieldOption(string fieldKey, int optionId) returns json|error {
-        string  path = string `/rest/api/2/field/${fieldKey}/option/${optionId}`;
+        string resourcePath = string `/rest/api/2/field/${fieldKey}/option/${optionId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> delete(path, request);
+        json response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function replaceIssueFieldOption(int? replaceWith, string? jql, string fieldKey, int optionId) returns TaskProgressBeanRemoveOptionFromIssuesResult|error {
-        string  path = string `/rest/api/2/field/${fieldKey}/option/${optionId}/issue`;
+        string resourcePath = string `/rest/api/2/field/${fieldKey}/option/${optionId}/issue`;
         map<anydata> queryParam = {replaceWith: replaceWith, jql: jql};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        TaskProgressBeanRemoveOptionFromIssuesResult response = check self.clientEp-> delete(path, request);
+        TaskProgressBeanRemoveOptionFromIssuesResult response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function getAllFieldConfigurations(int? startAt, int? maxResults, int[]? id, boolean? isDefault, string? query) returns PageBeanFieldConfiguration|error {
-        string  path = string `/rest/api/2/fieldconfiguration`;
+        string resourcePath = string `/rest/api/2/fieldconfiguration`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, id: id, isDefault: isDefault, query: query};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanFieldConfiguration response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanFieldConfiguration response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getFieldConfigurationItems(int id, int? startAt, int? maxResults) returns PageBeanFieldConfigurationItem|error {
-        string  path = string `/rest/api/2/fieldconfiguration/${id}/fields`;
+        string resourcePath = string `/rest/api/2/fieldconfiguration/${id}/fields`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanFieldConfigurationItem response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanFieldConfigurationItem response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllFieldConfigurationSchemes(int? startAt, int? maxResults, int[]? id) returns PageBeanFieldConfigurationScheme|error {
-        string  path = string `/rest/api/2/fieldconfigurationscheme`;
+        string resourcePath = string `/rest/api/2/fieldconfigurationscheme`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, id: id};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanFieldConfigurationScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanFieldConfigurationScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getFieldConfigurationSchemeMappings(int? startAt, int? maxResults, int[]? fieldConfigurationSchemeId) returns PageBeanFieldConfigurationIssueTypeItem|error {
-        string  path = string `/rest/api/2/fieldconfigurationscheme/mapping`;
+        string resourcePath = string `/rest/api/2/fieldconfigurationscheme/mapping`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, fieldConfigurationSchemeId: fieldConfigurationSchemeId};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanFieldConfigurationIssueTypeItem response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanFieldConfigurationIssueTypeItem response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getFieldConfigurationSchemeProjectMapping(int? startAt, int? maxResults, int[] projectId) returns PageBeanFieldConfigurationSchemeProjects|error {
-        string  path = string `/rest/api/2/fieldconfigurationscheme/project`;
+        string resourcePath = string `/rest/api/2/fieldconfigurationscheme/project`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, projectId: projectId};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanFieldConfigurationSchemeProjects response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanFieldConfigurationSchemeProjects response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function assignFieldConfigurationSchemeToProject(FieldConfigurationSchemeProjectAssociation payload) returns json|error {
-        string  path = string `/rest/api/2/fieldconfigurationscheme/project`;
+        string resourcePath = string `/rest/api/2/fieldconfigurationscheme/project`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getFilters(string? expand) returns FilterArr|error {
-        string  path = string `/rest/api/2/filter`;
+        string resourcePath = string `/rest/api/2/filter`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        FilterArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        FilterArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createFilter(string? expand, Filter payload) returns Filter|error {
-        string  path = string `/rest/api/2/filter`;
+        string resourcePath = string `/rest/api/2/filter`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Filter response = check self.clientEp->post(path, request);
+        Filter response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getDefaultShareScope() returns DefaultShareScope|error {
-        string  path = string `/rest/api/2/filter/defaultShareScope`;
-        DefaultShareScope response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/filter/defaultShareScope`;
+        DefaultShareScope response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setDefaultShareScope(DefaultShareScope payload) returns DefaultShareScope|error {
-        string  path = string `/rest/api/2/filter/defaultShareScope`;
+        string resourcePath = string `/rest/api/2/filter/defaultShareScope`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        DefaultShareScope response = check self.clientEp->put(path, request);
+        DefaultShareScope response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getFavouriteFilters(string? expand) returns FilterArr|error {
-        string  path = string `/rest/api/2/filter/favourite`;
+        string resourcePath = string `/rest/api/2/filter/favourite`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        FilterArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        FilterArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getMyFilters(string? expand, boolean? includeFavourites) returns FilterArr|error {
-        string  path = string `/rest/api/2/filter/my`;
+        string resourcePath = string `/rest/api/2/filter/my`;
         map<anydata> queryParam = {expand: expand, includeFavourites: includeFavourites};
-        path = path + check getPathForQueryParam(queryParam);
-        FilterArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        FilterArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getFiltersPaginated(string? filterName, string? accountId, string? owner, string? groupname, int? projectId, int[]? id, string? orderBy, int? startAt, int? maxResults, string? expand) returns PageBeanFilterDetails|error {
-        string  path = string `/rest/api/2/filter/search`;
+        string resourcePath = string `/rest/api/2/filter/search`;
         map<anydata> queryParam = {filterName: filterName, accountId: accountId, owner: owner, groupname: groupname, projectId: projectId, id: id, orderBy: orderBy, startAt: startAt, maxResults: maxResults, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanFilterDetails response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanFilterDetails response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getFilter(int id, string? expand) returns Filter|error {
-        string  path = string `/rest/api/2/filter/${id}`;
+        string resourcePath = string `/rest/api/2/filter/${id}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        Filter response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Filter response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateFilter(int id, string? expand, Filter payload) returns Filter|error {
-        string  path = string `/rest/api/2/filter/${id}`;
+        string resourcePath = string `/rest/api/2/filter/${id}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Filter response = check self.clientEp->put(path, request);
+        Filter response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteFilter(int id) returns http:Response | error {
-        string  path = string `/rest/api/2/filter/${id}`;
+        string resourcePath = string `/rest/api/2/filter/${id}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getColumns(int id) returns ColumnItemArr|error {
-        string  path = string `/rest/api/2/filter/${id}/columns`;
-        ColumnItemArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/filter/${id}/columns`;
+        ColumnItemArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setColumns(int id, [] payload) returns json|error {
-        string  path = string `/rest/api/2/filter/${id}/columns`;
+        string resourcePath = string `/rest/api/2/filter/${id}/columns`;
         http:Request request = new;
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function resetColumns(int id) returns http:Response | error {
-        string  path = string `/rest/api/2/filter/${id}/columns`;
+        string resourcePath = string `/rest/api/2/filter/${id}/columns`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function setFavouriteForFilter(int id, string? expand) returns Filter|error {
-        string  path = string `/rest/api/2/filter/${id}/favourite`;
+        string resourcePath = string `/rest/api/2/filter/${id}/favourite`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        Filter response = check self.clientEp-> put(path, request);
+        Filter response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     remote isolated function deleteFavouriteForFilter(int id, string? expand) returns Filter|error {
-        string  path = string `/rest/api/2/filter/${id}/favourite`;
+        string resourcePath = string `/rest/api/2/filter/${id}/favourite`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        Filter response = check self.clientEp-> delete(path, request);
+        Filter response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function getSharePermissions(int id) returns SharePermissionArr|error {
-        string  path = string `/rest/api/2/filter/${id}/permission`;
-        SharePermissionArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/filter/${id}/permission`;
+        SharePermissionArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function addSharePermission(int id, SharePermissionInputBean payload) returns SharePermissionArr|error {
-        string  path = string `/rest/api/2/filter/${id}/permission`;
+        string resourcePath = string `/rest/api/2/filter/${id}/permission`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        SharePermissionArr response = check self.clientEp->post(path, request);
+        SharePermissionArr response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getSharePermission(int id, int permissionId) returns SharePermission|error {
-        string  path = string `/rest/api/2/filter/${id}/permission/${permissionId}`;
-        SharePermission response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/filter/${id}/permission/${permissionId}`;
+        SharePermission response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function deleteSharePermission(int id, int permissionId) returns http:Response | error {
-        string  path = string `/rest/api/2/filter/${id}/permission/${permissionId}`;
+        string resourcePath = string `/rest/api/2/filter/${id}/permission/${permissionId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getGroup(string groupname, string? expand) returns Group|error {
-        string  path = string `/rest/api/2/group`;
+        string resourcePath = string `/rest/api/2/group`;
         map<anydata> queryParam = {groupname: groupname, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        Group response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Group response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createGroup(AddGroupBean payload) returns Group|error {
-        string  path = string `/rest/api/2/group`;
+        string resourcePath = string `/rest/api/2/group`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Group response = check self.clientEp->post(path, request);
+        Group response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function removeGroup(string groupname, string? swapGroup) returns http:Response | error {
-        string  path = string `/rest/api/2/group`;
+        string resourcePath = string `/rest/api/2/group`;
         map<anydata> queryParam = {groupname: groupname, swapGroup: swapGroup};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function bulkGetGroups(int? startAt, int? maxResults, string[]? groupId, string[]? groupName) returns PageBeanGroupDetails|error {
-        string  path = string `/rest/api/2/group/bulk`;
+        string resourcePath = string `/rest/api/2/group/bulk`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, groupId: groupId, groupName: groupName};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanGroupDetails response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanGroupDetails response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getUsersFromGroup(string groupname, boolean? includeInactiveUsers, int? startAt, int? maxResults) returns PageBeanUserDetails|error {
-        string  path = string `/rest/api/2/group/member`;
+        string resourcePath = string `/rest/api/2/group/member`;
         map<anydata> queryParam = {groupname: groupname, includeInactiveUsers: includeInactiveUsers, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanUserDetails response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanUserDetails response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function addUserToGroup(string groupname, UpdateUserToGroupBean payload) returns Group|error {
-        string  path = string `/rest/api/2/group/user`;
+        string resourcePath = string `/rest/api/2/group/user`;
         map<anydata> queryParam = {groupname: groupname};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Group response = check self.clientEp->post(path, request);
+        Group response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function removeUserFromGroup(string groupname, string? username, string accountId) returns http:Response | error {
-        string  path = string `/rest/api/2/group/user`;
+        string resourcePath = string `/rest/api/2/group/user`;
         map<anydata> queryParam = {groupname: groupname, username: username, accountId: accountId};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function findGroups(string? accountId, string? query, string[]? exclude, int? maxResults, string? userName) returns FoundGroups|error {
-        string  path = string `/rest/api/2/groups/picker`;
+        string resourcePath = string `/rest/api/2/groups/picker`;
         map<anydata> queryParam = {accountId: accountId, query: query, exclude: exclude, maxResults: maxResults, userName: userName};
-        path = path + check getPathForQueryParam(queryParam);
-        FoundGroups response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        FoundGroups response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function findUsersAndGroups(string query, int? maxResults, boolean? showAvatar, string? fieldId, string[]? projectId, string[]? issueTypeId, string? avatarSize, boolean? caseInsensitive, boolean? excludeConnectAddons) returns FoundUsersAndGroups|error {
-        string  path = string `/rest/api/2/groupuserpicker`;
+        string resourcePath = string `/rest/api/2/groupuserpicker`;
         map<anydata> queryParam = {query: query, maxResults: maxResults, showAvatar: showAvatar, fieldId: fieldId, projectId: projectId, issueTypeId: issueTypeId, avatarSize: avatarSize, caseInsensitive: caseInsensitive, excludeConnectAddons: excludeConnectAddons};
-        path = path + check getPathForQueryParam(queryParam);
-        FoundUsersAndGroups response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        FoundUsersAndGroups response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getLicense() returns License|error {
-        string  path = string `/rest/api/2/instance/license`;
-        License response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/instance/license`;
+        License response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createIssue(boolean? updateHistory, IssueUpdateDetails payload) returns CreatedIssue|error {
-        string  path = string `/rest/api/2/issue`;
+        string resourcePath = string `/rest/api/2/issue`;
         map<anydata> queryParam = {updateHistory: updateHistory};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        CreatedIssue response = check self.clientEp->post(path, request);
+        CreatedIssue response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function createIssues(IssuesUpdateBean payload) returns CreatedIssues|error {
-        string  path = string `/rest/api/2/issue/bulk`;
+        string resourcePath = string `/rest/api/2/issue/bulk`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        CreatedIssues response = check self.clientEp->post(path, request);
+        CreatedIssues response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getCreateIssueMeta(string[]? projectIds, string[]? projectKeys, string[]? issuetypeIds, string[]? issuetypeNames, string? expand) returns IssueCreateMetadata|error {
-        string  path = string `/rest/api/2/issue/createmeta`;
+        string resourcePath = string `/rest/api/2/issue/createmeta`;
         map<anydata> queryParam = {projectIds: projectIds, projectKeys: projectKeys, issuetypeIds: issuetypeIds, issuetypeNames: issuetypeNames, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        IssueCreateMetadata response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        IssueCreateMetadata response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getIssuePickerResource(string? query, string? currentJQL, string? currentIssueKey, string? currentProjectId, boolean? showSubTasks, boolean? showSubTaskParent) returns IssuePickerSuggestions|error {
-        string  path = string `/rest/api/2/issue/picker`;
+        string resourcePath = string `/rest/api/2/issue/picker`;
         map<anydata> queryParam = {query: query, currentJQL: currentJQL, currentIssueKey: currentIssueKey, currentProjectId: currentProjectId, showSubTasks: showSubTasks, showSubTaskParent: showSubTaskParent};
-        path = path + check getPathForQueryParam(queryParam);
-        IssuePickerSuggestions response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        IssuePickerSuggestions response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function bulkSetIssuesProperties(IssueEntityProperties payload) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/properties`;
+        string resourcePath = string `/rest/api/2/issue/properties`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response  response = check self.clientEp->post(path, request);
+        http:Response  response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function bulkSetIssueProperty(string propertyKey, BulkIssuePropertyUpdateRequest payload) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/issue/properties/${propertyKey}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response  response = check self.clientEp->put(path, request);
+        http:Response  response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function bulkDeleteIssueProperty(string propertyKey) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/issue/properties/${propertyKey}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getIssue(string issueIdOrKey, string[]? fields, boolean? fieldsByKeys, string? expand, string[]? properties, boolean? updateHistory) returns IssueBean|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}`;
         map<anydata> queryParam = {fields: fields, fieldsByKeys: fieldsByKeys, expand: expand, properties: properties, updateHistory: updateHistory};
-        path = path + check getPathForQueryParam(queryParam);
-        IssueBean response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        IssueBean response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function editIssue(string issueIdOrKey, boolean? notifyUsers, boolean? overrideScreenSecurity, boolean? overrideEditableFlag, IssueUpdateDetails payload) returns json|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}`;
         map<anydata> queryParam = {notifyUsers: notifyUsers, overrideScreenSecurity: overrideScreenSecurity, overrideEditableFlag: overrideEditableFlag};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteIssue(string issueIdOrKey, string? deleteSubtasks) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}`;
         map<anydata> queryParam = {deleteSubtasks: deleteSubtasks};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function assignIssue(string issueIdOrKey, User payload) returns json|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/assignee`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/assignee`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function addAttachment(string issueIdOrKey, string payload) returns AttachmentArr|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/attachments`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/attachments`;
         http:Request request = new;
-        AttachmentArr response = check self.clientEp->post(path, request);
+        AttachmentArr response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getChangeLogs(string issueIdOrKey, int? startAt, int? maxResults) returns PageBeanChangelog|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/changelog`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/changelog`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanChangelog response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanChangelog response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getComments(string issueIdOrKey, int? startAt, int? maxResults, string? orderBy, string? expand) returns PageOfComments|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/comment`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/comment`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, orderBy: orderBy, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PageOfComments response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageOfComments response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function addComment(string issueIdOrKey, string? expand, Comment payload) returns Comment|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/comment`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/comment`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Comment response = check self.clientEp->post(path, request);
+        Comment response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getComment(string issueIdOrKey, string id, string? expand) returns Comment|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/comment/${id}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/comment/${id}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        Comment response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Comment response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateComment(string issueIdOrKey, string id, string? expand, Comment payload) returns Comment|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/comment/${id}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/comment/${id}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Comment response = check self.clientEp->put(path, request);
+        Comment response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteComment(string issueIdOrKey, string id) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/comment/${id}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/comment/${id}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getEditIssueMeta(string issueIdOrKey, boolean? overrideScreenSecurity, boolean? overrideEditableFlag) returns IssueUpdateMetadata|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/editmeta`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/editmeta`;
         map<anydata> queryParam = {overrideScreenSecurity: overrideScreenSecurity, overrideEditableFlag: overrideEditableFlag};
-        path = path + check getPathForQueryParam(queryParam);
-        IssueUpdateMetadata response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        IssueUpdateMetadata response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function notify(string issueIdOrKey, Notification payload) returns json|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/notify`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/notify`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->post(path, request);
+        json response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getIssuePropertyKeys(string issueIdOrKey) returns PropertyKeys|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/properties`;
-        PropertyKeys response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/properties`;
+        PropertyKeys response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getIssueProperty(string issueIdOrKey, string propertyKey) returns EntityProperty|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/properties/${propertyKey}`;
-        EntityProperty response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/properties/${propertyKey}`;
+        EntityProperty response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setIssueProperty(string issueIdOrKey, string propertyKey, json payload) returns json|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/properties/${propertyKey}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteIssueProperty(string issueIdOrKey, string propertyKey) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/properties/${propertyKey}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getRemoteIssueLinks(string issueIdOrKey, string? globalId) returns RemoteIssueLink|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/remotelink`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/remotelink`;
         map<anydata> queryParam = {globalId: globalId};
-        path = path + check getPathForQueryParam(queryParam);
-        RemoteIssueLink response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        RemoteIssueLink response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createOrUpdateRemoteIssueLink(string issueIdOrKey, RemoteIssueLinkRequest payload) returns RemoteIssueLinkIdentifies|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/remotelink`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/remotelink`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        RemoteIssueLinkIdentifies response = check self.clientEp->post(path, request);
+        RemoteIssueLinkIdentifies response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function deleteRemoteIssueLinkByGlobalId(string issueIdOrKey, string globalId) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/remotelink`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/remotelink`;
         map<anydata> queryParam = {globalId: globalId};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getRemoteIssueLinkById(string issueIdOrKey, string linkId) returns RemoteIssueLink|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/remotelink/${linkId}`;
-        RemoteIssueLink response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/remotelink/${linkId}`;
+        RemoteIssueLink response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateRemoteIssueLink(string issueIdOrKey, string linkId, RemoteIssueLinkRequest payload) returns json|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/remotelink/${linkId}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/remotelink/${linkId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteRemoteIssueLinkById(string issueIdOrKey, string linkId) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/remotelink/${linkId}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/remotelink/${linkId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getTransitions(string issueIdOrKey, string? expand, string? transitionId, boolean? skipRemoteOnlyCondition, boolean? includeUnavailableTransitions, boolean? sortByOpsBarAndStatus) returns Transitions|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/transitions`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/transitions`;
         map<anydata> queryParam = {expand: expand, transitionId: transitionId, skipRemoteOnlyCondition: skipRemoteOnlyCondition, includeUnavailableTransitions: includeUnavailableTransitions, sortByOpsBarAndStatus: sortByOpsBarAndStatus};
-        path = path + check getPathForQueryParam(queryParam);
-        Transitions response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Transitions response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function doTransition(string issueIdOrKey, IssueUpdateDetails payload) returns json|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/transitions`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/transitions`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->post(path, request);
+        json response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getVotes(string issueIdOrKey) returns Votes|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/votes`;
-        Votes response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/votes`;
+        Votes response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function addVote(string issueIdOrKey) returns json|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/votes`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/votes`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> post(path, request);
+        json response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     remote isolated function removeVote(string issueIdOrKey) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/votes`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/votes`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getIssueWatchers(string issueIdOrKey) returns Watchers|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/watchers`;
-        Watchers response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/watchers`;
+        Watchers response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function addWatcher(string issueIdOrKey, string payload) returns json|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/watchers`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/watchers`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->post(path, request);
+        json response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function removeWatcher(string issueIdOrKey, string? username, string? accountId) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/watchers`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/watchers`;
         map<anydata> queryParam = {username: username, accountId: accountId};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getIssueWorklog(string issueIdOrKey, int? startAt, int? maxResults, int? startedAfter, string? expand) returns PageOfWorklogs|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/worklog`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/worklog`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, startedAfter: startedAfter, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PageOfWorklogs response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageOfWorklogs response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function addWorklog(string issueIdOrKey, boolean? notifyUsers, string? adjustEstimate, string? newEstimate, string? reduceBy, string? expand, boolean? overrideEditableFlag, Worklog payload) returns Worklog|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/worklog`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/worklog`;
         map<anydata> queryParam = {notifyUsers: notifyUsers, adjustEstimate: adjustEstimate, newEstimate: newEstimate, reduceBy: reduceBy, expand: expand, overrideEditableFlag: overrideEditableFlag};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Worklog response = check self.clientEp->post(path, request);
+        Worklog response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getWorklog(string issueIdOrKey, string id, string? expand) returns Worklog|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${id}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${id}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        Worklog response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Worklog response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateWorklog(string issueIdOrKey, string id, boolean? notifyUsers, string? adjustEstimate, string? newEstimate, string? expand, boolean? overrideEditableFlag, Worklog payload) returns Worklog|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${id}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${id}`;
         map<anydata> queryParam = {notifyUsers: notifyUsers, adjustEstimate: adjustEstimate, newEstimate: newEstimate, expand: expand, overrideEditableFlag: overrideEditableFlag};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Worklog response = check self.clientEp->put(path, request);
+        Worklog response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteWorklog(string issueIdOrKey, string id, boolean? notifyUsers, string? adjustEstimate, string? newEstimate, string? increaseBy, boolean? overrideEditableFlag) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${id}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${id}`;
         map<anydata> queryParam = {notifyUsers: notifyUsers, adjustEstimate: adjustEstimate, newEstimate: newEstimate, increaseBy: increaseBy, overrideEditableFlag: overrideEditableFlag};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getWorklogPropertyKeys(string issueIdOrKey, string worklogId) returns PropertyKeys|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${worklogId}/properties`;
-        PropertyKeys response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${worklogId}/properties`;
+        PropertyKeys response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getWorklogProperty(string issueIdOrKey, string worklogId, string propertyKey) returns EntityProperty|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${worklogId}/properties/${propertyKey}`;
-        EntityProperty response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${worklogId}/properties/${propertyKey}`;
+        EntityProperty response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setWorklogProperty(string issueIdOrKey, string worklogId, string propertyKey, json payload) returns json|error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${worklogId}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${worklogId}/properties/${propertyKey}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteWorklogProperty(string issueIdOrKey, string worklogId, string propertyKey) returns http:Response | error {
-        string  path = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${worklogId}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/issue/${issueIdOrKey}/worklog/${worklogId}/properties/${propertyKey}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function linkIssues(LinkIssueRequestJsonBean payload) returns json|error {
-        string  path = string `/rest/api/2/issueLink`;
+        string resourcePath = string `/rest/api/2/issueLink`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->post(path, request);
+        json response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getIssueLink(string linkId) returns IssueLink|error {
-        string  path = string `/rest/api/2/issueLink/${linkId}`;
-        IssueLink response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issueLink/${linkId}`;
+        IssueLink response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function deleteIssueLink(string linkId) returns http:Response | error {
-        string  path = string `/rest/api/2/issueLink/${linkId}`;
+        string resourcePath = string `/rest/api/2/issueLink/${linkId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getIssueLinkTypes() returns IssueLinkTypes|error {
-        string  path = string `/rest/api/2/issueLinkType`;
-        IssueLinkTypes response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issueLinkType`;
+        IssueLinkTypes response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createIssueLinkType(IssueLinkType payload) returns IssueLinkType|error {
-        string  path = string `/rest/api/2/issueLinkType`;
+        string resourcePath = string `/rest/api/2/issueLinkType`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        IssueLinkType response = check self.clientEp->post(path, request);
+        IssueLinkType response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getIssueLinkType(string issueLinkTypeId) returns IssueLinkType|error {
-        string  path = string `/rest/api/2/issueLinkType/${issueLinkTypeId}`;
-        IssueLinkType response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issueLinkType/${issueLinkTypeId}`;
+        IssueLinkType response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateIssueLinkType(string issueLinkTypeId, IssueLinkType payload) returns IssueLinkType|error {
-        string  path = string `/rest/api/2/issueLinkType/${issueLinkTypeId}`;
+        string resourcePath = string `/rest/api/2/issueLinkType/${issueLinkTypeId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        IssueLinkType response = check self.clientEp->put(path, request);
+        IssueLinkType response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteIssueLinkType(string issueLinkTypeId) returns http:Response | error {
-        string  path = string `/rest/api/2/issueLinkType/${issueLinkTypeId}`;
+        string resourcePath = string `/rest/api/2/issueLinkType/${issueLinkTypeId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getIssueSecuritySchemes() returns SecuritySchemes|error {
-        string  path = string `/rest/api/2/issuesecurityschemes`;
-        SecuritySchemes response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issuesecurityschemes`;
+        SecuritySchemes response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getIssueSecurityScheme(int id) returns SecurityScheme|error {
-        string  path = string `/rest/api/2/issuesecurityschemes/${id}`;
-        SecurityScheme response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issuesecurityschemes/${id}`;
+        SecurityScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getIssueSecurityLevelMembers(int issueSecuritySchemeId, int? startAt, int? maxResults, int[]? issueSecurityLevelId, string? expand) returns PageBeanIssueSecurityLevelMember|error {
-        string  path = string `/rest/api/2/issuesecurityschemes/${issueSecuritySchemeId}/members`;
+        string resourcePath = string `/rest/api/2/issuesecurityschemes/${issueSecuritySchemeId}/members`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, issueSecurityLevelId: issueSecurityLevelId, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueSecurityLevelMember response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueSecurityLevelMember response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getIssueAllTypes() returns IssueTypeDetailsArr|error {
-        string  path = string `/rest/api/2/issuetype`;
-        IssueTypeDetailsArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issuetype`;
+        IssueTypeDetailsArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createIssueType(IssueTypeCreateBean payload) returns IssueTypeDetails|error {
-        string  path = string `/rest/api/2/issuetype`;
+        string resourcePath = string `/rest/api/2/issuetype`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        IssueTypeDetails response = check self.clientEp->post(path, request);
+        IssueTypeDetails response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getIssueType(string id) returns IssueTypeDetails|error {
-        string  path = string `/rest/api/2/issuetype/${id}`;
-        IssueTypeDetails response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issuetype/${id}`;
+        IssueTypeDetails response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateIssueType(string id, IssueTypeUpdateBean payload) returns IssueTypeDetails|error {
-        string  path = string `/rest/api/2/issuetype/${id}`;
+        string resourcePath = string `/rest/api/2/issuetype/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        IssueTypeDetails response = check self.clientEp->put(path, request);
+        IssueTypeDetails response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteIssueType(string id, string? alternativeIssueTypeId) returns http:Response | error {
-        string  path = string `/rest/api/2/issuetype/${id}`;
+        string resourcePath = string `/rest/api/2/issuetype/${id}`;
         map<anydata> queryParam = {alternativeIssueTypeId: alternativeIssueTypeId};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getAlternativeIssueTypes(string id) returns IssueTypeDetailsArr|error {
-        string  path = string `/rest/api/2/issuetype/${id}/alternatives`;
-        IssueTypeDetailsArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issuetype/${id}/alternatives`;
+        IssueTypeDetailsArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createIssueTypeAvatar(string id, int? x, int? y, int size, json payload) returns Avatar|error {
-        string  path = string `/rest/api/2/issuetype/${id}/avatar2`;
+        string resourcePath = string `/rest/api/2/issuetype/${id}/avatar2`;
         map<anydata> queryParam = {x: x, y: y, size: size};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
-        Avatar response = check self.clientEp->post(path, request);
+        Avatar response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getIssueTypePropertyKeys(string issueTypeId) returns PropertyKeys|error {
-        string  path = string `/rest/api/2/issuetype/${issueTypeId}/properties`;
-        PropertyKeys response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issuetype/${issueTypeId}/properties`;
+        PropertyKeys response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getIssueTypeProperty(string issueTypeId, string propertyKey) returns EntityProperty|error {
-        string  path = string `/rest/api/2/issuetype/${issueTypeId}/properties/${propertyKey}`;
-        EntityProperty response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/issuetype/${issueTypeId}/properties/${propertyKey}`;
+        EntityProperty response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setIssueTypeProperty(string issueTypeId, string propertyKey, json payload) returns json|error {
-        string  path = string `/rest/api/2/issuetype/${issueTypeId}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/issuetype/${issueTypeId}/properties/${propertyKey}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteIssueTypeProperty(string issueTypeId, string propertyKey) returns http:Response | error {
-        string  path = string `/rest/api/2/issuetype/${issueTypeId}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/issuetype/${issueTypeId}/properties/${propertyKey}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getAllIssueTypeSchemes(int? startAt, int? maxResults, int[]? id) returns PageBeanIssueTypeScheme|error {
-        string  path = string `/rest/api/2/issuetypescheme`;
+        string resourcePath = string `/rest/api/2/issuetypescheme`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, id: id};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueTypeScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueTypeScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createIssueTypeScheme(IssueTypeSchemeDetails payload) returns IssueTypeSchemeID|error {
-        string  path = string `/rest/api/2/issuetypescheme`;
+        string resourcePath = string `/rest/api/2/issuetypescheme`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        IssueTypeSchemeID response = check self.clientEp->post(path, request);
+        IssueTypeSchemeID response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getIssueTypeSchemesMapping(int? startAt, int? maxResults, int[]? issueTypeSchemeId) returns PageBeanIssueTypeSchemeMapping|error {
-        string  path = string `/rest/api/2/issuetypescheme/mapping`;
+        string resourcePath = string `/rest/api/2/issuetypescheme/mapping`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, issueTypeSchemeId: issueTypeSchemeId};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueTypeSchemeMapping response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueTypeSchemeMapping response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getIssueTypeSchemeForProjects(int? startAt, int? maxResults, int[] projectId) returns PageBeanIssueTypeSchemeProjects|error {
-        string  path = string `/rest/api/2/issuetypescheme/project`;
+        string resourcePath = string `/rest/api/2/issuetypescheme/project`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, projectId: projectId};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueTypeSchemeProjects response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueTypeSchemeProjects response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function assignIssueTypeSchemeToProject(IssueTypeSchemeProjectAssociation payload) returns json|error {
-        string  path = string `/rest/api/2/issuetypescheme/project`;
+        string resourcePath = string `/rest/api/2/issuetypescheme/project`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function updateIssueTypeScheme(int issueTypeSchemeId, IssueTypeSchemeUpdateDetails payload) returns json|error {
-        string  path = string `/rest/api/2/issuetypescheme/${issueTypeSchemeId}`;
+        string resourcePath = string `/rest/api/2/issuetypescheme/${issueTypeSchemeId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteIssueTypeScheme(int issueTypeSchemeId) returns json|error {
-        string  path = string `/rest/api/2/issuetypescheme/${issueTypeSchemeId}`;
+        string resourcePath = string `/rest/api/2/issuetypescheme/${issueTypeSchemeId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> delete(path, request);
+        json response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function addIssueTypesToIssueTypeScheme(int issueTypeSchemeId, IssueTypeIds payload) returns json|error {
-        string  path = string `/rest/api/2/issuetypescheme/${issueTypeSchemeId}/issuetype`;
+        string resourcePath = string `/rest/api/2/issuetypescheme/${issueTypeSchemeId}/issuetype`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function reorderIssueTypesInIssueTypeScheme(int issueTypeSchemeId, OrderOfIssueTypes payload) returns json|error {
-        string  path = string `/rest/api/2/issuetypescheme/${issueTypeSchemeId}/issuetype/move`;
+        string resourcePath = string `/rest/api/2/issuetypescheme/${issueTypeSchemeId}/issuetype/move`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function removeIssueTypeFromIssueTypeScheme(int issueTypeSchemeId, int issueTypeId) returns json|error {
-        string  path = string `/rest/api/2/issuetypescheme/${issueTypeSchemeId}/issuetype/${issueTypeId}`;
+        string resourcePath = string `/rest/api/2/issuetypescheme/${issueTypeSchemeId}/issuetype/${issueTypeId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> delete(path, request);
+        json response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function getIssueTypeScreenSchemes(int? startAt, int? maxResults, int[]? id) returns PageBeanIssueTypeScreenScheme|error {
-        string  path = string `/rest/api/2/issuetypescreenscheme`;
+        string resourcePath = string `/rest/api/2/issuetypescreenscheme`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, id: id};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueTypeScreenScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueTypeScreenScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createIssueTypeScreenScheme(IssueTypeScreenSchemeDetails payload) returns IssueTypeScreenSchemeId|error {
-        string  path = string `/rest/api/2/issuetypescreenscheme`;
+        string resourcePath = string `/rest/api/2/issuetypescreenscheme`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        IssueTypeScreenSchemeId response = check self.clientEp->post(path, request);
+        IssueTypeScreenSchemeId response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getIssueTypeScreenSchemeMappings(int? startAt, int? maxResults, int[]? issueTypeScreenSchemeId) returns PageBeanIssueTypeScreenSchemeItem|error {
-        string  path = string `/rest/api/2/issuetypescreenscheme/mapping`;
+        string resourcePath = string `/rest/api/2/issuetypescreenscheme/mapping`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, issueTypeScreenSchemeId: issueTypeScreenSchemeId};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueTypeScreenSchemeItem response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueTypeScreenSchemeItem response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getIssueTypeScreenSchemeProjectAssociations(int? startAt, int? maxResults, int[] projectId) returns PageBeanIssueTypeScreenSchemesProjects|error {
-        string  path = string `/rest/api/2/issuetypescreenscheme/project`;
+        string resourcePath = string `/rest/api/2/issuetypescreenscheme/project`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, projectId: projectId};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanIssueTypeScreenSchemesProjects response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanIssueTypeScreenSchemesProjects response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function assignIssueTypeScreenSchemeToProject(IssueTypeScreenSchemeProjectAssociation payload) returns json|error {
-        string  path = string `/rest/api/2/issuetypescreenscheme/project`;
+        string resourcePath = string `/rest/api/2/issuetypescreenscheme/project`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function updateIssueTypeScreenScheme(string issueTypeScreenSchemeId, IssueTypeScreenSchemeUpdateDetails payload) returns json|error {
-        string  path = string `/rest/api/2/issuetypescreenscheme/${issueTypeScreenSchemeId}`;
+        string resourcePath = string `/rest/api/2/issuetypescreenscheme/${issueTypeScreenSchemeId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteIssueTypeScreenScheme(string issueTypeScreenSchemeId) returns json|error {
-        string  path = string `/rest/api/2/issuetypescreenscheme/${issueTypeScreenSchemeId}`;
+        string resourcePath = string `/rest/api/2/issuetypescreenscheme/${issueTypeScreenSchemeId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> delete(path, request);
+        json response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function appendMappingsForIssueTypeScreenScheme(string issueTypeScreenSchemeId, IssueTypeScreenSchemeMappingDetails payload) returns json|error {
-        string  path = string `/rest/api/2/issuetypescreenscheme/${issueTypeScreenSchemeId}/mapping`;
+        string resourcePath = string `/rest/api/2/issuetypescreenscheme/${issueTypeScreenSchemeId}/mapping`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function updateDefaultScreenScheme(string issueTypeScreenSchemeId, UpdateDefaultScreenScheme payload) returns json|error {
-        string  path = string `/rest/api/2/issuetypescreenscheme/${issueTypeScreenSchemeId}/mapping/default`;
+        string resourcePath = string `/rest/api/2/issuetypescreenscheme/${issueTypeScreenSchemeId}/mapping/default`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function removeMappingsFromIssueTypeScreenScheme(string issueTypeScreenSchemeId, IssueTypeIds payload) returns json|error {
-        string  path = string `/rest/api/2/issuetypescreenscheme/${issueTypeScreenSchemeId}/mapping/remove`;
+        string resourcePath = string `/rest/api/2/issuetypescreenscheme/${issueTypeScreenSchemeId}/mapping/remove`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->post(path, request);
+        json response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getAutoComplete() returns JQLReferenceData|error {
-        string  path = string `/rest/api/2/jql/autocompletedata`;
-        JQLReferenceData response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/jql/autocompletedata`;
+        JQLReferenceData response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAutoCompletePost(SearchAutoCompleteFilter payload) returns JQLReferenceData|error {
-        string  path = string `/rest/api/2/jql/autocompletedata`;
+        string resourcePath = string `/rest/api/2/jql/autocompletedata`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        JQLReferenceData response = check self.clientEp->post(path, request);
+        JQLReferenceData response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getFieldAutoCompleteForQueryString(string? fieldName, string? fieldValue, string? predicateName, string? predicateValue) returns AutoCompleteSuggestions|error {
-        string  path = string `/rest/api/2/jql/autocompletedata/suggestions`;
+        string resourcePath = string `/rest/api/2/jql/autocompletedata/suggestions`;
         map<anydata> queryParam = {fieldName: fieldName, fieldValue: fieldValue, predicateName: predicateName, predicateValue: predicateValue};
-        path = path + check getPathForQueryParam(queryParam);
-        AutoCompleteSuggestions response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        AutoCompleteSuggestions response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function matchIssues(IssuesAndJQLQueries payload) returns IssueMatches|error {
-        string  path = string `/rest/api/2/jql/match`;
+        string resourcePath = string `/rest/api/2/jql/match`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        IssueMatches response = check self.clientEp->post(path, request);
+        IssueMatches response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function parseJqlQueries(string? validation, JqlQueriesToParse payload) returns ParsedJqlQueries|error {
-        string  path = string `/rest/api/2/jql/parse`;
+        string resourcePath = string `/rest/api/2/jql/parse`;
         map<anydata> queryParam = {validation: validation};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ParsedJqlQueries response = check self.clientEp->post(path, request);
+        ParsedJqlQueries response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function migrateQueries(JQLPersonalDataMigrationRequest payload) returns ConvertedJQLQueries|error {
-        string  path = string `/rest/api/2/jql/pdcleaner`;
+        string resourcePath = string `/rest/api/2/jql/pdcleaner`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ConvertedJQLQueries response = check self.clientEp->post(path, request);
+        ConvertedJQLQueries response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getAllLabels(int? startAt, int? maxResults) returns PageBeanString|error {
-        string  path = string `/rest/api/2/label`;
+        string resourcePath = string `/rest/api/2/label`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanString response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanString response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getMyPermissions(string? projectKey, string? projectId, string? issueKey, string? issueId, string? permissions, string? projectUuid, string? projectConfigurationUuid) returns Permissions|error {
-        string  path = string `/rest/api/2/mypermissions`;
+        string resourcePath = string `/rest/api/2/mypermissions`;
         map<anydata> queryParam = {projectKey: projectKey, projectId: projectId, issueKey: issueKey, issueId: issueId, permissions: permissions, projectUuid: projectUuid, projectConfigurationUuid: projectConfigurationUuid};
-        path = path + check getPathForQueryParam(queryParam);
-        Permissions response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Permissions response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getPreference(string 'key) returns string|error {
-        string  path = string `/rest/api/2/mypreferences`;
+        string resourcePath = string `/rest/api/2/mypreferences`;
         map<anydata> queryParam = {'key: 'key};
-        path = path + check getPathForQueryParam(queryParam);
-        string response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setPreference(string 'key, string payload) returns json|error {
-        string  path = string `/rest/api/2/mypreferences`;
+        string resourcePath = string `/rest/api/2/mypreferences`;
         map<anydata> queryParam = {'key: 'key};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function removePreference(string 'key) returns http:Response | error {
-        string  path = string `/rest/api/2/mypreferences`;
+        string resourcePath = string `/rest/api/2/mypreferences`;
         map<anydata> queryParam = {'key: 'key};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getLocale() returns Locale|error {
-        string  path = string `/rest/api/2/mypreferences/locale`;
-        Locale response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/mypreferences/locale`;
+        Locale response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setLocale(Locale payload) returns json|error {
-        string  path = string `/rest/api/2/mypreferences/locale`;
+        string resourcePath = string `/rest/api/2/mypreferences/locale`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteLocale() returns json|error {
-        string  path = string `/rest/api/2/mypreferences/locale`;
+        string resourcePath = string `/rest/api/2/mypreferences/locale`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> delete(path, request);
+        json response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function getCurrentUser(string? expand) returns User|error {
-        string  path = string `/rest/api/2/myself`;
+        string resourcePath = string `/rest/api/2/myself`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        User response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getNotificationSchemes(int? startAt, int? maxResults, string? expand) returns PageBeanNotificationScheme|error {
-        string  path = string `/rest/api/2/notificationscheme`;
+        string resourcePath = string `/rest/api/2/notificationscheme`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanNotificationScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanNotificationScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getNotificationScheme(int id, string? expand) returns NotificationScheme|error {
-        string  path = string `/rest/api/2/notificationscheme/${id}`;
+        string resourcePath = string `/rest/api/2/notificationscheme/${id}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        NotificationScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        NotificationScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllPermissions() returns Permissions|error {
-        string  path = string `/rest/api/2/permissions`;
-        Permissions response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/permissions`;
+        Permissions response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getBulkPermissions(BulkPermissionsRequestBean payload) returns BulkPermissionGrants|error {
-        string  path = string `/rest/api/2/permissions/check`;
+        string resourcePath = string `/rest/api/2/permissions/check`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        BulkPermissionGrants response = check self.clientEp->post(path, request);
+        BulkPermissionGrants response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getPermittedProjects(PermissionsKeysBean payload) returns PermittedProjects|error {
-        string  path = string `/rest/api/2/permissions/project`;
+        string resourcePath = string `/rest/api/2/permissions/project`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        PermittedProjects response = check self.clientEp->post(path, request);
+        PermittedProjects response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getAllPermissionSchemes(string? expand) returns PermissionSchemes|error {
-        string  path = string `/rest/api/2/permissionscheme`;
+        string resourcePath = string `/rest/api/2/permissionscheme`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PermissionSchemes response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PermissionSchemes response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createPermissionScheme(string? expand, PermissionScheme payload) returns PermissionScheme|error {
-        string  path = string `/rest/api/2/permissionscheme`;
+        string resourcePath = string `/rest/api/2/permissionscheme`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        PermissionScheme response = check self.clientEp->post(path, request);
+        PermissionScheme response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getPermissionScheme(int schemeId, string? expand) returns PermissionScheme|error {
-        string  path = string `/rest/api/2/permissionscheme/${schemeId}`;
+        string resourcePath = string `/rest/api/2/permissionscheme/${schemeId}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PermissionScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PermissionScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updatePermissionScheme(int schemeId, string? expand, PermissionScheme payload) returns PermissionScheme|error {
-        string  path = string `/rest/api/2/permissionscheme/${schemeId}`;
+        string resourcePath = string `/rest/api/2/permissionscheme/${schemeId}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        PermissionScheme response = check self.clientEp->put(path, request);
+        PermissionScheme response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deletePermissionScheme(int schemeId) returns http:Response | error {
-        string  path = string `/rest/api/2/permissionscheme/${schemeId}`;
+        string resourcePath = string `/rest/api/2/permissionscheme/${schemeId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getPermissionSchemeGrants(int schemeId, string? expand) returns PermissionGrants|error {
-        string  path = string `/rest/api/2/permissionscheme/${schemeId}/permission`;
+        string resourcePath = string `/rest/api/2/permissionscheme/${schemeId}/permission`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PermissionGrants response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PermissionGrants response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createPermissionGrant(int schemeId, string? expand, PermissionGrant payload) returns PermissionGrant|error {
-        string  path = string `/rest/api/2/permissionscheme/${schemeId}/permission`;
+        string resourcePath = string `/rest/api/2/permissionscheme/${schemeId}/permission`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        PermissionGrant response = check self.clientEp->post(path, request);
+        PermissionGrant response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getPermissionSchemeGrant(int schemeId, int permissionId, string? expand) returns PermissionGrant|error {
-        string  path = string `/rest/api/2/permissionscheme/${schemeId}/permission/${permissionId}`;
+        string resourcePath = string `/rest/api/2/permissionscheme/${schemeId}/permission/${permissionId}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PermissionGrant response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PermissionGrant response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function deletePermissionSchemeEntity(int schemeId, int permissionId) returns http:Response | error {
-        string  path = string `/rest/api/2/permissionscheme/${schemeId}/permission/${permissionId}`;
+        string resourcePath = string `/rest/api/2/permissionscheme/${schemeId}/permission/${permissionId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getPriorities() returns PriorityArr|error {
-        string  path = string `/rest/api/2/priority`;
-        PriorityArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/priority`;
+        PriorityArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getPriority(string id) returns Priority|error {
-        string  path = string `/rest/api/2/priority/${id}`;
-        Priority response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/priority/${id}`;
+        Priority response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllProjects(string? expand, int? recent, string[]? properties) returns ProjectArr|error {
-        string  path = string `/rest/api/2/project`;
+        string resourcePath = string `/rest/api/2/project`;
         map<anydata> queryParam = {expand: expand, recent: recent, properties: properties};
-        path = path + check getPathForQueryParam(queryParam);
-        ProjectArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ProjectArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createProject(ProjectInputBean payload) returns ProjectIdentifiers|error {
-        string  path = string `/rest/api/2/project`;
+        string resourcePath = string `/rest/api/2/project`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ProjectIdentifiers response = check self.clientEp->post(path, request);
+        ProjectIdentifiers response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function searchProjects(int? startAt, int? maxResults, string? orderBy, string? query, string? typeKey, int? categoryId, string? action, string? expand, string[]? status, StringList[]? properties, string? propertyQuery) returns PageBeanProject|error {
-        string  path = string `/rest/api/2/project/search`;
+        string resourcePath = string `/rest/api/2/project/search`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, orderBy: orderBy, query: query, typeKey: typeKey, categoryId: categoryId, action: action, expand: expand, status: status, properties: properties, propertyQuery: propertyQuery};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanProject response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanProject response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllProjectTypes() returns ProjectTypeArr|error {
-        string  path = string `/rest/api/2/project/type`;
-        ProjectTypeArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/type`;
+        ProjectTypeArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllAccessibleProjectTypes() returns ProjectTypeArr|error {
-        string  path = string `/rest/api/2/project/type/accessible`;
-        ProjectTypeArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/type/accessible`;
+        ProjectTypeArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getProjectTypeByKey(string projectTypeKey) returns ProjectType|error {
-        string  path = string `/rest/api/2/project/type/${projectTypeKey}`;
-        ProjectType response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/type/${projectTypeKey}`;
+        ProjectType response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAccessibleProjectTypeByKey(string projectTypeKey) returns ProjectType|error {
-        string  path = string `/rest/api/2/project/type/${projectTypeKey}/accessible`;
-        ProjectType response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/type/${projectTypeKey}/accessible`;
+        ProjectType response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getProject(string projectIdOrKey, string? expand, string[]? properties) returns Project|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}`;
         map<anydata> queryParam = {expand: expand, properties: properties};
-        path = path + check getPathForQueryParam(queryParam);
-        Project response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Project response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateProject(string projectIdOrKey, string? expand, ProjectInputBean payload) returns Project|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Project response = check self.clientEp->put(path, request);
+        Project response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteProject(string projectIdOrKey, boolean? enableUndo) returns http:Response | error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}`;
         map<anydata> queryParam = {enableUndo: enableUndo};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function archiveProject(string projectIdOrKey) returns json|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/archive`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/archive`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> post(path, request);
+        json response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     remote isolated function updateProjectAvatar(string projectIdOrKey, Avatar payload) returns json|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/avatar`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/avatar`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteProjectAvatar(string projectIdOrKey, int id) returns http:Response | error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/avatar/${id}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/avatar/${id}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function createProjectAvatar(string projectIdOrKey, int? x, int? y, int? size, json payload) returns Avatar|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/avatar2`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/avatar2`;
         map<anydata> queryParam = {x: x, y: y, size: size};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
-        Avatar response = check self.clientEp->post(path, request);
+        Avatar response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getAllProjectAvatars(string projectIdOrKey) returns ProjectAvatars|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/avatars`;
-        ProjectAvatars response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/avatars`;
+        ProjectAvatars response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getProjectComponentsPaginated(string projectIdOrKey, int? startAt, int? maxResults, string? orderBy, string? query) returns PageBeanComponentWithIssueCount|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/component`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/component`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, orderBy: orderBy, query: query};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanComponentWithIssueCount response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanComponentWithIssueCount response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getProjectComponents(string projectIdOrKey) returns ComponentArr|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/components`;
-        ComponentArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/components`;
+        ComponentArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function deleteProjectAsynchronously(string projectIdOrKey) returns TaskProgressBeanObject|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/delete`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/delete`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        TaskProgressBeanObject response = check self.clientEp-> post(path, request);
+        TaskProgressBeanObject response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     remote isolated function getFeaturesForProject(string projectIdOrKey) returns ProjectFeaturesResponse|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/features`;
-        ProjectFeaturesResponse response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/features`;
+        ProjectFeaturesResponse response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function toggleFeatureForProject(string projectIdOrKey, string featureKey, ProjectFeatureToggleRequest payload) returns ProjectFeaturesResponse|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/features/${featureKey}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/features/${featureKey}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ProjectFeaturesResponse response = check self.clientEp->put(path, request);
+        ProjectFeaturesResponse response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getProjectPropertyKeys(string projectIdOrKey) returns PropertyKeys|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/properties`;
-        PropertyKeys response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/properties`;
+        PropertyKeys response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getProjectProperty(string projectIdOrKey, string propertyKey) returns EntityProperty|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/properties/${propertyKey}`;
-        EntityProperty response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/properties/${propertyKey}`;
+        EntityProperty response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setProjectProperty(string projectIdOrKey, string propertyKey, json payload) returns json|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/properties/${propertyKey}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteProjectProperty(string projectIdOrKey, string propertyKey) returns http:Response | error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/properties/${propertyKey}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function restore(string projectIdOrKey) returns Project|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/restore`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/restore`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Project response = check self.clientEp-> post(path, request);
+        Project response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     remote isolated function getProjectRoles(string projectIdOrKey) returns record|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/role`;
-        record response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/role`;
+        record response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getProjectRole(string projectIdOrKey, int id) returns ProjectRole|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/role/${id}`;
-        ProjectRole response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/role/${id}`;
+        ProjectRole response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setActors(string projectIdOrKey, int id, ProjectRoleActorsUpdateBean payload) returns ProjectRole|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/role/${id}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/role/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ProjectRole response = check self.clientEp->put(path, request);
+        ProjectRole response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function addActorUsers(string projectIdOrKey, int id, ActorsMap payload) returns ProjectRole|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/role/${id}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/role/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ProjectRole response = check self.clientEp->post(path, request);
+        ProjectRole response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function deleteActor(string projectIdOrKey, int id, string? user, string? 'group) returns http:Response | error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/role/${id}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/role/${id}`;
         map<anydata> queryParam = {user: user, 'group: 'group};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getProjectRoleDetails(string projectIdOrKey, boolean? currentMember, boolean? excludeConnectAddons) returns ProjectRoleDetailsArr|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/roledetails`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/roledetails`;
         map<anydata> queryParam = {currentMember: currentMember, excludeConnectAddons: excludeConnectAddons};
-        path = path + check getPathForQueryParam(queryParam);
-        ProjectRoleDetailsArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ProjectRoleDetailsArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllStatuses(string projectIdOrKey) returns IssueTypeWithStatusArr|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/statuses`;
-        IssueTypeWithStatusArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/statuses`;
+        IssueTypeWithStatusArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateProjectType(string projectIdOrKey, string newProjectTypeKey) returns Project|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/type/${newProjectTypeKey}`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/type/${newProjectTypeKey}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Project response = check self.clientEp-> put(path, request);
+        Project response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     remote isolated function getProjectVersionsPaginated(string projectIdOrKey, int? startAt, int? maxResults, string? orderBy, string? query, string? status, string? expand) returns PageBeanVersion|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/version`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/version`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, orderBy: orderBy, query: query, status: status, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanVersion response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanVersion response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getProjectVersions(string projectIdOrKey, string? expand) returns VersionArr|error {
-        string  path = string `/rest/api/2/project/${projectIdOrKey}/versions`;
+        string resourcePath = string `/rest/api/2/project/${projectIdOrKey}/versions`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        VersionArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        VersionArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getProjectEmail(int projectId) returns ProjectEmailAddress|error {
-        string  path = string `/rest/api/2/project/${projectId}/email`;
-        ProjectEmailAddress response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectId}/email`;
+        ProjectEmailAddress response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateProjectEmail(int projectId, ProjectEmailAddress payload) returns json|error {
-        string  path = string `/rest/api/2/project/${projectId}/email`;
+        string resourcePath = string `/rest/api/2/project/${projectId}/email`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getHierarchy(int projectId) returns ProjectIssueTypeHierarchy|error {
-        string  path = string `/rest/api/2/project/${projectId}/hierarchy`;
-        ProjectIssueTypeHierarchy response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectId}/hierarchy`;
+        ProjectIssueTypeHierarchy response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getProjectIssueSecurityScheme(string projectKeyOrId) returns SecurityScheme|error {
-        string  path = string `/rest/api/2/project/${projectKeyOrId}/issuesecuritylevelscheme`;
-        SecurityScheme response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectKeyOrId}/issuesecuritylevelscheme`;
+        SecurityScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getNotificationSchemeForProject(string projectKeyOrId, string? expand) returns NotificationScheme|error {
-        string  path = string `/rest/api/2/project/${projectKeyOrId}/notificationscheme`;
+        string resourcePath = string `/rest/api/2/project/${projectKeyOrId}/notificationscheme`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        NotificationScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        NotificationScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAssignedPermissionScheme(string projectKeyOrId, string? expand) returns PermissionScheme|error {
-        string  path = string `/rest/api/2/project/${projectKeyOrId}/permissionscheme`;
+        string resourcePath = string `/rest/api/2/project/${projectKeyOrId}/permissionscheme`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PermissionScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PermissionScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function assignPermissionScheme(string projectKeyOrId, string? expand, IdBean payload) returns PermissionScheme|error {
-        string  path = string `/rest/api/2/project/${projectKeyOrId}/permissionscheme`;
+        string resourcePath = string `/rest/api/2/project/${projectKeyOrId}/permissionscheme`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        PermissionScheme response = check self.clientEp->put(path, request);
+        PermissionScheme response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getSecurityLevelsForProject(string projectKeyOrId) returns ProjectIssueSecurityLevels|error {
-        string  path = string `/rest/api/2/project/${projectKeyOrId}/securitylevel`;
-        ProjectIssueSecurityLevels response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/project/${projectKeyOrId}/securitylevel`;
+        ProjectIssueSecurityLevels response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllProjectCategories() returns ProjectCategoryArr|error {
-        string  path = string `/rest/api/2/projectCategory`;
-        ProjectCategoryArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/projectCategory`;
+        ProjectCategoryArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createProjectCategory(ProjectCategory payload) returns ProjectCategory|error {
-        string  path = string `/rest/api/2/projectCategory`;
+        string resourcePath = string `/rest/api/2/projectCategory`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ProjectCategory response = check self.clientEp->post(path, request);
+        ProjectCategory response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getProjectCategoryById(int id) returns ProjectCategory|error {
-        string  path = string `/rest/api/2/projectCategory/${id}`;
-        ProjectCategory response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/projectCategory/${id}`;
+        ProjectCategory response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateProjectCategory(int id, ProjectCategory payload) returns UpdatedProjectCategory|error {
-        string  path = string `/rest/api/2/projectCategory/${id}`;
+        string resourcePath = string `/rest/api/2/projectCategory/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        UpdatedProjectCategory response = check self.clientEp->put(path, request);
+        UpdatedProjectCategory response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function removeProjectCategory(int id) returns http:Response | error {
-        string  path = string `/rest/api/2/projectCategory/${id}`;
+        string resourcePath = string `/rest/api/2/projectCategory/${id}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function validateProjectKey(string? 'key) returns ErrorCollection|error {
-        string  path = string `/rest/api/2/projectvalidate/key`;
+        string resourcePath = string `/rest/api/2/projectvalidate/key`;
         map<anydata> queryParam = {'key: 'key};
-        path = path + check getPathForQueryParam(queryParam);
-        ErrorCollection response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ErrorCollection response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getValidProjectKey(string? 'key) returns string|error {
-        string  path = string `/rest/api/2/projectvalidate/validProjectKey`;
+        string resourcePath = string `/rest/api/2/projectvalidate/validProjectKey`;
         map<anydata> queryParam = {'key: 'key};
-        path = path + check getPathForQueryParam(queryParam);
-        string response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getValidProjectName(string name) returns string|error {
-        string  path = string `/rest/api/2/projectvalidate/validProjectName`;
+        string resourcePath = string `/rest/api/2/projectvalidate/validProjectName`;
         map<anydata> queryParam = {name: name};
-        path = path + check getPathForQueryParam(queryParam);
-        string response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getResolutions() returns ResolutionArr|error {
-        string  path = string `/rest/api/2/resolution`;
-        ResolutionArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/resolution`;
+        ResolutionArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getResolution(string id) returns Resolution|error {
-        string  path = string `/rest/api/2/resolution/${id}`;
-        Resolution response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/resolution/${id}`;
+        Resolution response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllProjectRoles() returns ProjectRoleArr|error {
-        string  path = string `/rest/api/2/role`;
-        ProjectRoleArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/role`;
+        ProjectRoleArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createProjectRole(CreateUpdateRoleRequestBean payload) returns ProjectRole|error {
-        string  path = string `/rest/api/2/role`;
+        string resourcePath = string `/rest/api/2/role`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ProjectRole response = check self.clientEp->post(path, request);
+        ProjectRole response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getProjectRoleById(int id) returns ProjectRole|error {
-        string  path = string `/rest/api/2/role/${id}`;
-        ProjectRole response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/role/${id}`;
+        ProjectRole response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function fullyUpdateProjectRole(int id, CreateUpdateRoleRequestBean payload) returns ProjectRole|error {
-        string  path = string `/rest/api/2/role/${id}`;
+        string resourcePath = string `/rest/api/2/role/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ProjectRole response = check self.clientEp->put(path, request);
+        ProjectRole response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function partialUpdateProjectRole(int id, CreateUpdateRoleRequestBean payload) returns ProjectRole|error {
-        string  path = string `/rest/api/2/role/${id}`;
+        string resourcePath = string `/rest/api/2/role/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ProjectRole response = check self.clientEp->post(path, request);
+        ProjectRole response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function deleteProjectRole(int id, int? swap) returns http:Response | error {
-        string  path = string `/rest/api/2/role/${id}`;
+        string resourcePath = string `/rest/api/2/role/${id}`;
         map<anydata> queryParam = {swap: swap};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getProjectRoleActorsForRole(int id) returns ProjectRole|error {
-        string  path = string `/rest/api/2/role/${id}/actors`;
-        ProjectRole response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/role/${id}/actors`;
+        ProjectRole response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function addProjectRoleActorsToRole(int id, ActorInputBean payload) returns ProjectRole|error {
-        string  path = string `/rest/api/2/role/${id}/actors`;
+        string resourcePath = string `/rest/api/2/role/${id}/actors`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ProjectRole response = check self.clientEp->post(path, request);
+        ProjectRole response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function deleteProjectRoleActorsFromRole(int id, string? user, string? 'group) returns ProjectRole|error {
-        string  path = string `/rest/api/2/role/${id}/actors`;
+        string resourcePath = string `/rest/api/2/role/${id}/actors`;
         map<anydata> queryParam = {user: user, 'group: 'group};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        ProjectRole response = check self.clientEp-> delete(path, request);
+        ProjectRole response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function getScreens(int? startAt, int? maxResults, int[]? id) returns PageBeanScreen|error {
-        string  path = string `/rest/api/2/screens`;
+        string resourcePath = string `/rest/api/2/screens`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, id: id};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanScreen response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanScreen response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createScreen(ScreenDetails payload) returns Screen|error {
-        string  path = string `/rest/api/2/screens`;
+        string resourcePath = string `/rest/api/2/screens`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Screen response = check self.clientEp->post(path, request);
+        Screen response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function addFieldToDefaultScreen(string fieldId) returns json|error {
-        string  path = string `/rest/api/2/screens/addToDefault/${fieldId}`;
+        string resourcePath = string `/rest/api/2/screens/addToDefault/${fieldId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> post(path, request);
+        json response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     remote isolated function updateScreen(int screenId, UpdateScreenDetails payload) returns Screen|error {
-        string  path = string `/rest/api/2/screens/${screenId}`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Screen response = check self.clientEp->put(path, request);
+        Screen response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteScreen(int screenId) returns http:Response | error {
-        string  path = string `/rest/api/2/screens/${screenId}`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getAvailableScreenFields(int screenId) returns ScreenableFieldArr|error {
-        string  path = string `/rest/api/2/screens/${screenId}/availableFields`;
-        ScreenableFieldArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/screens/${screenId}/availableFields`;
+        ScreenableFieldArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllScreenTabs(int screenId, string? projectKey) returns ScreenableTabArr|error {
-        string  path = string `/rest/api/2/screens/${screenId}/tabs`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}/tabs`;
         map<anydata> queryParam = {projectKey: projectKey};
-        path = path + check getPathForQueryParam(queryParam);
-        ScreenableTabArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ScreenableTabArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function addScreenTab(int screenId, ScreenableTab payload) returns ScreenableTab|error {
-        string  path = string `/rest/api/2/screens/${screenId}/tabs`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}/tabs`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ScreenableTab response = check self.clientEp->post(path, request);
+        ScreenableTab response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function renameScreenTab(int screenId, int tabId, ScreenableTab payload) returns ScreenableTab|error {
-        string  path = string `/rest/api/2/screens/${screenId}/tabs/${tabId}`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}/tabs/${tabId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ScreenableTab response = check self.clientEp->put(path, request);
+        ScreenableTab response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteScreenTab(int screenId, int tabId) returns http:Response | error {
-        string  path = string `/rest/api/2/screens/${screenId}/tabs/${tabId}`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}/tabs/${tabId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getAllScreenTabFields(int screenId, int tabId, string? projectKey) returns ScreenableFieldArr|error {
-        string  path = string `/rest/api/2/screens/${screenId}/tabs/${tabId}/fields`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}/tabs/${tabId}/fields`;
         map<anydata> queryParam = {projectKey: projectKey};
-        path = path + check getPathForQueryParam(queryParam);
-        ScreenableFieldArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ScreenableFieldArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function addScreenTabField(int screenId, int tabId, AddFieldBean payload) returns ScreenableField|error {
-        string  path = string `/rest/api/2/screens/${screenId}/tabs/${tabId}/fields`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}/tabs/${tabId}/fields`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ScreenableField response = check self.clientEp->post(path, request);
+        ScreenableField response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function removeScreenTabField(int screenId, int tabId, string id) returns http:Response | error {
-        string  path = string `/rest/api/2/screens/${screenId}/tabs/${tabId}/fields/${id}`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}/tabs/${tabId}/fields/${id}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function moveScreenTabField(int screenId, int tabId, string id, MoveFieldBean payload) returns json|error {
-        string  path = string `/rest/api/2/screens/${screenId}/tabs/${tabId}/fields/${id}/move`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}/tabs/${tabId}/fields/${id}/move`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->post(path, request);
+        json response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function moveScreenTab(int screenId, int tabId, int pos) returns json|error {
-        string  path = string `/rest/api/2/screens/${screenId}/tabs/${tabId}/move/${pos}`;
+        string resourcePath = string `/rest/api/2/screens/${screenId}/tabs/${tabId}/move/${pos}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> post(path, request);
+        json response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     remote isolated function getScreenSchemes(int? startAt, int? maxResults, int[]? id) returns PageBeanScreenScheme|error {
-        string  path = string `/rest/api/2/screenscheme`;
+        string resourcePath = string `/rest/api/2/screenscheme`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, id: id};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanScreenScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanScreenScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createScreenScheme(ScreenSchemeDetails payload) returns ScreenSchemeId|error {
-        string  path = string `/rest/api/2/screenscheme`;
+        string resourcePath = string `/rest/api/2/screenscheme`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ScreenSchemeId response = check self.clientEp->post(path, request);
+        ScreenSchemeId response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function updateScreenScheme(string screenSchemeId, UpdateScreenSchemeDetails payload) returns json|error {
-        string  path = string `/rest/api/2/screenscheme/${screenSchemeId}`;
+        string resourcePath = string `/rest/api/2/screenscheme/${screenSchemeId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteScreenScheme(string screenSchemeId) returns http:Response | error {
-        string  path = string `/rest/api/2/screenscheme/${screenSchemeId}`;
+        string resourcePath = string `/rest/api/2/screenscheme/${screenSchemeId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function searchForIssuesUsingJql(string? jql, int? startAt, int? maxResults, string? validateQuery, string[]? fields, string? expand, string[]? properties, boolean? fieldsByKeys) returns SearchResults|error {
-        string  path = string `/rest/api/2/search`;
+        string resourcePath = string `/rest/api/2/search`;
         map<anydata> queryParam = {jql: jql, startAt: startAt, maxResults: maxResults, validateQuery: validateQuery, fields: fields, expand: expand, properties: properties, fieldsByKeys: fieldsByKeys};
-        path = path + check getPathForQueryParam(queryParam);
-        SearchResults response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        SearchResults response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function searchForIssuesUsingJqlPost(SearchRequestBean payload) returns SearchResults|error {
-        string  path = string `/rest/api/2/search`;
+        string resourcePath = string `/rest/api/2/search`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        SearchResults response = check self.clientEp->post(path, request);
+        SearchResults response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getIssueSecurityLevel(string id) returns SecurityLevel|error {
-        string  path = string `/rest/api/2/securitylevel/${id}`;
-        SecurityLevel response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/securitylevel/${id}`;
+        SecurityLevel response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getServerInfo() returns ServerInformation|error {
-        string  path = string `/rest/api/2/serverInfo`;
-        ServerInformation response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/serverInfo`;
+        ServerInformation response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getIssueNavigatorDefaultColumns() returns ColumnItemArr|error {
-        string  path = string `/rest/api/2/settings/columns`;
-        ColumnItemArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/settings/columns`;
+        ColumnItemArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setIssueNavigatorDefaultColumns([] payload) returns json|error {
-        string  path = string `/rest/api/2/settings/columns`;
+        string resourcePath = string `/rest/api/2/settings/columns`;
         http:Request request = new;
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getStatuses() returns StatusDetailsArr|error {
-        string  path = string `/rest/api/2/status`;
-        StatusDetailsArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/status`;
+        StatusDetailsArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getStatus(string idOrName) returns StatusDetails|error {
-        string  path = string `/rest/api/2/status/${idOrName}`;
-        StatusDetails response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/status/${idOrName}`;
+        StatusDetails response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getStatusCategories() returns StatusCategoryArr|error {
-        string  path = string `/rest/api/2/statuscategory`;
-        StatusCategoryArr response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/statuscategory`;
+        StatusCategoryArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getStatusCategory(string idOrKey) returns StatusCategory|error {
-        string  path = string `/rest/api/2/statuscategory/${idOrKey}`;
-        StatusCategory response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/statuscategory/${idOrKey}`;
+        StatusCategory response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getTask(string taskId) returns TaskProgressBeanObject|error {
-        string  path = string `/rest/api/2/task/${taskId}`;
-        TaskProgressBeanObject response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/task/${taskId}`;
+        TaskProgressBeanObject response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function cancelTask(string taskId) returns json|error {
-        string  path = string `/rest/api/2/task/${taskId}/cancel`;
+        string resourcePath = string `/rest/api/2/task/${taskId}/cancel`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> post(path, request);
+        json response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     remote isolated function getAvatars(string 'type, string entityId) returns Avatars|error {
-        string  path = string `/rest/api/2/universal_avatar/'type/${'type}/owner/${entityId}`;
-        Avatars response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/universal_avatar/'type/${'type}/owner/${entityId}`;
+        Avatars response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function storeAvatar(string 'type, string entityId, int? x, int? y, int size, json payload) returns Avatar|error {
-        string  path = string `/rest/api/2/universal_avatar/'type/${'type}/owner/${entityId}`;
+        string resourcePath = string `/rest/api/2/universal_avatar/'type/${'type}/owner/${entityId}`;
         map<anydata> queryParam = {x: x, y: y, size: size};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
-        Avatar response = check self.clientEp->post(path, request);
+        Avatar response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function deleteAvatar(string 'type, string owningObjectId, int id) returns http:Response | error {
-        string  path = string `/rest/api/2/universal_avatar/'type/${'type}/owner/${owningObjectId}/avatar/${id}`;
+        string resourcePath = string `/rest/api/2/universal_avatar/'type/${'type}/owner/${owningObjectId}/avatar/${id}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getUser(string? accountId, string? username, string? 'key, string? expand) returns User|error {
-        string  path = string `/rest/api/2/user`;
+        string resourcePath = string `/rest/api/2/user`;
         map<anydata> queryParam = {accountId: accountId, username: username, 'key: 'key, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        User response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createUser(UserWriteBean payload) returns User|error {
-        string  path = string `/rest/api/2/user`;
+        string resourcePath = string `/rest/api/2/user`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        User response = check self.clientEp->post(path, request);
+        User response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function removeUser(string accountId, string? username, string? 'key) returns http:Response | error {
-        string  path = string `/rest/api/2/user`;
+        string resourcePath = string `/rest/api/2/user`;
         map<anydata> queryParam = {accountId: accountId, username: username, 'key: 'key};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function findBulkAssignableUsers(string? query, string? username, string? accountId, string projectKeys, int? startAt, int? maxResults) returns UserArr|error {
-        string  path = string `/rest/api/2/user/assignable/multiProjectSearch`;
+        string resourcePath = string `/rest/api/2/user/assignable/multiProjectSearch`;
         map<anydata> queryParam = {query: query, username: username, accountId: accountId, projectKeys: projectKeys, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        UserArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        UserArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function findAssignableUsers(string? query, string? sessionId, string? username, string? accountId, string? project, string? issueKey, int? startAt, int? maxResults, int? actionDescriptorId, boolean? recommend) returns UserArr|error {
-        string  path = string `/rest/api/2/user/assignable/search`;
+        string resourcePath = string `/rest/api/2/user/assignable/search`;
         map<anydata> queryParam = {query: query, sessionId: sessionId, username: username, accountId: accountId, project: project, issueKey: issueKey, startAt: startAt, maxResults: maxResults, actionDescriptorId: actionDescriptorId, recommend: recommend};
-        path = path + check getPathForQueryParam(queryParam);
-        UserArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        UserArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function bulkGetUsers(int? startAt, int? maxResults, string[]? username, string[]? 'key, string[] accountId) returns PageBeanUser|error {
-        string  path = string `/rest/api/2/user/bulk`;
+        string resourcePath = string `/rest/api/2/user/bulk`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, username: username, 'key: 'key, accountId: accountId};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanUser response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanUser response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function bulkGetUsersMigration(int? startAt, int? maxResults, string[]? username, string[]? 'key) returns UserMigrationBeanArr|error {
-        string  path = string `/rest/api/2/user/bulk/migration`;
+        string resourcePath = string `/rest/api/2/user/bulk/migration`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, username: username, 'key: 'key};
-        path = path + check getPathForQueryParam(queryParam);
-        UserMigrationBeanArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        UserMigrationBeanArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getUserDefaultColumns(string? accountId, string? username) returns ColumnItemArr|error {
-        string  path = string `/rest/api/2/user/columns`;
+        string resourcePath = string `/rest/api/2/user/columns`;
         map<anydata> queryParam = {accountId: accountId, username: username};
-        path = path + check getPathForQueryParam(queryParam);
-        ColumnItemArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ColumnItemArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setUserColumns(string? accountId, [] payload) returns json|error {
-        string  path = string `/rest/api/2/user/columns`;
+        string resourcePath = string `/rest/api/2/user/columns`;
         map<anydata> queryParam = {accountId: accountId};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function resetUserColumns(string? accountId, string? username) returns http:Response | error {
-        string  path = string `/rest/api/2/user/columns`;
+        string resourcePath = string `/rest/api/2/user/columns`;
         map<anydata> queryParam = {accountId: accountId, username: username};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getUserEmail(string accountId) returns UnrestrictedUserEmail|error {
-        string  path = string `/rest/api/2/user/email`;
+        string resourcePath = string `/rest/api/2/user/email`;
         map<anydata> queryParam = {accountId: accountId};
-        path = path + check getPathForQueryParam(queryParam);
-        UnrestrictedUserEmail response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        UnrestrictedUserEmail response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getUserEmailBulk(string[] accountId) returns UnrestrictedUserEmail|error {
-        string  path = string `/rest/api/2/user/email/bulk`;
+        string resourcePath = string `/rest/api/2/user/email/bulk`;
         map<anydata> queryParam = {accountId: accountId};
-        path = path + check getPathForQueryParam(queryParam);
-        UnrestrictedUserEmail response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        UnrestrictedUserEmail response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getUserGroups(string accountId, string? username, string? 'key) returns GroupNameArr|error {
-        string  path = string `/rest/api/2/user/groups`;
+        string resourcePath = string `/rest/api/2/user/groups`;
         map<anydata> queryParam = {accountId: accountId, username: username, 'key: 'key};
-        path = path + check getPathForQueryParam(queryParam);
-        GroupNameArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        GroupNameArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function findUsersWithAllPermissions(string? query, string? username, string? accountId, string permissions, string? issueKey, string? projectKey, int? startAt, int? maxResults) returns UserArr|error {
-        string  path = string `/rest/api/2/user/permission/search`;
+        string resourcePath = string `/rest/api/2/user/permission/search`;
         map<anydata> queryParam = {query: query, username: username, accountId: accountId, permissions: permissions, issueKey: issueKey, projectKey: projectKey, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        UserArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        UserArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function findUsersForPicker(string query, int? maxResults, boolean? showAvatar, string[]? exclude, string[]? excludeAccountIds, string? avatarSize, boolean? excludeConnectUsers) returns FoundUsers|error {
-        string  path = string `/rest/api/2/user/picker`;
+        string resourcePath = string `/rest/api/2/user/picker`;
         map<anydata> queryParam = {query: query, maxResults: maxResults, showAvatar: showAvatar, exclude: exclude, excludeAccountIds: excludeAccountIds, avatarSize: avatarSize, excludeConnectUsers: excludeConnectUsers};
-        path = path + check getPathForQueryParam(queryParam);
-        FoundUsers response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        FoundUsers response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getUserPropertyKeys(string? accountId, string? userKey, string? username) returns PropertyKeys|error {
-        string  path = string `/rest/api/2/user/properties`;
+        string resourcePath = string `/rest/api/2/user/properties`;
         map<anydata> queryParam = {accountId: accountId, userKey: userKey, username: username};
-        path = path + check getPathForQueryParam(queryParam);
-        PropertyKeys response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PropertyKeys response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getUserProperty(string? accountId, string? userKey, string? username, string propertyKey) returns EntityProperty|error {
-        string  path = string `/rest/api/2/user/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/user/properties/${propertyKey}`;
         map<anydata> queryParam = {accountId: accountId, userKey: userKey, username: username};
-        path = path + check getPathForQueryParam(queryParam);
-        EntityProperty response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        EntityProperty response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setUserProperty(string? accountId, string? userKey, string? username, string propertyKey, json payload) returns json|error {
-        string  path = string `/rest/api/2/user/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/user/properties/${propertyKey}`;
         map<anydata> queryParam = {accountId: accountId, userKey: userKey, username: username};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteUserProperty(string? accountId, string? userKey, string? username, string propertyKey) returns http:Response | error {
-        string  path = string `/rest/api/2/user/properties/${propertyKey}`;
+        string resourcePath = string `/rest/api/2/user/properties/${propertyKey}`;
         map<anydata> queryParam = {accountId: accountId, userKey: userKey, username: username};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function findUsers(string? query, string? username, string? accountId, int? startAt, int? maxResults, string? property) returns UserArr|error {
-        string  path = string `/rest/api/2/user/search`;
+        string resourcePath = string `/rest/api/2/user/search`;
         map<anydata> queryParam = {query: query, username: username, accountId: accountId, startAt: startAt, maxResults: maxResults, property: property};
-        path = path + check getPathForQueryParam(queryParam);
-        UserArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        UserArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function findUsersByQuery(string query, int? startAt, int? maxResults) returns PageBeanUser|error {
-        string  path = string `/rest/api/2/user/search/query`;
+        string resourcePath = string `/rest/api/2/user/search/query`;
         map<anydata> queryParam = {query: query, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanUser response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanUser response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function findUserKeysByQuery(string query, int? startAt, int? maxResults) returns PageBeanUserKey|error {
-        string  path = string `/rest/api/2/user/search/query/key`;
+        string resourcePath = string `/rest/api/2/user/search/query/key`;
         map<anydata> queryParam = {query: query, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanUserKey response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanUserKey response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function findUsersWithBrowsePermission(string? query, string? username, string? accountId, string? issueKey, string? projectKey, int? startAt, int? maxResults) returns UserArr|error {
-        string  path = string `/rest/api/2/user/viewissue/search`;
+        string resourcePath = string `/rest/api/2/user/viewissue/search`;
         map<anydata> queryParam = {query: query, username: username, accountId: accountId, issueKey: issueKey, projectKey: projectKey, startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        UserArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        UserArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllUsersDefault(int? startAt, int? maxResults) returns UserArr|error {
-        string  path = string `/rest/api/2/users`;
+        string resourcePath = string `/rest/api/2/users`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        UserArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        UserArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getAllUsers(int? startAt, int? maxResults) returns UserArr|error {
-        string  path = string `/rest/api/2/users/search`;
+        string resourcePath = string `/rest/api/2/users/search`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        UserArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        UserArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createVersion(Version payload) returns Version|error {
-        string  path = string `/rest/api/2/version`;
+        string resourcePath = string `/rest/api/2/version`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Version response = check self.clientEp->post(path, request);
+        Version response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getVersion(string id, string? expand) returns Version|error {
-        string  path = string `/rest/api/2/version/${id}`;
+        string resourcePath = string `/rest/api/2/version/${id}`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        Version response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Version response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateVersion(string id, Version payload) returns Version|error {
-        string  path = string `/rest/api/2/version/${id}`;
+        string resourcePath = string `/rest/api/2/version/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Version response = check self.clientEp->put(path, request);
+        Version response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteVersion(string id, string? moveFixIssuesTo, string? moveAffectedIssuesTo) returns http:Response | error {
-        string  path = string `/rest/api/2/version/${id}`;
+        string resourcePath = string `/rest/api/2/version/${id}`;
         map<anydata> queryParam = {moveFixIssuesTo: moveFixIssuesTo, moveAffectedIssuesTo: moveAffectedIssuesTo};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function mergeVersions(string id, string moveIssuesTo) returns json|error {
-        string  path = string `/rest/api/2/version/${id}/mergeto/${moveIssuesTo}`;
+        string resourcePath = string `/rest/api/2/version/${id}/mergeto/${moveIssuesTo}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        json response = check self.clientEp-> put(path, request);
+        json response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     remote isolated function moveVersion(string id, VersionMoveBean payload) returns Version|error {
-        string  path = string `/rest/api/2/version/${id}/move`;
+        string resourcePath = string `/rest/api/2/version/${id}/move`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        Version response = check self.clientEp->post(path, request);
+        Version response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getVersionRelatedIssues(string id) returns VersionIssueCounts|error {
-        string  path = string `/rest/api/2/version/${id}/relatedIssueCounts`;
-        VersionIssueCounts response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/version/${id}/relatedIssueCounts`;
+        VersionIssueCounts response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function deleteAndReplaceVersion(string id, DeleteAndReplaceVersionBean payload) returns json|error {
-        string  path = string `/rest/api/2/version/${id}/removeAndSwap`;
+        string resourcePath = string `/rest/api/2/version/${id}/removeAndSwap`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->post(path, request);
+        json response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getVersionUnresolvedIssues(string id) returns VersionUnresolvedIssuesCount|error {
-        string  path = string `/rest/api/2/version/${id}/unresolvedIssueCount`;
-        VersionUnresolvedIssuesCount response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/version/${id}/unresolvedIssueCount`;
+        VersionUnresolvedIssuesCount response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getDynamicWebhooksForApp(int? startAt, int? maxResults) returns PageBeanWebhook|error {
-        string  path = string `/rest/api/2/webhook`;
+        string resourcePath = string `/rest/api/2/webhook`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanWebhook response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanWebhook response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function registerDynamicWebhooks(WebhookRegistrationDetails payload) returns ContainerForRegisteredWebhooks|error {
-        string  path = string `/rest/api/2/webhook`;
+        string resourcePath = string `/rest/api/2/webhook`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        ContainerForRegisteredWebhooks response = check self.clientEp->post(path, request);
+        ContainerForRegisteredWebhooks response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function deleteWebhookById() returns http:Response | error {
-        string  path = string `/rest/api/2/webhook`;
+        string resourcePath = string `/rest/api/2/webhook`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getFailedWebhooks(int? maxResults, int? after) returns FailedWebhooks|error {
-        string  path = string `/rest/api/2/webhook/failed`;
+        string resourcePath = string `/rest/api/2/webhook/failed`;
         map<anydata> queryParam = {maxResults: maxResults, after: after};
-        path = path + check getPathForQueryParam(queryParam);
-        FailedWebhooks response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        FailedWebhooks response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function refreshWebhooks(ContainerForWebhookIDs payload) returns WebhooksExpirationDate|error {
-        string  path = string `/rest/api/2/webhook/refresh`;
+        string resourcePath = string `/rest/api/2/webhook/refresh`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WebhooksExpirationDate response = check self.clientEp->put(path, request);
+        WebhooksExpirationDate response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getAllWorkflows(string? workflowName) returns DeprecatedWorkflowArr|error {
-        string  path = string `/rest/api/2/workflow`;
+        string resourcePath = string `/rest/api/2/workflow`;
         map<anydata> queryParam = {workflowName: workflowName};
-        path = path + check getPathForQueryParam(queryParam);
-        DeprecatedWorkflowArr response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        DeprecatedWorkflowArr response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createWorkflow(CreateWorkflowDetails payload) returns WorkflowIDs|error {
-        string  path = string `/rest/api/2/workflow`;
+        string resourcePath = string `/rest/api/2/workflow`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowIDs response = check self.clientEp->post(path, request);
+        WorkflowIDs response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getWorkflowTransitionRuleConfigurations(int? startAt, int? maxResults, string[] types, string[]? keys, string? expand) returns PageBeanWorkflowTransitionRules|error {
-        string  path = string `/rest/api/2/workflow/rule/config`;
+        string resourcePath = string `/rest/api/2/workflow/rule/config`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, types: types, keys: keys, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanWorkflowTransitionRules response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanWorkflowTransitionRules response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateWorkflowTransitionRuleConfigurations(WorkflowTransitionRulesUpdate payload) returns WorkflowTransitionRulesUpdateErrors|error {
-        string  path = string `/rest/api/2/workflow/rule/config`;
+        string resourcePath = string `/rest/api/2/workflow/rule/config`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowTransitionRulesUpdateErrors response = check self.clientEp->put(path, request);
+        WorkflowTransitionRulesUpdateErrors response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getWorkflowsPaginated(int? startAt, int? maxResults, string[]? workflowName, string? expand) returns PageBeanWorkflow|error {
-        string  path = string `/rest/api/2/workflow/search`;
+        string resourcePath = string `/rest/api/2/workflow/search`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults, workflowName: workflowName, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanWorkflow response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanWorkflow response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getWorkflowTransitionProperties(int transitionId, boolean? includeReservedKeys, string? 'key, string workflowName, string? workflowMode) returns WorkflowTransitionProperty|error {
-        string  path = string `/rest/api/2/workflow/transitions/${transitionId}/properties`;
+        string resourcePath = string `/rest/api/2/workflow/transitions/${transitionId}/properties`;
         map<anydata> queryParam = {includeReservedKeys: includeReservedKeys, 'key: 'key, workflowName: workflowName, workflowMode: workflowMode};
-        path = path + check getPathForQueryParam(queryParam);
-        WorkflowTransitionProperty response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        WorkflowTransitionProperty response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateWorkflowTransitionProperty(int transitionId, string 'key, string workflowName, string? workflowMode, WorkflowTransitionProperty payload) returns WorkflowTransitionProperty|error {
-        string  path = string `/rest/api/2/workflow/transitions/${transitionId}/properties`;
+        string resourcePath = string `/rest/api/2/workflow/transitions/${transitionId}/properties`;
         map<anydata> queryParam = {'key: 'key, workflowName: workflowName, workflowMode: workflowMode};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowTransitionProperty response = check self.clientEp->put(path, request);
+        WorkflowTransitionProperty response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function createWorkflowTransitionProperty(int transitionId, string 'key, string workflowName, string? workflowMode, WorkflowTransitionProperty payload) returns WorkflowTransitionProperty|error {
-        string  path = string `/rest/api/2/workflow/transitions/${transitionId}/properties`;
+        string resourcePath = string `/rest/api/2/workflow/transitions/${transitionId}/properties`;
         map<anydata> queryParam = {'key: 'key, workflowName: workflowName, workflowMode: workflowMode};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowTransitionProperty response = check self.clientEp->post(path, request);
+        WorkflowTransitionProperty response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function deleteWorkflowTransitionProperty(int transitionId, string 'key, string workflowName, string? workflowMode) returns http:Response | error {
-        string  path = string `/rest/api/2/workflow/transitions/${transitionId}/properties`;
+        string resourcePath = string `/rest/api/2/workflow/transitions/${transitionId}/properties`;
         map<anydata> queryParam = {'key: 'key, workflowName: workflowName, workflowMode: workflowMode};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function deleteInactiveWorkflow(string entityId) returns http:Response | error {
-        string  path = string `/rest/api/2/workflow/${entityId}`;
+        string resourcePath = string `/rest/api/2/workflow/${entityId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getAllWorkflowSchemes(int? startAt, int? maxResults) returns PageBeanWorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme`;
+        string resourcePath = string `/rest/api/2/workflowscheme`;
         map<anydata> queryParam = {startAt: startAt, maxResults: maxResults};
-        path = path + check getPathForQueryParam(queryParam);
-        PageBeanWorkflowScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PageBeanWorkflowScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function createWorkflowScheme(WorkflowScheme payload) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme`;
+        string resourcePath = string `/rest/api/2/workflowscheme`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowScheme response = check self.clientEp->post(path, request);
+        WorkflowScheme response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getWorkflowSchemeProjectAssociations(int[] projectId) returns ContainerOfWorkflowSchemeAssociations|error {
-        string  path = string `/rest/api/2/workflowscheme/project`;
+        string resourcePath = string `/rest/api/2/workflowscheme/project`;
         map<anydata> queryParam = {projectId: projectId};
-        path = path + check getPathForQueryParam(queryParam);
-        ContainerOfWorkflowSchemeAssociations response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ContainerOfWorkflowSchemeAssociations response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function assignSchemeToProject(WorkflowSchemeProjectAssociation payload) returns json|error {
-        string  path = string `/rest/api/2/workflowscheme/project`;
+        string resourcePath = string `/rest/api/2/workflowscheme/project`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        json response = check self.clientEp->put(path, request);
+        json response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function getWorkflowScheme(int id, boolean? returnDraftIfExists) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}`;
         map<anydata> queryParam = {returnDraftIfExists: returnDraftIfExists};
-        path = path + check getPathForQueryParam(queryParam);
-        WorkflowScheme response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        WorkflowScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateWorkflowScheme(int id, WorkflowScheme payload) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowScheme response = check self.clientEp->put(path, request);
+        WorkflowScheme response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteWorkflowScheme(int id) returns http:Response | error {
-        string  path = string `/rest/api/2/workflowscheme/${id}`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function createWorkflowSchemeDraftFromParent(int id) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/createdraft`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/createdraft`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        WorkflowScheme response = check self.clientEp-> post(path, request);
+        WorkflowScheme response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     remote isolated function getDefaultWorkflow(int id, boolean? returnDraftIfExists) returns DefaultWorkflow|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/default`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/default`;
         map<anydata> queryParam = {returnDraftIfExists: returnDraftIfExists};
-        path = path + check getPathForQueryParam(queryParam);
-        DefaultWorkflow response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        DefaultWorkflow response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateDefaultWorkflow(int id, DefaultWorkflow payload) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/default`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/default`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowScheme response = check self.clientEp->put(path, request);
+        WorkflowScheme response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteDefaultWorkflow(int id, boolean? updateDraftIfNeeded) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/default`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/default`;
         map<anydata> queryParam = {updateDraftIfNeeded: updateDraftIfNeeded};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        WorkflowScheme response = check self.clientEp-> delete(path, request);
+        WorkflowScheme response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function getWorkflowSchemeDraft(int id) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft`;
-        WorkflowScheme response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft`;
+        WorkflowScheme response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateWorkflowSchemeDraft(int id, WorkflowScheme payload) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowScheme response = check self.clientEp->put(path, request);
+        WorkflowScheme response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteWorkflowSchemeDraft(int id) returns http:Response | error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getDraftDefaultWorkflow(int id) returns DefaultWorkflow|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft/default`;
-        DefaultWorkflow response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft/default`;
+        DefaultWorkflow response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateDraftDefaultWorkflow(int id, DefaultWorkflow payload) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft/default`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft/default`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowScheme response = check self.clientEp->put(path, request);
+        WorkflowScheme response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteDraftDefaultWorkflow(int id) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft/default`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft/default`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        WorkflowScheme response = check self.clientEp-> delete(path, request);
+        WorkflowScheme response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function getWorkflowSchemeDraftIssueType(int id, string issueType) returns IssueTypeWorkflowMapping|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft/issuetype/${issueType}`;
-        IssueTypeWorkflowMapping response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft/issuetype/${issueType}`;
+        IssueTypeWorkflowMapping response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setWorkflowSchemeDraftIssueType(int id, string issueType, IssueTypeWorkflowMapping payload) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft/issuetype/${issueType}`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft/issuetype/${issueType}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowScheme response = check self.clientEp->put(path, request);
+        WorkflowScheme response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteWorkflowSchemeDraftIssueType(int id, string issueType) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft/issuetype/${issueType}`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft/issuetype/${issueType}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        WorkflowScheme response = check self.clientEp-> delete(path, request);
+        WorkflowScheme response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function getDraftWorkflow(int id, string? workflowName) returns IssueTypesWorkflowMapping|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft/workflow`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft/workflow`;
         map<anydata> queryParam = {workflowName: workflowName};
-        path = path + check getPathForQueryParam(queryParam);
-        IssueTypesWorkflowMapping response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        IssueTypesWorkflowMapping response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateDraftWorkflowMapping(int id, string workflowName, IssueTypesWorkflowMapping payload) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft/workflow`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft/workflow`;
         map<anydata> queryParam = {workflowName: workflowName};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowScheme response = check self.clientEp->put(path, request);
+        WorkflowScheme response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteDraftWorkflowMapping(int id, string workflowName) returns http:Response | error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/draft/workflow`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/draft/workflow`;
         map<anydata> queryParam = {workflowName: workflowName};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getWorkflowSchemeIssueType(int id, string issueType, boolean? returnDraftIfExists) returns IssueTypeWorkflowMapping|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/issuetype/${issueType}`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/issuetype/${issueType}`;
         map<anydata> queryParam = {returnDraftIfExists: returnDraftIfExists};
-        path = path + check getPathForQueryParam(queryParam);
-        IssueTypeWorkflowMapping response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        IssueTypeWorkflowMapping response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function setWorkflowSchemeIssueType(int id, string issueType, IssueTypeWorkflowMapping payload) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/issuetype/${issueType}`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/issuetype/${issueType}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowScheme response = check self.clientEp->put(path, request);
+        WorkflowScheme response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteWorkflowSchemeIssueType(int id, string issueType, boolean? updateDraftIfNeeded) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/issuetype/${issueType}`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/issuetype/${issueType}`;
         map<anydata> queryParam = {updateDraftIfNeeded: updateDraftIfNeeded};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        WorkflowScheme response = check self.clientEp-> delete(path, request);
+        WorkflowScheme response = check self.clientEp-> delete(resourcePath, request);
         return response;
     }
     remote isolated function getWorkflow(int id, string? workflowName, boolean? returnDraftIfExists) returns IssueTypesWorkflowMapping|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/workflow`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/workflow`;
         map<anydata> queryParam = {workflowName: workflowName, returnDraftIfExists: returnDraftIfExists};
-        path = path + check getPathForQueryParam(queryParam);
-        IssueTypesWorkflowMapping response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        IssueTypesWorkflowMapping response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function updateWorkflowMapping(int id, string workflowName, IssueTypesWorkflowMapping payload) returns WorkflowScheme|error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/workflow`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/workflow`;
         map<anydata> queryParam = {workflowName: workflowName};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorkflowScheme response = check self.clientEp->put(path, request);
+        WorkflowScheme response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function deleteWorkflowMapping(int id, string workflowName, boolean? updateDraftIfNeeded) returns http:Response | error {
-        string  path = string `/rest/api/2/workflowscheme/${id}/workflow`;
+        string resourcePath = string `/rest/api/2/workflowscheme/${id}/workflow`;
         map<anydata> queryParam = {workflowName: workflowName, updateDraftIfNeeded: updateDraftIfNeeded};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function getIdsOfWorklogsDeletedSince(int? since) returns ChangedWorklogs|error {
-        string  path = string `/rest/api/2/worklog/deleted`;
+        string resourcePath = string `/rest/api/2/worklog/deleted`;
         map<anydata> queryParam = {since: since};
-        path = path + check getPathForQueryParam(queryParam);
-        ChangedWorklogs response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ChangedWorklogs response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function getWorklogsForIds(string? expand, WorklogIdsRequestBean payload) returns WorklogArr|error {
-        string  path = string `/rest/api/2/worklog/list`;
+        string resourcePath = string `/rest/api/2/worklog/list`;
         map<anydata> queryParam = {expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        WorklogArr response = check self.clientEp->post(path, request);
+        WorklogArr response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function getIdsOfWorklogsModifiedSince(int? since, string? expand) returns ChangedWorklogs|error {
-        string  path = string `/rest/api/2/worklog/updated`;
+        string resourcePath = string `/rest/api/2/worklog/updated`;
         map<anydata> queryParam = {since: since, expand: expand};
-        path = path + check getPathForQueryParam(queryParam);
-        ChangedWorklogs response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        ChangedWorklogs response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function 'AddonPropertiesResource\.getAddonProperties\_get(string addonKey) returns PropertyKeys|error {
-        string  path = string `/rest/atlassian-connect/1/addons/${addonKey}/properties`;
-        PropertyKeys response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/atlassian-connect/1/addons/${addonKey}/properties`;
+        PropertyKeys response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function 'AddonPropertiesResource\.getAddonProperty\_get(string addonKey, string propertyKey) returns EntityProperty|error {
-        string  path = string `/rest/atlassian-connect/1/addons/${addonKey}/properties/${propertyKey}`;
-        EntityProperty response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/atlassian-connect/1/addons/${addonKey}/properties/${propertyKey}`;
+        EntityProperty response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function 'AddonPropertiesResource\.putAddonProperty\_put(string addonKey, string propertyKey, json payload) returns OperationMessage|error {
-        string  path = string `/rest/atlassian-connect/1/addons/${addonKey}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/atlassian-connect/1/addons/${addonKey}/properties/${propertyKey}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        OperationMessage response = check self.clientEp->put(path, request);
+        OperationMessage response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     remote isolated function 'AddonPropertiesResource\.deleteAddonProperty\_delete(string addonKey, string propertyKey) returns http:Response | error {
-        string  path = string `/rest/atlassian-connect/1/addons/${addonKey}/properties/${propertyKey}`;
+        string resourcePath = string `/rest/atlassian-connect/1/addons/${addonKey}/properties/${propertyKey}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
     remote isolated function 'DynamicModulesResource\.getModules\_get() returns ConnectModules|error {
-        string  path = string `/rest/atlassian-connect/1/app/module/dynamic`;
-        ConnectModules response = check self.clientEp-> get(path);
+        string resourcePath = string `/rest/atlassian-connect/1/app/module/dynamic`;
+        ConnectModules response = check self.clientEp-> get(resourcePath);
         return response;
     }
     remote isolated function 'DynamicModulesResource\.registerModules\_post(ConnectModules payload) returns http:Response | error {
-        string  path = string `/rest/atlassian-connect/1/app/module/dynamic`;
+        string resourcePath = string `/rest/atlassian-connect/1/app/module/dynamic`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody, "application/json");
-        http:Response  response = check self.clientEp->post(path, request);
+        http:Response  response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     remote isolated function 'DynamicModulesResource\.removeModules\_delete(string[]? moduleKey) returns http:Response | error {
-        string  path = string `/rest/atlassian-connect/1/app/module/dynamic`;
+        string resourcePath = string `/rest/atlassian-connect/1/app/module/dynamic`;
         map<anydata> queryParam = {moduleKey: moduleKey};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response  response = check self.clientEp-> delete(path, request );
+        http:Response  response = check self.clientEp-> delete(resourcePath, request );
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/multiple_pathparam.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/multiple_pathparam.bal
@@ -18,8 +18,8 @@ public isolated client class Client {
     # + name - test
     # + return - Ok
     remote isolated function pathParameter(int 'version, string name) returns string|error {
-        string  path = string `/v1/${'version}/v2/${name}`;
-        string response = check self.clientEp-> get(path);
+        string resourcePath = string `/v1/${'version}/v2/${name}`;
+        string response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/openapi_weather_api.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/openapi_weather_api.bal
@@ -36,10 +36,10 @@ public isolated client class Client {
     # + return - Successful response
     @display {label: "Current Weather"}
     remote isolated function getCurretWeatherData(@display {label: "CityName or StateCode or CountryCode"} string? q = (), @display {label: "City Id"} string? id = (), @display {label: "Latitude"} string? lat = (), @display {label: "Longitude"} string? lon = (), @display {label: "Zip Code"} string? zip = (), @display {label: "Units"} string units = "imperial", @display {label: "Language"} string lang = "en", @display {label: "Mode"} string mode = "json") returns CurrentWeatherData|error {
-        string  path = string `/weather`;
+        string resourcePath = string `/weather`;
         map<anydata> queryParam = {"q": q, "id": id, "lat": lat, "lon": lon, "zip": zip, "units": units, "lang": lang, "mode": mode, "appid": self.apiKeyConfig.appid};
-        path = path + check getPathForQueryParam(queryParam);
-        CurrentWeatherData response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        CurrentWeatherData response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Provide weather forecast for any geographical coordinates
@@ -52,10 +52,10 @@ public isolated client class Client {
     # + return - Successful response
     @display {label: "Weather Forecast"}
     remote isolated function getWeatherForecast(@display {label: "Latitude"} string lat, @display {label: "Longtitude"} string lon, @display {label: "Exclude"} string? exclude = (), @display {label: "Units"} string? units = (), @display {label: "Language"} string? lang = ()) returns WeatherForecast|error {
-        string  path = string `/onecall`;
+        string resourcePath = string `/onecall`;
         map<anydata> queryParam = {"lat": lat, "lon": lon, "exclude": exclude, "units": units, "lang": lang, "appid": self.apiKeyConfig.appid};
-        path = path + check getPathForQueryParam(queryParam);
-        WeatherForecast response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        WeatherForecast response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/operation.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/operation.bal
@@ -17,8 +17,8 @@ public isolated client class Client {
     #
     #+return-Default response with array of strings
     remote isolated function getCountryList() returns CountryInfo[]|error {
-        string  path = string `/api/v1/countries/list/`;
-        CountryInfo[] response = check self.clientEp-> get(path);
+        string resourcePath = string `/api/v1/countries/list/`;
+        CountryInfo[] response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/tag.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/tag.bal
@@ -17,8 +17,8 @@ public isolated client class Client {
     #
     #+return-A list of countries with all informtion included.
     remote isolated function getCovidinAllCountries() returns Countries[]|error {
-        string  path = string `/api`;
-        Countries[] response = check self.clientEp-> get(path);
+        string resourcePath = string `/api`;
+        Countries[] response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/uber_openapi.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/uber_openapi.bal
@@ -28,10 +28,10 @@ public isolated client class Client {
     # + longitude - Longitude component of location.
     # + return - An array of products
     remote isolated function getProducts(float latitude, float longitude) returns Product[]|error {
-        string  path = string `/products`;
+        string resourcePath = string `/products`;
         map<anydata> queryParam = {"latitude": latitude, "longitude": longitude, "server_token": self.apiKeyConfig.serverToken};
-        path = path + check getPathForQueryParam(queryParam);
-        Product[] response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Product[] response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Price Estimates
@@ -42,10 +42,10 @@ public isolated client class Client {
     # + endLongitude - Longitude component of end location.
     # + return - An array of price estimates by product
     remote isolated function getPrice(float startLatitude, float startLongitude, float endLatitude, float endLongitude) returns PriceEstimate[]|error {
-        string  path = string `/estimates/price`;
+        string resourcePath = string `/estimates/price`;
         map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "end_latitude": endLatitude, "end_longitude": endLongitude};
-        path = path + check getPathForQueryParam(queryParam);
-        PriceEstimate[] response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        PriceEstimate[] response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # Time Estimates
@@ -56,18 +56,18 @@ public isolated client class Client {
     # + productId - Unique identifier representing a specific product for a given latitude & longitude.
     # + return - An array of products
     remote isolated function getTimeEstimates(float startLatitude, float startLongitude, string? customerUuid = (), string? productId = ()) returns Product[]|error {
-        string  path = string `/estimates/time`;
+        string resourcePath = string `/estimates/time`;
         map<anydata> queryParam = {"start_latitude": startLatitude, "start_longitude": startLongitude, "customer_uuid": customerUuid, "product_id": productId};
-        path = path + check getPathForQueryParam(queryParam);
-        Product[] response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Product[] response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # User Profile
     #
     # + return - Profile information for a user
     remote isolated function getUserProfile() returns Profile|error {
-        string  path = string `/me`;
-        Profile response = check self.clientEp-> get(path);
+        string resourcePath = string `/me`;
+        Profile response = check self.clientEp-> get(resourcePath);
         return response;
     }
     # User Activity
@@ -76,10 +76,10 @@ public isolated client class Client {
     # + 'limit - Number of items to retrieve. Default is 5, maximum is 100.
     # + return - History information for the given user
     remote isolated function getUserActivity(int? offset = (), int? 'limit = ()) returns Activities|error {
-        string  path = string `/history`;
+        string resourcePath = string `/history`;
         map<anydata> queryParam = {"offset": offset, "limit": 'limit};
-        path = path + check getPathForQueryParam(queryParam);
-        Activities response = check self.clientEp-> get(path);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Activities response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/ballerina-platform/openapi-tools/issues/570

## Goals

Old Implementation
```bal
remote isolated function listPets(int? 'limit = ()) returns Pets|error {
        string path = string `/pets`;
        map<anydata> queryParam = {"limit": 'limit};
        path = path + check getPathForQueryParam(queryParam);
        Pets response = check self.clientEp-> get(path);
        return response;
    }
```

New Implementation
```bal
remote isolated function listPets(int? 'limit = ()) returns Pets|error {
        string resourcePath = string `/pets`;
        map<anydata> queryParam = {"limit": 'limit};
        resourcePath = **resourcePath** + check getPathForQueryParam(queryParam);
        Pets response = check self.clientEp-> get(resourcePath);
        return response;
    }
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
