### PR TITLE
[Service] Fix query parameter order in resource function

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ParametersGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ParametersGenerator.java
@@ -90,8 +90,8 @@ public class ParametersGenerator {
      */
     public List<Node> generateResourcesInputs(Map.Entry<PathItem.HttpMethod, Operation> operation)
             throws BallerinaOpenApiException {
-        List<Node> params = new ArrayList<>();
-        List<Node> defaultable = new ArrayList<>();
+        List<Node> requiredParams = new ArrayList<>();
+        List<Node> defaultableParams = new ArrayList<>();
         Token comma = createToken(SyntaxKind.COMMA_TOKEN);
         // Handle header and query parameters
         if (operation.getValue().getParameters() != null) {
@@ -99,8 +99,8 @@ public class ParametersGenerator {
             for (Parameter parameter: parameters) {
                 if (parameter.getIn().trim().equals(HEADER)) {
                     RequiredParameterNode param = handleHeader(parameter);
-                    params.add(param);
-                    params.add(comma);
+                    requiredParams.add(param);
+                    requiredParams.add(comma);
                 } else if (parameter.getIn().trim().equals(QUERY)) {
                     if (parameter.getRequired() != null && parameter.getRequired() &&
                             (parameter.getSchema().getNullable() != null &&  parameter.getSchema().getNullable())) {
@@ -110,11 +110,11 @@ public class ParametersGenerator {
                     // public type () |BasicType|BasicType []| map<json>;
                     Node param = createNodeForQueryParam(parameter);
                     if (param.kind() == SyntaxKind.DEFAULTABLE_PARAM) {
-                        defaultable.add(param);
-                        defaultable.add(comma);
+                        defaultableParams.add(param);
+                        defaultableParams.add(comma);
                     } else {
-                        params.add(param);
-                        params.add(comma);
+                        requiredParams.add(param);
+                        requiredParams.add(comma);
                     }
                 }
             }
@@ -126,17 +126,17 @@ public class ParametersGenerator {
             RequestBody requestBody = operation.getValue().getRequestBody();
             if (requestBody.getContent() != null) {
                 RequestBodyGenerator requestBodyGen = new RequestBodyGenerator();
-                params.add(requestBodyGen.createNodeForRequestBody(requestBody));
-                params.add(comma);
+                requiredParams.add(requestBodyGen.createNodeForRequestBody(requestBody));
+                requiredParams.add(comma);
             }
         }
-        if (!defaultable.isEmpty()) {
-            params.addAll(defaultable);
+        if (!defaultableParams.isEmpty()) {
+            requiredParams.addAll(defaultableParams);
         }
-        if (params.size() > 1) {
-            params.remove(params.size() - 1);
+        if (requiredParams.size() > 1) {
+            requiredParams.remove(requiredParams.size() - 1);
         }
-        return params;
+        return requiredParams;
     }
 
     /**

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/QueryParameterTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/QueryParameterTests.java
@@ -179,4 +179,22 @@ public class QueryParameterTests {
         syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("query/query_12.bal", syntaxTree);
     }
+
+    @Test(description = "13. Default query parameter has string type")
+    public void stringDefaultQueryParameter() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/query/query_13.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("query/query_13.bal", syntaxTree);
+    }
+
+    @Test(description = "14. Fix the query parameter order")
+    public void queryParameterOrder() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/query/query_14.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("query/query_14.bal", syntaxTree);
+    }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/query/query_13.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/query/query_13.bal
@@ -1,0 +1,10 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
+
+service /v1 on ep0 {
+    resource function get pets(string petType = "tests") returns http:Ok {
+    }
+    resource function get pets02(string petType = "tests") returns http:Ok {
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/ballerina/query/query_14.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/query/query_14.bal
@@ -1,0 +1,8 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
+
+service /v1 on ep0 {
+    resource function get pets(string? petType02, int petType03, string petType01 = "tests") returns http:Ok {
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/swagger/query/query_13.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/query/query_13.yaml
@@ -1,0 +1,35 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstoe
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+paths:
+  /pets:
+    get:
+      operationId: listPetsForType
+      parameters:
+        - name: petType
+          in: query
+          schema:
+            type: string
+            default: "tests"
+      responses:
+        '200':
+          description: An paged array of pets
+  /pets02:
+    get:
+      operationId: listPets
+      parameters:
+        - name: petType
+          in: query
+          schema:
+            type: string
+            default: tests
+      responses:
+        '200':
+          description: An paged array of pets

--- a/openapi-cli/src/test/resources/generators/service/swagger/query/query_14.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/query/query_14.yaml
@@ -1,0 +1,32 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstoe
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+paths:
+  /pets:
+    get:
+      operationId: listPetsForType
+      parameters:
+        - name: petType01
+          in: query
+          schema:
+            type: string
+            default: "tests"
+        - name: petType02
+          in: query
+          schema:
+            type: string
+        - name: petType03
+          in: query
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: An paged array of pets


### PR DESCRIPTION
## Purpose

- Fix query parameter order
- Fix missing quoted marks for defaultable query parameter
- Fix https://github.com/ballerina-platform/openapi-tools/issues/797

## Automation tests
 - Unit tests - add
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.