### PR TITLE
[Service] Fix Compilation error for union type payload body in generated service

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -140,6 +140,7 @@ public class GeneratorConstants {
     public static final String HEADER = "header";
     public static final String HEADER_VALUES = "headerValues";
     public static final String PAYLOAD = "payload";
+    public static final String PAYLOAD_KEYWORD = "Payload";
     public static final String PDF = "pdf";
     public static final String QUERY_PARAM = "queryParam";
     public static final String SELF = "self";
@@ -157,6 +158,7 @@ public class GeneratorConstants {
     public static final String ERROR = "error";
     public static final String MAP_JSON = "map<json>";
     public static final String APPLICATION_JSON = "application/json";
+    public static final String MEDIA_TYPE_KEYWORD = "mediaType";
 
     // auth related constants
     public static final String API_KEY = "apikey";

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -147,18 +147,23 @@ public class GeneratorConstants {
     public static final String TEXT_PREFIX = "text/";
     public static final String XML_DATA = "xmldata";
     public static final String IMAGE = "image";
-    public static final String ANY_TYPE = "*/*";
     public static final String VENDOR_SPECIFIC_TYPE = "vnd.";
-    public static final String APPLICATION_PDF = "application/pdf";
-    public static final String IMAGE_PNG = "image/png";
     public static final String MIME = "mime";
     public static final String HTTP_HEADERS = "httpHeaders";
     public static final String RESOURCE_PATH = "resourcePath";
     public static final String ARRAY = "array";
     public static final String ERROR = "error";
     public static final String MAP_JSON = "map<json>";
-    public static final String APPLICATION_JSON = "application/json";
     public static final String MEDIA_TYPE_KEYWORD = "mediaType";
+
+    public static final String ANY_TYPE = "*/*";
+    public static final String APPLICATION_JSON = "application/json";
+    public static final String APPLICATION_PDF = "application/pdf";
+    public static final String APPLICATION_XML = "application/xml";
+    public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+    public static final String TEXT = "text";
+    public static final String IMAGE_PNG = "image/png";
+    public static final String TEXT_PLAIN = "text/plain";
 
     // auth related constants
     public static final String API_KEY = "apikey";

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/BallerinaServiceGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/BallerinaServiceGenerator.java
@@ -207,7 +207,7 @@ public class BallerinaServiceGenerator {
         IdentifierToken functionName = createIdentifierToken(operation.getKey().name()
                 .toLowerCase(Locale.ENGLISH), SINGLE_WS_MINUTIAE, SINGLE_WS_MINUTIAE);
         NodeList<Node> relativeResourcePath = NodeFactory.createNodeList(pathNodes);
-        ParametersGenerator parametersGenerator = new ParametersGenerator();
+        ParametersGenerator parametersGenerator = new ParametersGenerator(false, openAPI.getComponents());
         List<Node> params = parametersGenerator.generateResourcesInputs(operation);
         if (!isNullableRequired) {
             isNullableRequired = parametersGenerator.isNullableRequired();

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ParametersGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ParametersGenerator.java
@@ -86,7 +86,7 @@ import static io.ballerina.openapi.generators.service.ServiceGenerationUtils.get
 public class ParametersGenerator {
 
     private boolean isNullableRequired;
-    private Components components;
+    private final Components components;
 
     public ParametersGenerator(boolean isNullableRequired, Components components) {
         this.isNullableRequired = isNullableRequired;

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ParametersGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ParametersGenerator.java
@@ -34,6 +34,7 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import io.ballerina.openapi.exception.BallerinaOpenApiException;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.ArraySchema;
@@ -84,8 +85,17 @@ import static io.ballerina.openapi.generators.service.ServiceGenerationUtils.get
  */
 public class ParametersGenerator {
 
-    boolean isNullableRequired = false;
+    private boolean isNullableRequired;
+    private Components components;
 
+    public ParametersGenerator(boolean isNullableRequired, Components components) {
+        this.isNullableRequired = isNullableRequired;
+        this.components = components;
+    }
+
+    public Components getComponents() {
+        return components;
+    }
     public boolean isNullableRequired() {
         return isNullableRequired;
     }
@@ -139,7 +149,7 @@ public class ParametersGenerator {
             RequestBody requestBody = operation.getValue().getRequestBody();
             if (requestBody.getContent() != null) {
                 RequestBodyGenerator requestBodyGen = new RequestBodyGenerator();
-                requiredParams.add(requestBodyGen.createNodeForRequestBody(requestBody));
+                requiredParams.add(requestBodyGen.createNodeForRequestBody(this.components, requestBody));
                 requiredParams.add(comma);
             }
         }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ParametersGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ParametersGenerator.java
@@ -93,9 +93,6 @@ public class ParametersGenerator {
         this.components = components;
     }
 
-    public Components getComponents() {
-        return components;
-    }
     public boolean isNullableRequired() {
         return isNullableRequired;
     }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/RequestBodyGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/RequestBodyGenerator.java
@@ -53,9 +53,13 @@ import static io.ballerina.compiler.syntax.tree.NodeFactory.createArrayTypeDescr
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createBuiltinSimpleNameReferenceNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createRequiredParameterNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createSimpleNameReferenceNode;
+import static io.ballerina.openapi.generators.GeneratorConstants.APPLICATION_JSON;
+import static io.ballerina.openapi.generators.GeneratorConstants.APPLICATION_OCTET_STREAM;
+import static io.ballerina.openapi.generators.GeneratorConstants.APPLICATION_XML;
 import static io.ballerina.openapi.generators.GeneratorConstants.MEDIA_TYPE_KEYWORD;
 import static io.ballerina.openapi.generators.GeneratorConstants.PAYLOAD;
 import static io.ballerina.openapi.generators.GeneratorConstants.PAYLOAD_KEYWORD;
+import static io.ballerina.openapi.generators.GeneratorConstants.TEXT;
 import static io.ballerina.openapi.generators.GeneratorUtils.SINGLE_WS_MINUTIAE;
 import static io.ballerina.openapi.generators.service.ServiceGenerationUtils.extractReferenceType;
 import static io.ballerina.openapi.generators.service.ServiceGenerationUtils.getAnnotationNode;
@@ -103,6 +107,9 @@ public class RequestBodyGenerator {
         return createRequiredParameterNode(annotation, typeName, paramName);
     }
 
+    /**
+     * This util function is for generating type node for request payload in resource function.
+     */
     private TypeDescriptorNode getNodeForPayloadType(Components components, Map.Entry<String, MediaType> mediaType)
             throws BallerinaOpenApiException {
         TypeDescriptorNode typeName;
@@ -112,19 +119,19 @@ public class RequestBodyGenerator {
             if (schema instanceof ComposedSchema && (((ComposedSchema) schema).getOneOf() != null)) {
                 String mediaTypeContent = mediaType.getKey().trim();
                 if (mediaTypeContent.matches("text/.*")) {
-                    mediaTypeContent = "text";
+                    mediaTypeContent = TEXT;
                 }
                 IdentifierToken identifierToken;
                 switch (mediaTypeContent) {
-                    case "application/xml":
+                    case APPLICATION_XML:
                         identifierToken = createIdentifierToken(GeneratorConstants.XML);
                         typeName = createSimpleNameReferenceNode(identifierToken);
                         break;
-                    case "text":
+                    case TEXT:
                         identifierToken = createIdentifierToken(GeneratorConstants.STRING);
                         typeName = createSimpleNameReferenceNode(identifierToken);
                         break;
-                    case "application/octet-stream":
+                    case APPLICATION_OCTET_STREAM:
                         ArrayDimensionNode dimensionNode = NodeFactory.createArrayDimensionNode(
                                 createToken(SyntaxKind.OPEN_BRACKET_TOKEN), null,
                                 createToken(SyntaxKind.CLOSE_BRACKET_TOKEN));
@@ -132,7 +139,7 @@ public class RequestBodyGenerator {
                                         null, createIdentifierToken(GeneratorConstants.BYTE)),
                                 NodeFactory.createNodeList(dimensionNode));
                         break;
-                    case "application/json":
+                    case APPLICATION_JSON:
                     default:
                         identifierToken = createIdentifierToken(GeneratorConstants.JSON);
                         typeName = createSimpleNameReferenceNode(identifierToken);

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ReturnTypeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ReturnTypeGenerator.java
@@ -41,7 +41,6 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
-import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
@@ -167,8 +166,6 @@ public class ReturnTypeGenerator {
                     dataType = extractReferenceType(schema.get$ref().trim());
                     type = createBuiltinSimpleNameReferenceNode(null,
                             createIdentifierToken(dataType));
-                } else if (schema instanceof ObjectSchema) {
-                    type = ServiceGenerationUtils.getRecordTypeDescriptorNode(schema);
                 } else if (schema instanceof ComposedSchema) {
                     Iterator<Schema> iterator = ((ComposedSchema) schema).getOneOf().iterator();
                     type = getUnionNodeForOneOf(iterator);

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ReturnTypeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/ReturnTypeGenerator.java
@@ -59,7 +59,6 @@ import static io.ballerina.compiler.syntax.tree.NodeFactory.createReturnTypeDesc
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createSimpleNameReferenceNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createUnionTypeDescriptorNode;
 import static io.ballerina.openapi.generators.GeneratorUtils.SINGLE_WS_MINUTIAE;
-import static io.ballerina.openapi.generators.GeneratorUtils.convertOpenAPITypeToBallerina;
 import static io.ballerina.openapi.generators.GeneratorUtils.getQualifiedNameReferenceNode;
 import static io.ballerina.openapi.generators.service.ServiceDiagnosticMessages.OAS_SERVICE_107;
 import static io.ballerina.openapi.generators.service.ServiceGenerationUtils.extractReferenceType;
@@ -169,7 +168,7 @@ public class ReturnTypeGenerator {
                     type = createBuiltinSimpleNameReferenceNode(null,
                             createIdentifierToken(dataType));
                 } else if (schema instanceof ObjectSchema) {
-                    type = getRecordTypeDescriptorNode(schema);
+                    type = ServiceGenerationUtils.getRecordTypeDescriptorNode(schema);
                 } else if (schema instanceof ComposedSchema) {
                     Iterator<Schema> iterator = ((ComposedSchema) schema).getOneOf().iterator();
                     type = getUnionNodeForOneOf(iterator);
@@ -178,40 +177,6 @@ public class ReturnTypeGenerator {
                 }
             }
         }
-        return type;
-    }
-
-    /**
-     * This for generate record node for object schema.
-     */
-    public TypeDescriptorNode getRecordTypeDescriptorNode(Schema schema) throws BallerinaOpenApiException {
-        TypeDescriptorNode type;
-        Token recordKeyWord = createIdentifierToken("record", AbstractNodeFactory.createEmptyMinutiaeList(),
-                SINGLE_WS_MINUTIAE);
-        Token bodyStartDelimiter = createIdentifierToken("{|");
-        // Create record fields
-        List<Node> recordFields = new ArrayList<>();
-        if (schema.getProperties() != null) {
-            Map<String, Schema> properties = schema.getProperties();
-            for (Map.Entry<String, Schema> field: properties.entrySet()) {
-                Token fieldName = createIdentifierToken(field.getKey().trim());
-                String typeProperty;
-                if (field.getValue().get$ref() != null) {
-                    typeProperty = extractReferenceType(field.getValue().get$ref());
-                } else {
-                    typeProperty = convertOpenAPITypeToBallerina(field.getValue().getType());
-                }
-                Token typeRecordField = createIdentifierToken(typeProperty,
-                        AbstractNodeFactory.createEmptyMinutiaeList(), SINGLE_WS_MINUTIAE);
-                RecordFieldNode recordFieldNode =  NodeFactory.createRecordFieldNode(null, null,
-                        typeRecordField, fieldName, null, createToken(SyntaxKind.SEMICOLON_TOKEN));
-                recordFields.add(recordFieldNode);
-            }
-        }
-        NodeList<Node> fieldsList = NodeFactory.createSeparatedNodeList(recordFields);
-        Token bodyEndDelimiter = createIdentifierToken("|}");
-        type = NodeFactory.createRecordTypeDescriptorNode(recordKeyWord, bodyStartDelimiter, fieldsList,
-                null, bodyEndDelimiter);
         return type;
     }
 

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -107,7 +107,7 @@ public class RequestBodyTests {
             expectedExceptions = BallerinaOpenApiException.class)
     public void testRequestBodyWithUnsupportedMediaType() throws IOException, BallerinaOpenApiException {
         CodeGenerator codeGenerator = new CodeGenerator();
-        Path definitionPath = RES_DIR.resolve("swagger/oneOf_request_body.yaml");
+        Path definitionPath = RES_DIR.resolve("swagger/unsupported_request_body.yaml");
         OpenAPI openAPI = codeGenerator.normalizeOpenAPI(definitionPath, true);
         BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(openAPI, filter, false);
         ballerinaClientGenerator.generateSyntaxTree();

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -107,7 +107,7 @@ public class RequestBodyTests {
             expectedExceptions = BallerinaOpenApiException.class)
     public void testRequestBodyWithUnsupportedMediaType() throws IOException, BallerinaOpenApiException {
         CodeGenerator codeGenerator = new CodeGenerator();
-        Path definitionPath = RES_DIR.resolve("swagger/unsupported_request_body.yaml");
+        Path definitionPath = RES_DIR.resolve("swagger/oneOf_request_body.yaml");
         OpenAPI openAPI = codeGenerator.normalizeOpenAPI(definitionPath, true);
         BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(openAPI, filter, false);
         ballerinaClientGenerator.generateSyntaxTree();

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/RequestBodyTests.java
@@ -102,4 +102,14 @@ public class RequestBodyTests {
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
                 "requestBody/scenario_04_rb.bal", syntaxTree);
     }
+
+    @Test(description = "RequestBody has oneOf scenarios")
+    public void oneOfScenarios() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/requestBody/oneOf_request_body.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "requestBody/oneof_requestBody.bal", syntaxTree);
+    }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ReturnTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ReturnTypeTests.java
@@ -256,4 +256,14 @@ public class ReturnTypeTests {
         syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("real_apis/box.bal", syntaxTree);
     }
+
+    @Test(description = "Response and Request body have inline object schema")
+    public void testWithInlineObjectSchema() throws IOException, BallerinaOpenApiException, FormatterException {
+        Path definitionPath = RES_DIR.resolve("swagger/inline_record_type_request_response.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "inline_record.bal", syntaxTree);
+    }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/inline_record.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/inline_record.bal
@@ -1,0 +1,8 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
+
+service /v1 on ep0 {
+    resource function post user(@http:Payload UserBody payload) returns InlineResponse200 {
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_requestBody.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_requestBody.bal
@@ -1,0 +1,16 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (9090, config = {host: "localhost"});
+
+service / on ep0 {
+    resource function put storageSpaces01(@http:Payload json payload) returns http:Ok {
+    }
+    resource function post storageSpaces01(@http:Payload json payload) returns http:Ok {
+    }
+    resource function put storageSpaces02(@http:Payload string payload) returns http:Ok {
+    }
+    resource function post storageSpaces02(@http:Payload xml payload) returns http:Ok {
+    }
+    resource function put storageSpaces/[string  name](@http:Payload json payload) returns http:Ok|http:BadRequest {
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/swagger/inline_record_type_request_response.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/inline_record_type_request_response.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.0
+info:
+  title: refComponent
+  description: refComponent
+  version: 1.0.0
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+paths:
+  /user:
+    post:
+      summary: Creates a new user.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - userName
+                properties:
+                  userName:
+                    type: string
+                  lastName:
+                    type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - userName
+              properties:
+                userName:
+                  type: string
+                firstName:
+                  type: string

--- a/openapi-cli/src/test/resources/generators/service/swagger/requestBody/oneOf_request_body.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/requestBody/oneOf_request_body.yaml
@@ -1,0 +1,108 @@
+openapi: 3.0.1
+info:
+  title:  Storage Space
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+paths:
+  /storageSpaces01:
+    put:
+      summary: "Unsupported scenario 01: Customised request body with empty schema"
+      operationId: putKey
+      requestBody:
+        description: "Customised request body with empty schema"
+        content:
+          application/snowflake+json:
+            schema: {}
+      responses:
+        200:
+          description: Successful operation.
+    post:
+      summary: "Unsupported scenario 02: Customised request body with oneOf schema"
+      operationId: post
+      requestBody:
+        description: "Customised request body"
+        content:
+          application/snowflake+json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/HandleRequest_RequestBody"
+                - $ref: "#/components/schemas/HandleRequest_RequestBody02"
+      responses:
+        200:
+          description: Successful operation.
+  /storageSpaces02:
+    post:
+      summary: "Unsupported scenario 03: Request body with oneOf schema"
+      operationId: postKey
+      requestBody:
+        description: "Ballerina not support for oneOf data type in request body"
+        content:
+          application/xml:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/HandleRequest_RequestBody"
+                - $ref: "#/components/schemas/HandleRequest_RequestBody02"
+      responses:
+        200:
+          description: Successful operation.
+    put:
+      summary: "Unsupported scenario 04: Request body with oneOf schema with integer, number"
+      operationId: put
+      requestBody:
+        description: "Ballerina not support for oneOf data type in request body"
+        content:
+          text/plain:
+            schema:
+              oneOf:
+                - type: string
+                - type: integer
+                - type: number
+      responses:
+        200:
+          description: Successful operation.
+  /storageSpaces/{name}:
+    put:
+      summary: Put key value
+      operationId: key
+      parameters:
+        - name: name
+          in: path
+          description: name of the storage space
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Value to be added
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: string
+                - type: integer
+                - type: number
+                - type: object
+      responses:
+        200:
+          description: Successful operation.
+        400:
+          description: Invalid storage space name supplied
+components:
+  schemas:
+    HandleRequest_RequestBody:
+      title: Request/Response handler
+      type: object
+      properties:
+        headers:
+          type: string
+        body:
+          type: string
+    HandleRequest_RequestBody02:
+      title: Request/Response handler
+      type: object
+      properties:
+        headers:
+          type: string
+        body:
+          type: string


### PR DESCRIPTION
## Purpose
> Fix #900 
Current tool generated union type for oneOf schemas, allowing union type will be requested via this [issue](https://github.com/ballerina-platform/ballerina-standard-library/issues/2701) in http module.
We will provide the fix for union type once they provide a fix. Until that we are removing generating union type for service now and adding the type for relevant media type. 
## Automation tests
 - Unit tests  - add
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.