### PR TITLE
Replace Slack channel with discord in `module-ballerina-openapi/Package.md`

### DIFF
--- a/module-ballerina-openapi/Package.md
+++ b/module-ballerina-openapi/Package.md
@@ -14,7 +14,7 @@ To report bugs, request new features, start new discussions, etc., go to the [op
 ### Useful Links
 
 * Discuss about code changes of the Ballerina project in [ballerina-dev@googlegroups.com](mailto:ballerina-dev@googlegroups.com).
-* Chat live with us via our [Slack channel](https://ballerina.io/community/slack/).
+* Chat live with us via our [Discord server](https://discord.gg/ballerinalang).
 * Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag.
 * View the [Ballerina performance test results](performance/benchmarks/summary.md).
 


### PR DESCRIPTION
## Purpose
- Replace Slack channel with discord in `module-ballerina-openapi/Package.md`

## Related Issue
- https://github.com/ballerina-platform/ballerina-standard-library/issues/3463