### PR TITLE
[Client] Make target type `nillable` when 204 response is given along with other success responses 

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -151,6 +151,7 @@ public class GeneratorConstants {
     public static final String IMAGE_PNG = "image/png";
     public static final String MIME = "mime";
     public static final String HTTP_HEADERS = "httpHeaders";
+    public static final String ERROR = "error";
 
     // auth related constants
     public static final String API_KEY = "apikey";
@@ -296,4 +297,5 @@ public class GeneratorConstants {
     // OS specific line separator
     public static final String LINE_SEPARATOR = System.lineSeparator();
     public static final String DOUBLE_LINE_SEPARATOR = LINE_SEPARATOR + LINE_SEPARATOR;
+    public static final String DEFAULT_RETURN = HTTP_RESPONSE + "|" + ERROR;
 }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/FunctionBodyGenerator.java
@@ -108,6 +108,7 @@ import static io.ballerina.openapi.generators.GeneratorConstants.HEAD;
 import static io.ballerina.openapi.generators.GeneratorConstants.HEADER;
 import static io.ballerina.openapi.generators.GeneratorConstants.HEADER_VALUES;
 import static io.ballerina.openapi.generators.GeneratorConstants.HTTP_HEADERS;
+import static io.ballerina.openapi.generators.GeneratorConstants.NILLABLE;
 import static io.ballerina.openapi.generators.GeneratorConstants.PATCH;
 import static io.ballerina.openapi.generators.GeneratorConstants.POST;
 import static io.ballerina.openapi.generators.GeneratorConstants.PUT;
@@ -677,10 +678,7 @@ public class FunctionBodyGenerator {
         String returnType;
         int index = rType.lastIndexOf("|");
         returnType = rType.substring(0, index);
-        if (returnType.contains("|")) {
-            returnType = returnType.replaceAll("\\|", "");
-        }
-        return returnType;
+        return (rType.contains(NILLABLE) ? returnType + NILLABLE : returnType);
     }
 
     /**

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/BallerinaDiagnosticTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/BallerinaDiagnosticTests.java
@@ -75,7 +75,8 @@ public class BallerinaDiagnosticTests {
                 {"petstore_with_oneOf_response.yaml"},
                 {"response_nested_array.yaml"},
                 {"xml_payload.yaml"},
-                {"xml_payload_with_ref.yaml"}
+                {"xml_payload_with_ref.yaml"},
+                {"duplicated_response.yaml"}
         };
     }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/ComparedGeneratedFileTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/ComparedGeneratedFileTests.java
@@ -92,7 +92,10 @@ public class ComparedGeneratedFileTests {
                 {"uber_openapi.yaml", "uber_openapi.bal"},
                 {"multiple_pathparam.yaml", "multiple_pathparam.bal"},
                 {"display_annotation.yaml", "display_annotation.bal"},
-                {"api2pdf.yaml", "api2pdf.bal"}
+                {"api2pdf.yaml", "api2pdf.bal"},
+                {"nillable_response.yaml", "nillable_response.bal"},
+                {"nillable_union_response.yaml", "nillable_union_response.bal"},
+                {"duplicated_response.yaml", "duplicated_response.bal"}
         };
     }
 

--- a/openapi-cli/src/test/resources/generators/client/diagnostic_files/duplicated_response.yaml
+++ b/openapi-cli/src/test/resources/generators/client/diagnostic_files/duplicated_response.yaml
@@ -1,0 +1,39 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: https://petstore/v1
+    description: The production API server
+paths:
+  /pets:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      description: "Get pet details"
+      responses:
+        '200':
+          description: The status information is returned for the requested file upload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetDetails'
+        '202':
+          description: The status information is returned for the requested file upload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetDetails'
+        '204':
+          description: The status information cannot be retrieved for the specified request ID.
+          content: {}
+components:
+  schemas:
+    PetDetails:
+      properties:
+        name:
+          type: string
+        age:
+          type: string

--- a/openapi-cli/src/test/resources/generators/client/diagnostic_files/head_operation.yaml
+++ b/openapi-cli/src/test/resources/generators/client/diagnostic_files/head_operation.yaml
@@ -3,6 +3,7 @@ info:
   title: Azure Data Lake Storage
   description: Azure Data Lake Storage provides storage for Hadoop and other big data
     workloads.
+  version: 1.0.0
 servers:
   - url: https://azure.local/
 paths:

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/duplicated_response.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/duplicated_response.bal
@@ -1,0 +1,23 @@
+import ballerina/http;
+
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + clientConfig - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore/v1") returns error? {
+        http:Client httpEp = check new (serviceUrl, clientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Get a pet
+    #
+    # + return - The status information is returned for the requested file upload.
+    remote isolated function getPet() returns PetDetails|error? {
+        string path = string `/pets`;
+        PetDetails? response = check self.clientEp->get(path);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/nillable_response.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/nillable_response.bal
@@ -1,0 +1,23 @@
+import ballerina/http;
+
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + clientConfig - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
+        http:Client httpEp = check new (serviceUrl, clientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Get a pet
+    #
+    # + return - The status information is returned for the requested file upload.
+    remote isolated function getPet() returns PetDetails|error? {
+        string path = string `/pets`;
+        PetDetails? response = check self.clientEp->get(path);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/nillable_union_response.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/nillable_union_response.bal
@@ -1,0 +1,23 @@
+import ballerina/http;
+
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + clientConfig - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(http:ClientConfiguration clientConfig =  {}, string serviceUrl = "https://petstore/v1") returns error? {
+        http:Client httpEp = check new (serviceUrl, clientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Get a pet
+    #
+    # + return - The status information is returned for the requested file upload.
+    remote isolated function getPet() returns PetDetails02|PetDetails|error? {
+        string path = string `/pets`;
+        PetDetails02|PetDetails? response = check self.clientEp->get(path);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/file_provider/swagger/duplicated_response.yaml
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/swagger/duplicated_response.yaml
@@ -1,0 +1,38 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: https://petstore/v1
+    description: The production API server
+paths:
+  /pets:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      responses:
+        '200':
+          description: The status information is returned for the requested file upload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetDetails'
+        '202':
+          description: The status information is returned for the requested file upload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetDetails'
+        '204':
+          description: The status information cannot be retrieved for the specified request ID.
+          content: {}
+components:
+  schemas:
+    PetDetails:
+      properties:
+        name:
+          type: string
+        age:
+          type: string

--- a/openapi-cli/src/test/resources/generators/client/file_provider/swagger/nillable_response.yaml
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/swagger/nillable_response.yaml
@@ -1,0 +1,51 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      tags:
+        - pets
+      responses:
+        '200':
+          description: The status information is returned for the requested file upload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetDetails'
+        '204':
+          description: The status information cannot be retrieved for the specified request ID.
+          content: {}
+components:
+  schemas:
+    PetDetails:
+      properties:
+        name:
+          type: string
+        age:
+          type: string

--- a/openapi-cli/src/test/resources/generators/client/file_provider/swagger/nillable_union_response.yaml
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/swagger/nillable_union_response.yaml
@@ -1,0 +1,44 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: https://petstore/v1
+    description: The production API server
+paths:
+  /pets:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      responses:
+        '200':
+          description: The status information is returned for the requested file upload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetDetails'
+        '202':
+          description: The status information is returned for the requested file upload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetDetails02'
+        '204':
+          description: The status information cannot be retrieved for the specified request ID.
+          content: {}
+components:
+  schemas:
+    PetDetails:
+      properties:
+        name:
+          type: string
+        age:
+          type: string
+    PetDetails02:
+      properties:
+        name:
+          type: string
+        age:
+          type: string


### PR DESCRIPTION
## Purpose
> Consider all the success response scenarios
> Generate a `nillable` response if no content (ex: 204) response is given
> Resolves https://github.com/ballerina-platform/openapi-tools/issues/696

## Goals
**Scenario 1 - Only 204 response is given**
Sample OpenAPI file

```yaml
  /pets:
    get:
      summary: Get a pet
      operationId: getPet
      tags:
        - pets
      responses:
        '204':
          description: The status information cannot be retrieved for the specified request ID.
          content: {}
```
Generated remote function

```bal
    remote isolated function getPet() returns http:Response|error {
        string path = string `/pets`;
        http:Response response = check self.clientEp->get(path);
        return response;
    }
```
**Scenario 2 - 204 response is given along with other success responses**
Sample OpenAPI file

```yaml
  /pets:
    get:
      summary: Get a pet
      operationId: getPet
      tags:
        - pets
      responses:
        '200':
          description: The status information is returned for the requested file upload.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/PetDetails'
        '204':
          description: The status information cannot be retrieved for the specified request ID.
          content: {}
```
Generated remote function

```bal
    remote isolated function getPet() returns PetDetails|error? {
        string path = string `/pets`;
        PetDetails? response = check self.clientEp->get(path);
        return response;
    }
```
**Scenario 3 - Multiple responses with different schemas are given**

Sample OpenAPI file

```yaml
  /pets:
    get:
      summary: Get a pet
      operationId: getPet
      tags:
        - pets
      responses:
        '200':
          description: The status information is returned for the requested file upload.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/PetDetails'
         '202':
          description: The status information is returned for the requested file upload.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/DogDetails'
        '204':
          description: The status information cannot be retrieved for the specified request ID.
          content: {}
```
Generated remote function

```bal
    remote isolated function getPet() returns PetDetails|DogDetails|error? {
        string path = string `/pets`;
        PetDetails|DogDetails? response = check self.clientEp->get(path);
        return response;
    }
```
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes