### PR TITLE
[BallerinaToOpenAPI]Add support to generate OAS when request payload has `map<string>` type

### DIFF
--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/Constants.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/Constants.java
@@ -74,8 +74,8 @@ public class Constants {
     public static final String XML_POSTFIX = "+xml";
     public static final String TEXT_POSTFIX = "+plain";
     public static final String OCTECT_STREAM_POSTFIX = "+octet-stream";
-    public static final String X_WWW_FROM_URLENCODED_POSTFIX = "+x-www-form-urlencoded";
-    public static final String X_WWW_FROM_URLENCODED = "x-www-form-urlencoded";
+    public static final String X_WWW_FORM_URLENCODED_POSTFIX = "+x-www-form-urlencoded";
+    public static final String X_WWW_FORM_URLENCODED = "x-www-form-urlencoded";
 
     public static final String TEXT_PREFIX = "text/";
     public static final String MAP_JSON = "map<json>";

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/Constants.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/Constants.java
@@ -74,14 +74,19 @@ public class Constants {
     public static final String XML_POSTFIX = "+xml";
     public static final String TEXT_POSTFIX = "+plain";
     public static final String OCTECT_STREAM_POSTFIX = "+octet-stream";
+    public static final String X_WWW_FROM_URLENCODED_POSTFIX = "+x-www-form-urlencoded";
+    public static final String X_WWW_FROM_URLENCODED = "x-www-form-urlencoded";
+
     public static final String TEXT_PREFIX = "text/";
     public static final String MAP_JSON = "map<json>";
+    public static final String MAP_STRING = "map<string>";
     public static final String HTTP_REQUEST = "http:Request";
     public static final String DEFAULT = "default";
     public static final String HTTP_RESPONSE = "http:Response";
     public static final String RESPONSE_HEADERS = "headers";
     public static final String WILD_CARD_CONTENT_KEY = "*/*";
     public static final String WILD_CARD_SUMMARY = "Any type of entity body";
+    public static final String MEDIA_TYPE = "mediaType";
 
     /**
      * Enum to select the Ballerina Type.

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIRequestBodyMapper.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIRequestBodyMapper.java
@@ -59,7 +59,7 @@ import static io.ballerina.openapi.converter.Constants.OCTECT_STREAM_POSTFIX;
 import static io.ballerina.openapi.converter.Constants.TEXT_POSTFIX;
 import static io.ballerina.openapi.converter.Constants.TEXT_PREFIX;
 import static io.ballerina.openapi.converter.Constants.XML_POSTFIX;
-import static io.ballerina.openapi.converter.Constants.X_WWW_FROM_URLENCODED_POSTFIX;
+import static io.ballerina.openapi.converter.Constants.X_WWW_FORM_URLENCODED_POSTFIX;
 
 /**
  * OpenAPIRequestBodyMapper provides functionality for converting ballerina payload to OAS request body model.
@@ -166,7 +166,7 @@ public class OpenAPIRequestBodyMapper {
                 break;
             case Constants.MAP_STRING:
                 mediaTypeString = customMediaPrefix == null ? MediaType.APPLICATION_FORM_URLENCODED :
-                        APPLICATION_PREFIX + customMediaPrefix + X_WWW_FROM_URLENCODED_POSTFIX;
+                        APPLICATION_PREFIX + customMediaPrefix + X_WWW_FORM_URLENCODED_POSTFIX;
                 Schema objectSchema = new ObjectSchema();
                 objectSchema.additionalProperties(new StringSchema());
                 io.swagger.v3.oas.models.media.MediaType mediaType = new io.swagger.v3.oas.models.media.MediaType();
@@ -243,28 +243,28 @@ public class OpenAPIRequestBodyMapper {
                                          RequiredParameterNode payloadNode, Map<String, Schema> schema) {
 
         for (MappingFieldNode fieldNode: fields) {
-            if (((SpecificFieldNode) fieldNode).fieldName().toString().equals(MEDIA_TYPE)) {
-                if (fieldNode.children() != null) {
-                    RequestBody requestBody = new RequestBody();
-                    SpecificFieldNode field = (SpecificFieldNode) fieldNode;
-                    if (field.valueExpr().isPresent()) {
-                        ExpressionNode valueNode = field.valueExpr().get();
-                        if (valueNode instanceof ListConstructorExpressionNode) {
-                            SeparatedNodeList mimeList = ((ListConstructorExpressionNode) valueNode).expressions();
-                            if (mimeList.size() != 0) {
-                                for (Object mime : mimeList) {
-                                    if (mime instanceof BasicLiteralNode) {
-                                        createRequestBody(bodyParameter, payloadNode, schema, requestBody,
-                                                ((BasicLiteralNode) mime).literalToken().text());
-                                    }
-                                }
-                            }
-                        } else {
-                            createRequestBody(bodyParameter, payloadNode, schema, requestBody,
-                                    valueNode.toString());
-                        }
+            if (!(fieldNode instanceof SpecificFieldNode) ||
+                    !((SpecificFieldNode) fieldNode).fieldName().toString().equals(MEDIA_TYPE) ||
+                    fieldNode.children() == null) {
+                continue;
+            }
+            RequestBody requestBody = new RequestBody();
+            SpecificFieldNode field = (SpecificFieldNode) fieldNode;
+            if (field.valueExpr().isEmpty()) {
+                continue;
+            }
+            ExpressionNode valueNode = field.valueExpr().get();
+            if (valueNode instanceof ListConstructorExpressionNode) {
+                SeparatedNodeList mimeList = ((ListConstructorExpressionNode) valueNode).expressions();
+                for (Object mime : mimeList) {
+                    if (mime instanceof BasicLiteralNode) {
+                        createRequestBody(bodyParameter, payloadNode, schema, requestBody,
+                                ((BasicLiteralNode) mime).literalToken().text());
                     }
                 }
+            } else {
+                createRequestBody(bodyParameter, payloadNode, schema, requestBody,
+                        valueNode.toString());
             }
         }
     }

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/utils/ConverterCommonUtils.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/utils/ConverterCommonUtils.java
@@ -126,7 +126,7 @@ public class ConverterCommonUtils {
             case Constants.MAP_JSON:
                 schema = new ObjectSchema();
                 break;
-            case Constants.X_WWW_FROM_URLENCODED:
+            case Constants.X_WWW_FORM_URLENCODED:
                 schema = new ObjectSchema();
                 schema.setAdditionalProperties(new StringSchema());
                 break;

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/utils/ConverterCommonUtils.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/utils/ConverterCommonUtils.java
@@ -126,6 +126,10 @@ public class ConverterCommonUtils {
             case Constants.MAP_JSON:
                 schema = new ObjectSchema();
                 break;
+            case Constants.X_WWW_FROM_URLENCODED:
+                schema = new ObjectSchema();
+                schema.setAdditionalProperties(new StringSchema());
+                break;
             case Constants.TYPE_REFERENCE:
             case Constants.TYPEREFERENCE:
             case Constants.XML:

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/RequestBodyTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/RequestBodyTest.java
@@ -220,6 +220,15 @@ public class RequestBodyTest {
         compareWithGeneratedFile(ballerinaFilePath, "rb_scenario14.yaml");
     }
 
+    @Test(description = "Generate OpenAPI spec for request body having map<string> type")
+    public void testRequestBodyWithMapString() {
+        Path ballerinaFilePath = RES_DIR.resolve("request_body/rb_scenario15.bal");
+        OpenApiConverter openApiConverterUtils = new OpenApiConverter();
+        openApiConverterUtils.generateOAS3DefinitionsAllService(ballerinaFilePath, this.tempDir, null
+                , true);
+        Assert.assertTrue(openApiConverterUtils.getErrors().isEmpty());
+        compareWithGeneratedFile(ballerinaFilePath, "rb_scenario15.yaml");
+    }
     @Test(description = "Generate OpenAPI spec with json file")
     public void testNestedRecordPayLoadJson() {
         Path ballerinaFilePath = RES_DIR.resolve("request_body/nestedRecord_payload_service.bal");

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/rb_scenario15.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/rb_scenario15.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
+paths:
+  /pets:
+    post:
+      operationId: operation_post_/pets
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        "200":
+          description: Ok
+  /pets02:
+    post:
+      operationId: operation_post_/pets02
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        "200":
+          description: Ok
+  /pets03:
+    post:
+      operationId: operation_post_/pets03
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        "200":
+          description: Ok
+components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/request_body/rb_scenario15.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/request_body/rb_scenario15.bal
@@ -1,0 +1,20 @@
+import ballerina/http;
+
+listener http:Listener helloEp = new (9090);
+
+service /payloadV on helloEp {
+    resource function post pets(@http:Payload map<string> req) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+
+    resource function post pets02(@http:Payload{} map<string> req) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+
+    resource function post pets03(@http:Payload{mediaType: "application/x-www-form-urlencoded"} map<string> req) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+}


### PR DESCRIPTION
## Purpose
> Fix #841 


## Automation tests
 - Unit tests - add
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.