### PR TITLE
[Client] Add tokenUrl by default for OAuth ClientCredintial

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -56,6 +56,7 @@ public class GeneratorConstants {
         BASIC("http:CredentialsConfig"),
         BEARER("http:BearerTokenConfig"),
         CLIENT_CREDENTIAL("http:OAuth2ClientCredentialsGrantConfig"),
+        CUSTOM_CLIENT_CREDENTIAL("OAuth2ClientCredentialsGrantConfig"),
         REFRESH_TOKEN("http:OAuth2RefreshTokenGrantConfig"),
         PASSWORD("http:OAuth2PasswordGrantConfig");
 

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/client/BallerinaClientGenerator.java
@@ -192,15 +192,8 @@ public class BallerinaClientGenerator {
                 , GeneratorConstants.HTTP);
         imports.add(importForHttp);
         List<ModuleMemberDeclarationNode> nodes =  new ArrayList<>();
-        if (openAPI.getComponents() != null && openAPI.getComponents().getSecuritySchemes() != null) {
-            // Add authentication related records to module member nodes
-            nodes.add(ballerinaAuthConfigGenerator.getConfigRecord(openAPI));
-            
-            // Add `AuthConfig` record if combination of ApiKey and HTTP/OAuth authentication is supported
-            if (ballerinaAuthConfigGenerator.isApiKey() && ballerinaAuthConfigGenerator.isHttpOROAuth()) {
-                nodes.add(ballerinaAuthConfigGenerator.getAuthConfigRecord());
-            }
-        }
+        // Add authentication related records
+        ballerinaAuthConfigGenerator.addAuthRelatedRecords(openAPI, nodes);
 
         // Add class definition node to module member nodes
         nodes.add(getClassDefinitionNode());

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/auth/OAuth2Tests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/auth/OAuth2Tests.java
@@ -91,7 +91,8 @@ public class OAuth2Tests {
     public Object[][] dataProvider() {
         return new Object[][]{
                 {"oauth2_authrization_code.yaml", TestConstants.OAUTH2_AUTHORIZATION_CODE_CONFIG_REC},
-                {"oauth2_client_credential.yaml", TestConstants.OAUTH2_CLIENT_CRED_CONFIG_REC},
+                {"oauth2_client_credential.yaml", TestConstants.OAUTH2_CUSTOM_CLIENT_CRED_CONFIG_REC},
+                {"oauth2_client_credential_without_tokenurl.yaml", TestConstants.OAUTH2_CLIENT_CRED_CONFIG_REC},
                 {"oauth2_implicit.yaml", TestConstants.OAUTH2_IMPLICIT_CONFIG_REC},
                 {"oauth2_password.yaml", TestConstants.OAUTH2_PASSWORD_CONFIG_REC},
                 {"oauth2_multipleflows.yaml", TestConstants.OAUTH2_MULTI_FLOWS_CONFIG_REC}

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/common/TestConstants.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/common/TestConstants.java
@@ -80,6 +80,11 @@ public class TestConstants {
             "public type ClientConfig record {|\n" +
             "   # Configurations related to client authentication\n" +
             "   http:OAuth2ClientCredentialsGrantConfig auth;\n" + commonClientConfigurationFields;
+    public static final String OAUTH2_CUSTOM_CLIENT_CRED_CONFIG_REC = "" +
+            clientConfigRecordDoc +
+            "public type ClientConfig record {|\n" +
+            "   # Configurations related to client authentication\n" +
+            "   OAuth2ClientCredentialsGrantConfig auth;\n" + commonClientConfigurationFields;
     public static final String OAUTH2_MULTI_FLOWS_CONFIG_REC = "" +
             clientConfigRecordDoc +
             "public type ClientConfig record {|\n" +

--- a/openapi-cli/src/test/resources/generators/client/auth/scenarios/oauth2/oauth2_client_credential_without_tokenurl.yaml
+++ b/openapi-cli/src/test/resources/generators/client/auth/scenarios/oauth2/oauth2_client_credential_without_tokenurl.yaml
@@ -1,0 +1,420 @@
+openapi: 3.0.0
+info:
+  title: Salesforce REST APIs
+  version: 0.1-oas3
+servers:
+  - url: https://{domain}/services/data
+    variables:
+      domain:
+        default: domain
+tags:
+  - name: Account
+    description: Represents an individual account, which is an organization or person involved with your business (such as customers, competitors, and partners).
+paths:
+  /{version}/sobjects/Account/{id}:
+    get:
+      tags:
+        - Account
+      summary: Get account information
+      operationId: getAccountById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: version
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            default: v48.0
+            enum:
+              - v47.0
+              - v48.0
+      responses:
+        "200":
+          description: "Status Okay"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Account_inner'
+        "400":
+          description: The request couldn’t be understood, usually because the JSON or XML body contains an error.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MessagewithErrorCode'
+        "401":
+          description: The session ID or OAuth token used has expired or is invalid. The response body contains the message and errorCode.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MessagewithErrorCode'
+      security:
+        - oAuth2ClientCredentials: []
+components:
+  schemas:
+    attributes:
+      required:
+        - type
+        - url
+      type: object
+      properties:
+        type:
+          type: string
+          description: the type of object.
+          example: Account
+        url:
+          type: string
+          description: The relative path of the object.
+          example: /services/data/v46.0/sobjects/Account/0010E00000Up3QGQAZ
+    address:
+      type: object
+      properties:
+        city:
+          type: string
+          example: Uden
+        country:
+          type: string
+          example: Netherlands
+        countryCode:
+          type: string
+          example: NL
+        geocodeAccuracy:
+          type: string
+        latitude:
+          type: string
+        longtitude:
+          type: string
+        postalCode:
+          type: string
+          example: 5405 BW
+        state:
+          type: string
+        stateCode:
+          type: string
+        street:
+          type: string
+          example: Jagersveld 15
+    MessagewithErrorCode:
+      type: array
+      items:
+        $ref: '#/components/schemas/MessagewithErrorCode_inner'
+    Account_inner:
+      required:
+        - Attributes
+        - Id
+        - Name
+      type: object
+      properties:
+        Attributes:
+          $ref: '#/components/schemas/attributes'
+        Id:
+          type: string
+          description: The Salesforce ID of the account
+          example: 0010E00000Up3QGQAZ
+        IsDeleted:
+          type: boolean
+          description: Indicates whether the object has been moved to the Recycle Bin (true) or not (false).
+          example: false
+        MasterRecordId:
+          type: string
+          description: If this object was deleted as the result of a merge, this field contains the ID of the record that was kept. If this object was deleted for any other reason, or has not been deleted, the value is null.
+        Name:
+          type: string
+          description: 'Name of the account. Maximum size is 255 characters. If the account has a record type of Person Account: This value is the concatenation of the FirstName, MiddleName, LastName, and Suffix of the associated person contact. You can''t modify this value.'
+          example: Klaas Vaak
+        LastName:
+          type: string
+          description: Last name of the account.
+          example: Vaak
+        FirstName:
+          type: string
+          description: First name of the account
+          example: Klaas
+        Salutation:
+          type: string
+          description: Honorific added to the name for use in letters, etc.
+          example: Mr.
+        MiddleName:
+          type: string
+          description: Middle name of the account.
+        Suffix:
+          type: string
+          description: Name suffix of the person for a person account. Maximum size is 40 characters.
+        Type:
+          type: string
+          description: Type of account, for example, Customer, Competitor, or Partner.
+          example: Customer
+        RecordTypeId:
+          type: string
+          description: Classification of the type of account. The record type influences the business process, picklist values and page layouts. The id references the record type which can correspond to business account or person account.
+          example: 0121i000000Y4jLAAS
+        ParentId:
+          type: string
+          description: ID of the parent object, if any.
+        BillingStreet:
+          type: string
+          description: Street address for the billing address of this account.
+          example: Jagersveld 15
+        BillingCity:
+          type: string
+          description: City for the billing address of this account.
+          example: Uden
+        BillingState:
+          type: string
+          description: State for the billing address of this account.
+        BillingPostalCode:
+          type: string
+          description: Postal code for the billing address of this account.
+          example: 5405 BW
+        BillingCountry:
+          type: string
+          description: Country for the billing address of this account.
+          example: the Netherlands
+        BillingStateCode:
+          type: string
+          description: Code of the state for the billing address of this account.
+        BillingCountryCode:
+          type: string
+          description: Country code for the billing address of this account.
+          example: NL
+        BillingLatitude:
+          type: string
+          description: 'Used with BillingLongitude to specify the precise geolocation of a billing address. Acceptable values are numbers between –90 and 90 with up to 15 decimal places. '
+        BillingLongitude:
+          type: string
+          description: 'Used with BillingLatitude to specify the precise geolocation of a billing address. Acceptable values are numbers between –180 and 180 with up to 15 decimal places. '
+        BillingGeocodeAccuracy:
+          type: string
+          description: Accuracy level of the geocode for the billing address. See Compound Field Considerations and Limitations for details on geolocation compound fields.
+        BillingAddress:
+          $ref: '#/components/schemas/address'
+        ShippingStreet:
+          type: string
+          description: 'The street address of the shipping address for this account. '
+          example: Jagersveld 15
+        ShippingCity:
+          type: string
+          description: 'City of the shipping address for this account. '
+          example: Uden
+        ShippingState:
+          type: string
+          description: 'State of the shipping address for this account. '
+        ShippingPostalCode:
+          type: string
+          description: 'Postal code of the shipping address for this account. '
+          example: 5405 BW
+        ShippingCountry:
+          type: string
+          description: 'Country of the shipping address for this account. '
+          example: the Netherlands
+        ShippingStateCode:
+          type: string
+          description: 'Code of the state of the shipping address for this account. '
+        ShippingCountryCode:
+          type: string
+          description: 'Country code of the shipping address for this account. '
+          example: NL
+        ShippingLatitude:
+          type: string
+          description: 'Used with ShippingLongitude to specify the precise geolocation of a shipping address. Acceptable values are numbers between –90 and 90 with up to 15 decimal places. '
+        ShippingLongitude:
+          type: string
+          description: 'Used with ShippingLatitude to specify the precise geolocation of an address. Acceptable values are numbers between –180 and 180 with up to 15 decimal places. '
+        ShippingGeocodeAccuracy:
+          type: string
+          description: Accuracy level of the geocode for the shipping address. See Compound Field Considerations and Limitations for details on geolocation compound fields.
+        ShippingAddress:
+          $ref: '#/components/schemas/address'
+        Phone:
+          type: string
+          description: 'Phone number of the account. '
+          example: "623456789"
+        Website:
+          type: string
+          description: The website of this account. Maximum of 255 characters.
+          example: https://www.swisssense.nl
+        PhotoUrl:
+          type: string
+          description: Path to be combined with the URL of a Salesforce instance (for example, https://yourInstance.salesforce.com/) to generate a URL to request the social network profile image associated with the account. Generated URL returns an HTTP redirect (code 302) to the social network profile image for the account. Blank if Social Accounts and Contacts isn't enabled for the organization or if Social Accounts and Contacts is disabled for the requesting user.
+          example: /services/images/photo/0010E00000XDEnHQAX
+        Industry:
+          type: string
+          description: An industry associated with this account. Maximum size is 40 characters.
+        NumberOfEmployees:
+          type: integer
+          description: Number of employees working at the company represented by this account. Maximum size is eight digits.
+        Description:
+          type: string
+          description: Text description of the account.
+          example: Sample Description
+        OwnerId:
+          type: string
+          description: 'The ID of the user who currently owns this account. '
+          example: 0051i000000kb4lAAA
+        CreatedDate:
+          type: string
+          description: 'Date and time when this record was created. '
+          format: rfc2822
+          example: 2019-09-04T13:49:25.000+0000
+        CreatedById:
+          type: string
+          description: 'ID of the User who created this record. '
+          example: 0051i000000kb4lAAA
+        LastModifiedDate:
+          type: string
+          description: 'Date and time when a user last modified this record. '
+          format: rfc2822
+          example: 2019-09-04T13:49:25.000+0000
+        LastModifiedById:
+          type: string
+          description: 'ID of the User who last updated this record. '
+          example: 0051i000000kb4lAAA
+        SystemModstamp:
+          type: string
+          description: 'Date and time when a user or automated process (such as a trigger) last modified this record. '
+          format: rfc2822
+          example: 2019-09-04T13:49:25.000+0000
+        LastActivityDate:
+          type: string
+          description: 'Value is one of the following, whichever is the most recent: Due date of the most recent event logged against the record. Due date of the most recently closed task associated with the record.'
+          format: rfc2822
+          example: 2019-09-04T13:49:25.000+0000
+        LastViewedDate:
+          type: string
+          description: The timestamp for when the current user last viewed this record or list view. If this value is null, this record or list view might only have been referenced (LastReferencedDate) and not viewed.
+          format: rfc2822
+          example: 2019-09-04T13:49:25.000+0000
+        LastReferencedDate:
+          type: string
+          description: The timestamp for when the current user last viewed a record related to this record or list view.
+          format: rfc2822
+          example: 2019-09-04T13:49:25.000+0000
+        PersonContactId:
+          type: string
+          description: The ID for the contact associated with this person account.
+          example: 0030E00000UkUPpQAN
+        IsPersonAccount:
+          type: boolean
+          description: Indicates whether this account has a record type of Person Account (true) or not (false).
+          example: true
+        PersonMailingStreet:
+          type: string
+          description: 'The mailing street address for this person account. '
+          example: Jagersveld 15
+        PersonMailingCity:
+          type: string
+          description: 'The city mailing address for this person account. '
+          example: Uden
+        PersonMailingState:
+          type: string
+          description: 'The state of the mailing address for this person account. '
+        PersonMailingPostalCode:
+          type: string
+          description: 'The postal code of the mailing address for this person account. '
+          example: 5405 BW
+        PersonMailingCountry:
+          type: string
+          description: 'The country of the mailing address for this person account. '
+          example: the Netherlands
+        PersonMailingStateCode:
+          type: string
+          description: 'The state code of the mailing address for this person account. '
+        PersonMailingCountryCode:
+          type: string
+          description: 'The country code of the mailing address for this person account. '
+          example: NL
+        PersonMailingLatitude:
+          type: string
+          description: 'Used with PersonMailingLongitude to specify the precise geolocation of a person account’s mailing address. Acceptable values are numbers between –90 and 90 with up to 15 decimal places. '
+        PersonMailingLongitude:
+          type: string
+          description: 'Used with PersonMailingLatitude to specify the precise geolocation of a person account’s mailing address. Acceptable values are numbers between –180 and 180 with up to 15 decimal places. '
+        PersonMailingGeocodeAccuracy:
+          type: string
+          description: Accuracy level of the geocode for the person’s mailing address. See Compound Field Considerations and Limitations for details on geolocation compound fields.
+        PersonMailingAddress:
+          $ref: '#/components/schemas/address'
+        PersonMobilePhone:
+          type: string
+          description: 'The mobile phone number for this person account. '
+          example: "623456789"
+        PersonEmail:
+          type: string
+          description: 'Email address for this person account. '
+        PersonTitle:
+          type: string
+          description: 'The person account’s title. '
+        PersonDepartment:
+          type: string
+          description: The department. Maximum size is 80 characters.
+        PersonBirthdate:
+          type: string
+          description: The birth date of the person account.
+          format: date
+          example: 1923-09-26
+        PersonLastCURequestDate:
+          type: string
+          description: The last date that this person account was requested.
+          format: rfc2822
+        PersonLastCUUpdateDate:
+          type: string
+          description: The last date a person account was updated.
+          format: rfc2822
+        PersonEmailBouncedReason:
+          type: string
+          description: If bounce management is activated and an email sent to the person account bounces, the reason the bounce occurred
+        PersonEmailBouncedDate:
+          type: string
+          description: If bounce management is activated and an email sent to the person account bounces, the date and time the bounce occurred.
+          format: rfc2822
+        PersonIndividualId:
+          type: string
+          description: ID of the data privacy record associated with this person’s account. This field is available if you enabled Data Protection and Privacy in Setup.
+        Jigsaw:
+          type: string
+          description: References the ID of a company in Data.com. If an account has a value in this field, it means that the account was imported from Data.com. If the field value is null, the account was not imported from Data.com. Maximum size is 20 characters. Available in API version 22.0 and later. Label is Data.com Key.The Jigsaw field is exposed in the API to support troubleshooting for import errors and reimporting of corrected data. Do not modify the value in the Jigsaw field.
+        JigsawCompanyId:
+          type: string
+        AccountSource:
+          type: string
+          description: The source of the account record. For example, Advertisement, Data.com, or Trade Show. The source is selected from a picklist of available values, which are set by an administrator. Each picklist value can have up to 40 characters.
+        SicDesc:
+          type: string
+          description: A brief description of an organization’s line of business, based on its SIC code. Maximum length is 80 characters.
+    MessagewithErrorCode_inner:
+      required:
+        - errorCode
+        - message
+      type: object
+      properties:
+        message:
+          type: string
+        errorCode:
+          type: string
+  responses: {}
+  parameters: {}
+  examples: {}
+  requestBodies: {}
+  headers: {}
+  securitySchemes:
+    oAuth2ClientCredentials:
+      type: oauth2
+      description: See salesforce.help.com
+      flows:
+        clientCredentials:
+          tokenUrl: ""
+          scopes: {}

--- a/openapi-cli/src/test/resources/generators/client/ballerina/combination_of_apikey_and_http_oauth.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/combination_of_apikey_and_http_oauth.bal
@@ -11,7 +11,14 @@ public type ApiKeysConfig record {|
 # Provides Auth configurations needed when communicating with a remote HTTP endpoint.
 public type AuthConfig record {|
     # Auth Configuration
-    http:OAuth2ClientCredentialsGrantConfig|http:BearerTokenConfig|http:OAuth2RefreshTokenGrantConfig|ApiKeysConfig auth;
+    OAuth2ClientCredentialsGrantConfig|http:BearerTokenConfig|http:OAuth2RefreshTokenGrantConfig|ApiKeysConfig auth;
+|};
+
+# OAuth2 Client Credintials Grant Configs
+public type OAuth2ClientCredentialsGrantConfig record {|
+    *http:OAuth2ClientCredentialsGrantConfig;
+    # Token URL
+    string tokenUrl = "https://dev.to/oauth/token";
 |};
 
 public isolated client class Client {
@@ -27,7 +34,7 @@ public isolated client class Client {
         if authConfig.auth is ApiKeysConfig {
             self.apiKeyConfig = (<ApiKeysConfig>authConfig.auth).cloneReadOnly();
         } else {
-            clientConfig.auth = <http:OAuth2ClientCredentialsGrantConfig|http:BearerTokenConfig|http:OAuth2RefreshTokenGrantConfig>authConfig.auth;
+            clientConfig.auth = <OAuth2ClientCredentialsGrantConfig|http:BearerTokenConfig|http:OAuth2RefreshTokenGrantConfig>authConfig.auth;
             self.apiKeyConfig = ();
         }
         http:Client httpEp = check new (serviceUrl, clientConfig);


### PR DESCRIPTION
## Purpose
- Fix https://github.com/ballerina-platform/openapi-tools/issues/733

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes