### PR TITLE
Throw errors when unsupported array types given

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
@@ -67,6 +67,7 @@ public class FunctionSignatureNodeTests {
         RequiredParameterNode param01 = (RequiredParameterNode) parameters.get(0);
         RequiredParameterNode param02 = (RequiredParameterNode) parameters.get(1);
         RequiredParameterNode param03 = (RequiredParameterNode) parameters.get(2);
+        RequiredParameterNode param04 = (RequiredParameterNode) parameters.get(3);
 
         Assert.assertEquals(param01.paramName().orElseThrow().text(), "latitude");
         Assert.assertEquals(param01.typeName().toString(), "float");
@@ -76,6 +77,9 @@ public class FunctionSignatureNodeTests {
 
         Assert.assertEquals(param03.paramName().orElseThrow().text(), "country");
         Assert.assertEquals(param03.typeName().toString(), "string");
+
+        Assert.assertEquals(param04.paramName().orElseThrow().text(), "pages");
+        Assert.assertEquals(param04.typeName().toString(), "int[]");
 
         ReturnTypeDescriptorNode returnTypeNode = signature.returnTypeDesc().orElseThrow();
         Assert.assertEquals(returnTypeNode.type().toString(), "Product[]|error");
@@ -167,6 +171,28 @@ public class FunctionSignatureNodeTests {
         Assert.assertEquals(returnTypeNode.type().toString(), "string[]|error");
     }
 
+    @Test(description = "Test unsupported nested array type query parameter generation",
+            expectedExceptions = BallerinaOpenApiException.class,
+            expectedExceptionsMessageRegExp = "Unsupported parameter type is found in the parameter : .*")
+    public void testNestedArrayQueryParamGeneration() throws IOException, BallerinaOpenApiException {
+        OpenAPI openAPI = getOpenAPI(RESDIR.resolve("swagger/invalid_array_query_params.yaml"));
+        FunctionSignatureGenerator functionSignatureGenerator = new FunctionSignatureGenerator(openAPI,
+                new BallerinaTypesGenerator(openAPI), new ArrayList<>());
+        functionSignatureGenerator.getFunctionSignatureNode(openAPI.getPaths()
+                .get("/pets").getGet(), new ArrayList<>());
+    }
+
+    @Test(description = "Test generation of array type query parameter when type of the parameter not given",
+            expectedExceptions = BallerinaOpenApiException.class,
+            expectedExceptionsMessageRegExp = "Please define the array item type of the parameter : .*")
+    public void testArrayQueryParamWithNoTypeGeneration() throws IOException, BallerinaOpenApiException {
+        OpenAPI openAPI = getOpenAPI(RESDIR.resolve("swagger/invalid_array_query_params.yaml"));
+        FunctionSignatureGenerator functionSignatureGenerator = new FunctionSignatureGenerator(openAPI,
+                new BallerinaTypesGenerator(openAPI), new ArrayList<>());
+        functionSignatureGenerator.getFunctionSignatureNode(openAPI.getPaths()
+                .get("/dogs").getGet(), new ArrayList<>());
+    }
+
     @AfterTest
     private void deleteGeneratedFiles() {
         try {
@@ -175,5 +201,4 @@ public class FunctionSignatureNodeTests {
         } catch (IOException ignored) {
         }
     }
-
 }

--- a/openapi-cli/src/test/resources/generators/client/swagger/invalid_array_query_params.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/invalid_array_query_params.yaml
@@ -1,0 +1,40 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstoe
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: offset
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: array
+              items:
+                type: integer
+      responses:
+        '200':
+          description: An paged array of pets
+  /dogs:
+    get:
+      operationId: listDogs
+      parameters:
+        - name: offset
+          in: query
+          required: true
+          schema:
+            type: array
+            items: {}
+      responses:
+        '200':
+          description: An paged array of pets

--- a/openapi-cli/src/test/resources/generators/client/swagger/valid_operation.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/valid_operation.yaml
@@ -34,6 +34,15 @@ paths:
           required: true
           schema:
             type: string
+        - name: pages
+          in: query
+          required: true
+          description: pages to fetch
+          schema:
+            type: array
+            items:
+              type: number
+              format: integer
       tags:
         - Products
       responses:


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/ballerina-platform/openapi-tools/issues/777

## Goals
1. Throw an error when nested array is given as a query parameter
```yaml
parameters:
        - name: offset
          in: query
          required: true
          schema:
            type: array
            items:
              type: array
              items: 
               type: integer
```

2. Throw an error when array type is not defined in a query parameter
```yml
parameters:
        - name: offset
          in: query
          required: true
          schema:
            type: array
            items: {}
```
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes