### PR TITLE
[BallerinaToOpenAPI]Add support for tuple type mapping

### DIFF
--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/Constants.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/Constants.java
@@ -78,6 +78,7 @@ public class Constants {
     public static final String WILD_CARD_CONTENT_KEY = "*/*";
     public static final String WILD_CARD_SUMMARY = "Any type of entity body";
     public static final String MEDIA_TYPE = "mediaType";
+    public static final String TUPLE = "tuple";
 
     /**
      * Enum to select the Ballerina Type.

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIComponentMapper.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIComponentMapper.java
@@ -448,12 +448,13 @@ public class OpenAPIComponentMapper {
         }
         // Handle the tuple type
         if (symbol.typeKind().equals(TypeDescKind.TUPLE)) {
-            // Add it to oneOF
+            // Add all the schema related to typeSymbols into the list. Then the list can be mapped into oneOf
+            // type.
             TupleTypeSymbol tuple = (TupleTypeSymbol) symbol;
             List<Schema> arrayItems = new ArrayList<>();
             for (TypeSymbol typeSymbol : tuple.memberTypeDescriptors()) {
                 Schema<?> openApiSchema = ConverterCommonUtils.getOpenApiSchema(typeSymbol.signature());
-                // Handle type reference type
+                // Handle type_reference type
                 if (typeSymbol instanceof TypeReferenceTypeSymbol) {
                     openApiSchema.set$ref(typeSymbol.signature());
                     createComponentSchema(schema, typeSymbol);

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/utils/ConverterCommonUtils.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/utils/ConverterCommonUtils.java
@@ -115,6 +115,7 @@ public class ConverterCommonUtils {
                 schema = new BooleanSchema();
                 break;
             case Constants.ARRAY:
+            case Constants.TUPLE:
                 schema = new ArraySchema();
                 break;
             case Constants.INT:

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/DataTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/DataTypeTests.java
@@ -54,6 +54,13 @@ public class DataTypeTests {
         TestUtils.compareWithGeneratedFile(ballerinaFilePath, "data_type/nullable_type_def.yaml");
     }
 
+    @Test(description = "test for tuple type scenarios")
+    public void testForTupleType() throws IOException {
+        Path ballerinaFilePath = RES_DIR.resolve("data_type/tuple_types.bal");
+        //Compare generated yaml file with expected yaml content
+        TestUtils.compareWithGeneratedFile(ballerinaFilePath, "data_type/tuple_type.yaml");
+    }
+
     @AfterMethod
     public void cleanUp() {
         TestUtils.deleteDirectory(this.tempDir);

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/data_type/tuple_types.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/data_type/tuple_types.bal
@@ -1,0 +1,21 @@
+import ballerina/http;
+
+public type Pet record {
+    int id;
+    [int, string, decimal, float, User] address;
+    ReturnTypes? tuples;
+    [int, decimal]? unionTuple;
+};
+
+public type User readonly & record {|
+    int id;
+    int age;
+|};
+
+public type ReturnTypes readonly & [int, decimal];
+
+service /payloadV on new http:Listener(9090) {
+    resource function post .(@http:Payload Pet payload) {
+
+    }
+}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/tuple_type.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/tuple_type.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
+paths:
+  /:
+    post:
+      operationId: post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        "202":
+          description: Accepted
+components:
+  schemas:
+    User:
+      required:
+        - age
+        - id
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        age:
+          type: integer
+          format: int64
+    ReturnTypes:
+      type: array
+      items:
+        oneOf:
+          - type: integer
+            format: int64
+          - type: number
+            format: double
+    Pet:
+      required:
+        - address
+        - id
+        - tuples
+        - unionTuple
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        address:
+          type: array
+          items:
+            oneOf:
+              - type: integer
+                format: int64
+              - type: string
+              - type: number
+                format: double
+              - type: number
+                format: float
+              - $ref: '#/components/schemas/User'
+        tuples:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/ReturnTypes'
+        unionTuple:
+          type: array
+          nullable: true
+          items:
+            oneOf:
+              - type: integer
+                format: int64
+              - type: number
+                format: double


### PR DESCRIPTION
## Purpose
Fix https://github.com/ballerina-platform/openapi-tools/issues/1024
https://github.com/wso2-enterprise/internal-support-ballerina/issues/126
> Given the support for tuple type mapping ballerina to openAPI, in OpenAPI tuples are represent in using array type with oneOf composed schema.

```ballerina
import ballerina/http;

public type Pet record {
    int id;
//01 tuple type in record field (including possible data types)
    [int, string, decimal, float, User] address;
//02 tuple type in user defined data type
    ReturnTypes tuples;
//03 tuple type with nullable enable
    [int, decimal]? unionTuple;
};

public type User readonly & record {|
    int id;
    int age;
|};

public type ReturnTypes readonly & [int, decimal];

service /payloadV on new http:Listener(9090) {
    resource function post .(@http:Payload Pet payload) {

    }
}
```
```openapi
openapi: 3.0.1
info:
  title: PayloadV
  version: 0.0.0
servers:
  - url: "{server}:{port}/payloadV"
    variables:
      server:
        default: http://localhost
      port:
        default: "9090"
paths:
  /:
    post:
      operationId: post
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Pet'
      responses:
        "202":
          description: Accepted
components:
  schemas:
    User:
      required:
        - age
        - id
      type: object
      properties:
        id:
          type: integer
          format: int64
        age:
          type: integer
          format: int64
    ReturnTypes:
      type: array
      items:
        oneOf:
          - type: integer
            format: int64
          - type: number
            format: double
    Pet:
      required:
        - address
        - id
        - tuples
        - unionTuple
      type: object
      properties:
        id:
          type: integer
          format: int64
        address:
          type: array
          items:
            oneOf:
              - type: integer
                format: int64
              - type: string
              - type: number
                format: double
              - type: number
                format: float
              - $ref: '#/components/schemas/User'
        tuples:
          - $ref: '#/components/schemas/ReturnTypes'
        unionTuple:
          type: array
          nullable: true
          items:
            oneOf:
              - type: integer
                format: int64
              - type: number
                format: double
```

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests  - add
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
