### PR TITLE
[Client ]Bug fix in inline record generation

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/schema/ballerinatypegenerators/AllOfRecordTypeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/schema/ballerinatypegenerators/AllOfRecordTypeGenerator.java
@@ -98,7 +98,7 @@ public class AllOfRecordTypeGenerator extends TypeGenerator {
             } else if (allOfSchema.getProperties() != null) {
                 Map<String, Schema> properties = allOfSchema.getProperties();
                 List<String> required = allOfSchema.getRequired();
-                recordFieldList.addAll(TypeGeneratorUtils.addRecordFields(required, properties.entrySet()));
+                recordFieldList.addAll(TypeGeneratorUtils.addRecordFields(required, properties.entrySet(), true));
             } else if (allOfSchema instanceof ComposedSchema) {
                 ComposedSchema nestedComposedSchema = (ComposedSchema) allOfSchema;
                 if (nestedComposedSchema.getAllOf() != null) {

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
@@ -84,7 +84,7 @@ public class RecordTypeGenerator extends TypeGenerator {
         if (schema.getProperties() != null) {
             Map<String, Schema> properties = schema.getProperties();
             List<String> required = schema.getRequired();
-            List<Node> recordFList = TypeGeneratorUtils.addRecordFields(required, properties.entrySet());
+            List<Node> recordFList = TypeGeneratorUtils.addRecordFields(required, properties.entrySet(), true);
             NodeList<Node> fieldNodes = AbstractNodeFactory.createNodeList(recordFList);
             return NodeFactory.createRecordTypeDescriptorNode(createToken(RECORD_KEYWORD),
                     createToken(OPEN_BRACE_TOKEN), fieldNodes, null, createToken(CLOSE_BRACE_TOKEN));

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/OneOfDataTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/OneOfDataTypeTests.java
@@ -88,13 +88,24 @@ public class OneOfDataTypeTests {
         TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree("schema/ballerina/oneOf.bal", syntaxTree);
     }
 
-    @Test(description = "Tests record generation for nested OneOf schema inside AllOf schema")
-    public void arrayHasMaxItemsExceedLimit02() throws IOException, BallerinaOpenApiException {
-        Path definitionPath = RES_DIR.resolve("generators/schema/swagger/nested_oneOf_with_allOf.yaml");
+    @Test(description = "Tests record generation for oneOf schemas with inline object schemas")
+    public void oneOfWithInlineObject() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("generators/schema/swagger/oneOf_with_inline_schemas.yaml");
         OpenAPI openAPI = codeGenerator.normalizeOpenAPI(definitionPath, true);
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
         SyntaxTree syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
         TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
-                "schema/ballerina/nested_oneOf_with_allOf.bal", syntaxTree);
+                "schema/ballerina/oneOf_with_inline_schemas.bal", syntaxTree);
+    }
+
+    @Test(description = "Tests record generation for nested OneOf schema inside AllOf schema",
+            expectedExceptions = BallerinaOpenApiException.class,
+            expectedExceptionsMessageRegExp = "" +
+                    "Unsupported scenario is found. AllOf schema is given inside a oneOf or anyOf schema.")
+    public void oneOfWithNestedAllOf() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("generators/schema/swagger/nested_oneOf_with_allOf.yaml");
+        OpenAPI openAPI = codeGenerator.normalizeOpenAPI(definitionPath, true);
+        BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
+        SyntaxTree syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
     }
 }

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/oneOf_with_inline_schemas.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/oneOf_with_inline_schemas.bal
@@ -1,0 +1,6 @@
+public type Address record{string streetNo?;string houseNo?;}|record{string streatName?;string country?;}|record{int zipCode?;}|record{}|CountryDetails;
+
+public type CountryDetails record {
+    string iso_code?;
+    string name?;
+};

--- a/openapi-cli/src/test/resources/generators/schema/swagger/oneOf_with_inline_schemas.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/oneOf_with_inline_schemas.yaml
@@ -57,16 +57,23 @@ components:
         - properties:
             streetNo:
               type: string
+              description: Street Number
             houseNo:
               type: string
+              description: House Number
         - properties:
             streatName:
               type: string
+              description: Street Name
             country:
               type: string
+              description: Country Name
         - properties:
             zipCode:
               type: integer
+              description: Zipcode
+        - type: object
+          description: Additional fields
         - $ref: '#/components/schemas/CountryDetails'
     CountryDetails:
       properties:


### PR DESCRIPTION
## Purpose
> Fix https://github.com/ballerina-platform/openapi-tools/issues/786

## Goals
> Generate inline record with proper formatting when oneOf schema has inline object schemas

## Approach
> Add implementation not to generate doc comments for inline record fields

**Sample OpenAPI**
```yaml
    schema:
      oneOf:
        - type: object
          properties:
            fieldId:
              type: integer
              description: Lead Field Id with email address
              example: 1
            placeholders:
              type: object
              description: Object with template placeholders
        - type: object
          properties:
            email:
              description: Recipient Email
              type: string
              format: email
              example: example@iriscrm.com
            name:
              description: Recipient Name
              type: string
              example: John Doe
            placeholders:
              type: object
              description: Object with template placeholders
```
**Before the fix**
```bal
public type EmailsTemplateidBody record{#Lead Field Id with email addressint fieldId?;#Object with template placeholdersrecord{}placeholders?;}|record{#Recipient Emailstring email?;#Recipient Namestring name?;#Object with template placeholdersrecord{}placeholders?;};

```
**After the fix**
```bal
public type Tests record{int fieldId?;record{}placeholders?;}|record{string email?;string name?;record{}placeholders?;};
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> [List any other related PRs](https://github.com/ballerina-platform/openapi-tools/pull/775)