### PR TITLE
[BallerinaToOpenAPI]Add support for when return type has float and decimal types

### DIFF
--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
@@ -420,6 +420,8 @@ public class OpenAPIResponseMapper {
             case QUALIFIED_NAME_REFERENCE:
                 QualifiedNameReferenceNode qNode = (QualifiedNameReferenceNode) typeNode;
                 return  handleQualifiedNameType(apiResponses, customMediaPrefix, headers, apiResponse, qNode);
+            case FLOAT_TYPE_DESC:
+            case DECIMAL_TYPE_DESC:
             case INT_TYPE_DESC:
             case STRING_TYPE_DESC:
             case BOOLEAN_TYPE_DESC:

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/ResponseTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/ResponseTests.java
@@ -222,7 +222,7 @@ public class ResponseTests {
     }
 
     @Test(description = "When the response has float return type")
-    public void returnHasFloat() throws IOException {
+    public void testResponseWithFloatReturnType() throws IOException {
         Path ballerinaFilePath = RES_DIR.resolve("response/float.bal");
         OpenApiConverter openApiConverterUtils = new OpenApiConverter();
         openApiConverterUtils.generateOAS3DefinitionsAllService(ballerinaFilePath, this.tempDir, null
@@ -232,7 +232,7 @@ public class ResponseTests {
     }
 
     @Test(description = "When the response has decimal return type")
-    public void returnHasDecimal() throws IOException {
+    public void testResponseWithDecimalReturnType() throws IOException {
         Path ballerinaFilePath = RES_DIR.resolve("response/decimal.bal");
         OpenApiConverter openApiConverterUtils = new OpenApiConverter();
         openApiConverterUtils.generateOAS3DefinitionsAllService(ballerinaFilePath, this.tempDir, null

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/ResponseTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/ResponseTests.java
@@ -221,6 +221,26 @@ public class ResponseTests {
         TestUtils.compareWithGeneratedFile(ballerinaFilePath, "response/response_code.yaml");
     }
 
+    @Test(description = "When the response has float return type")
+    public void returnHasFloat() throws IOException {
+        Path ballerinaFilePath = RES_DIR.resolve("response/float.bal");
+        OpenApiConverter openApiConverterUtils = new OpenApiConverter();
+        openApiConverterUtils.generateOAS3DefinitionsAllService(ballerinaFilePath, this.tempDir, null
+                , false);
+        Assert.assertTrue(openApiConverterUtils.getErrors().isEmpty());
+        TestUtils.compareWithGeneratedFile(ballerinaFilePath, "response/float.yaml");
+    }
+
+    @Test(description = "When the response has decimal return type")
+    public void returnHasDecimal() throws IOException {
+        Path ballerinaFilePath = RES_DIR.resolve("response/decimal.bal");
+        OpenApiConverter openApiConverterUtils = new OpenApiConverter();
+        openApiConverterUtils.generateOAS3DefinitionsAllService(ballerinaFilePath, this.tempDir, null
+                , false);
+        Assert.assertTrue(openApiConverterUtils.getErrors().isEmpty());
+        TestUtils.compareWithGeneratedFile(ballerinaFilePath, "response/decimal.yaml");
+    }
+
     @AfterMethod
     public void cleanUp() {
         TestUtils.deleteDirectory(this.tempDir);

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/decimal.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/decimal.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
+paths:
+  /fareCalculator:
+    get:
+      operationId: getFarecalculator
+      parameters:
+        - name: flightNo
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: noOfPassengers
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: number
+                format: double
+components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/float.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/float.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
+paths:
+  /fareCalculator:
+    get:
+      operationId: getFarecalculator
+      parameters:
+        - name: flightNo
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: noOfPassengers
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: number
+                format: float
+components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/response/decimal.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/response/decimal.bal
@@ -1,0 +1,7 @@
+import ballerina/http;
+
+service /payloadV on new http:Listener(9090) {
+    resource function get fareCalculator(string flightNo, int noOfPassengers) returns decimal {
+        return 1.0;
+    }
+}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/response/float.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/response/float.bal
@@ -1,0 +1,7 @@
+import ballerina/http;
+
+service /payloadV on new http:Listener(9090) {
+    resource function get fareCalculator(string flightNo, int noOfPassengers) returns float {
+        return 1.0;
+    }
+}


### PR DESCRIPTION
## Purpose
> Fix #977 

## Automation tests
 - Unit tests - added
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.