### PR TITLE
Fix conflicting configs error for `openApiDefinition`

### DIFF
--- a/openapi-extension-tests/src/test/java/io/ballerina/openapi/extension/OpenApiExtensionTest.java
+++ b/openapi-extension-tests/src/test/java/io/ballerina/openapi/extension/OpenApiExtensionTest.java
@@ -127,6 +127,7 @@ public class OpenApiExtensionTest {
     public void testGeneratedDocEmbedWithUserProvidedOpenApiDoc() {
         Package currentPackage = loadPackage("sample_11", false);
         PackageCompilation compilation = currentPackage.getCompilation();
+        Assert.assertEquals(compilation.diagnosticResult().errorCount(), 0);
         Assert.assertTrue(noOpenApiWarningAvailable(compilation));
     }
 

--- a/openapi-extension/src/main/java/io/ballerina/openapi/extension/doc/OpenApiInfoUpdaterTask.java
+++ b/openapi-extension/src/main/java/io/ballerina/openapi/extension/doc/OpenApiInfoUpdaterTask.java
@@ -176,7 +176,7 @@ public class OpenApiInfoUpdaterTask implements ModifierTask<SourceModifierContex
         for (MappingFieldNode field : existingFields) {
             if (field instanceof SpecificFieldNode) {
                 String fieldName = ((SpecificFieldNode) field).fieldName().toString();
-                openApiDefAvailable = Constants.OPEN_API_DEFINITION_FIELD.equals(fieldName);
+                openApiDefAvailable = Constants.OPEN_API_DEFINITION_FIELD.equals(fieldName.trim());
             }
             fields.add(field);
             fields.add(separator);


### PR DESCRIPTION
## Purpose
> $subject

Related to  [`Conflicting configs for OpenAPI definition returns a duplicate key error #2889`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2889)