### PR TITLE
[1.2.x]Fix unsupported response and request body type in service generation resource functions

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/GeneratorConstants.java
@@ -354,4 +354,5 @@ public class GeneratorConstants {
     public static final String EXCLUSIVE_MIN = "minValueExclusive";
     public static final String SPECIAL_CHARACTER_REGEX = "([\\[\\]\\\\?!<>@#&~`*\\-=^+'();:\\/\\_{}\\s|.$])";
     public static final String HTTP_VERSION = "http:HttpVersion";
+    public static final String HTTP_REQUEST = "http:Request";
 }

--- a/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/RequestBodyGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/generators/service/RequestBodyGenerator.java
@@ -35,6 +35,7 @@ import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import io.ballerina.openapi.exception.BallerinaOpenApiException;
 import io.ballerina.openapi.generators.GeneratorConstants;
+import io.ballerina.openapi.generators.GeneratorUtils;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.MediaType;
@@ -46,25 +47,18 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
+import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyNodeList;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createIdentifierToken;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createToken;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createArrayTypeDescriptorNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createBuiltinSimpleNameReferenceNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createRequiredParameterNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createSimpleNameReferenceNode;
-import static io.ballerina.openapi.generators.GeneratorConstants.APPLICATION_JSON;
-import static io.ballerina.openapi.generators.GeneratorConstants.APPLICATION_OCTET_STREAM;
-import static io.ballerina.openapi.generators.GeneratorConstants.APPLICATION_URL_ENCODE;
-import static io.ballerina.openapi.generators.GeneratorConstants.APPLICATION_XML;
-import static io.ballerina.openapi.generators.GeneratorConstants.MEDIA_TYPE_KEYWORD;
+import static io.ballerina.openapi.generators.GeneratorConstants.HTTP_REQUEST;
 import static io.ballerina.openapi.generators.GeneratorConstants.PAYLOAD;
-import static io.ballerina.openapi.generators.GeneratorConstants.PAYLOAD_KEYWORD;
-import static io.ballerina.openapi.generators.GeneratorConstants.TEXT;
-import static io.ballerina.openapi.generators.GeneratorConstants.TEXT_WILDCARD_REGEX;
-import static io.ballerina.openapi.generators.GeneratorUtils.SINGLE_WS_MINUTIAE;
-import static io.ballerina.openapi.generators.GeneratorUtils.getValidName;
 import static io.ballerina.openapi.generators.service.ServiceGenerationUtils.extractReferenceType;
 import static io.ballerina.openapi.generators.service.ServiceGenerationUtils.getAnnotationNode;
 import static io.ballerina.openapi.generators.service.ServiceGenerationUtils.getMediaTypeToken;
@@ -86,13 +80,12 @@ public class RequestBodyGenerator {
     /**
      * This for creating request Body for given request object.
      */
-    public RequiredParameterNode createNodeForRequestBody()
-            throws BallerinaOpenApiException {
+    public RequiredParameterNode createNodeForRequestBody() throws BallerinaOpenApiException {
         // type CustomRecord record {| anydata...; |};
         // public type PayloadType string|json|xml|byte[]|CustomRecord|CustomRecord[] ;
         List<Node> literals = new ArrayList<>();
         MappingConstructorExpressionNode annotValue = null;
-        TypeDescriptorNode typeName;
+        Optional<TypeDescriptorNode> typeName;
         // Filter same data type
         HashSet<Map.Entry<String, MediaType>> equalDataType = filterMediaTypes(requestBody);
         if (!equalDataType.isEmpty()) {
@@ -105,69 +98,75 @@ public class RequestBodyGenerator {
             Map.Entry<String, MediaType> mime = content.next();
             equalDataType.add(mime);
             typeName = getNodeForPayloadType(components, mime);
-            if (mime.getKey().equals(APPLICATION_URL_ENCODE)) {
+            if (mime.getKey().equals(GeneratorConstants.APPLICATION_URL_ENCODE)) {
                 SeparatedNodeList<MappingFieldNode> fields = fillRequestAnnotationValues(literals, equalDataType);
                 annotValue = NodeFactory.createMappingConstructorExpressionNode(
                         createToken(SyntaxKind.OPEN_BRACE_TOKEN), fields, createToken(SyntaxKind.CLOSE_BRACE_TOKEN));
             }
         }
-        AnnotationNode annotationNode = getAnnotationNode(PAYLOAD_KEYWORD, annotValue);
-        NodeList<AnnotationNode> annotation =  NodeFactory.createNodeList(annotationNode);
-        Token paramName = createIdentifierToken(PAYLOAD, SINGLE_WS_MINUTIAE, SINGLE_WS_MINUTIAE);
-        return createRequiredParameterNode(annotation, typeName, paramName);
+        if (typeName.isEmpty()) {
+            return createRequiredParameterNode(createEmptyNodeList(),
+                    createSimpleNameReferenceNode(createIdentifierToken(HTTP_REQUEST)), createIdentifierToken(PAYLOAD));
+        }
+        AnnotationNode annotationNode = getAnnotationNode(GeneratorConstants.PAYLOAD_KEYWORD, annotValue);
+        NodeList<AnnotationNode> annotation = NodeFactory.createNodeList(annotationNode);
+        Token paramName = createIdentifierToken(GeneratorConstants.PAYLOAD, GeneratorUtils.SINGLE_WS_MINUTIAE,
+                GeneratorUtils.SINGLE_WS_MINUTIAE);
+        return createRequiredParameterNode(annotation, typeName.get(), paramName);
     }
 
     /**
      * This util function is for generating type node for request payload in resource function.
      */
-    private TypeDescriptorNode getNodeForPayloadType(Components components, Map.Entry<String, MediaType> mediaType)
-            throws BallerinaOpenApiException {
-        TypeDescriptorNode typeName;
+    private Optional<TypeDescriptorNode> getNodeForPayloadType(Components components, Map.Entry<String,
+            MediaType> mediaType) throws BallerinaOpenApiException {
+
+        Optional<TypeDescriptorNode> typeName;
         if (mediaType.getValue().getSchema().get$ref() != null) {
             String schemaName = extractReferenceType(mediaType.getValue().getSchema().get$ref());
             Map<String, Schema> schemas = components.getSchemas();
             String mediaTypeContent = mediaType.getKey().trim();
-            if (mediaTypeContent.matches(TEXT_WILDCARD_REGEX)) {
-                mediaTypeContent = TEXT;
+            if (mediaTypeContent.matches(GeneratorConstants.TEXT_WILDCARD_REGEX)) {
+                mediaTypeContent = GeneratorConstants.TEXT;
             }
             IdentifierToken identifierToken;
             switch (mediaTypeContent) {
-                case APPLICATION_XML:
+                case GeneratorConstants.APPLICATION_XML:
                     identifierToken = createIdentifierToken(GeneratorConstants.XML);
-                    typeName = createSimpleNameReferenceNode(identifierToken);
+                    typeName = Optional.ofNullable(createSimpleNameReferenceNode(identifierToken));
                     break;
-                case TEXT:
+                case GeneratorConstants.TEXT:
                     identifierToken = createIdentifierToken(GeneratorConstants.STRING);
-                    typeName = createSimpleNameReferenceNode(identifierToken);
+                    typeName = Optional.ofNullable(createSimpleNameReferenceNode(identifierToken));
                     break;
-                case APPLICATION_OCTET_STREAM:
+                case GeneratorConstants.APPLICATION_OCTET_STREAM:
                     ArrayDimensionNode dimensionNode = NodeFactory.createArrayDimensionNode(
                             createToken(SyntaxKind.OPEN_BRACKET_TOKEN), null,
                             createToken(SyntaxKind.CLOSE_BRACKET_TOKEN));
-                    typeName = createArrayTypeDescriptorNode(createBuiltinSimpleNameReferenceNode(
+                    typeName = Optional.ofNullable(createArrayTypeDescriptorNode(createBuiltinSimpleNameReferenceNode(
                                     null, createIdentifierToken(GeneratorConstants.BYTE)),
-                            NodeFactory.createNodeList(dimensionNode));
+                            NodeFactory.createNodeList(dimensionNode)));
                     break;
-                case APPLICATION_JSON:
-                    Schema<?> schema = schemas.get(getValidName(schemaName, true));
+                case GeneratorConstants.APPLICATION_JSON:
+                    Schema<?> schema = schemas.get(GeneratorUtils.getValidName(schemaName, true));
                     // This condition is to avoid wrong code generation for union type request body. If given schema
                     // has oneOf type , then it will not be able to support via ballerina. We need to pick it mime
                     // type instead of schema type.
                     if ((schema instanceof ComposedSchema) && (((ComposedSchema) schema).getOneOf() != null)) {
                         identifierToken = createIdentifierToken(GeneratorConstants.JSON);
-                        typeName = createSimpleNameReferenceNode(identifierToken);
+                        typeName = Optional.ofNullable(createSimpleNameReferenceNode(identifierToken));
                     } else {
-                        typeName = createSimpleNameReferenceNode(createIdentifierToken(
-                                getValidName(schemaName, true)));
+                        typeName = Optional.ofNullable(createSimpleNameReferenceNode(createIdentifierToken(
+                                GeneratorUtils.getValidName(schemaName, true))));
                     }
                     break;
-                case APPLICATION_URL_ENCODE:
-                    typeName = createSimpleNameReferenceNode(createIdentifierToken(
-                            getValidName(schemaName, true)));
+                case GeneratorConstants.APPLICATION_URL_ENCODE:
+                    typeName = Optional.ofNullable(createSimpleNameReferenceNode(createIdentifierToken(
+                            GeneratorUtils.getValidName(schemaName, true))));
                     break;
                 default:
                     identifierToken = createIdentifierToken(GeneratorConstants.JSON);
-                    typeName = createSimpleNameReferenceNode(identifierToken);
+                    typeName = Optional.ofNullable(createSimpleNameReferenceNode(identifierToken));
             }
         } else {
             typeName = getMediaTypeToken(mediaType);
@@ -176,26 +175,26 @@ public class RequestBodyGenerator {
     }
 
     /**
-     *  This function fill the annotation values.
-     *
-     *  01. when field has some override media type
-     *  <pre> @http:Payload{mediaType: "application/x-www-form-urlencoded"} User payload</pre>
-     *  02. when field has list media value
-     *  <pre> @http:Payload{mediaType: ["application/json", "application/snowflake+json"]} User payload</pre>
-     *
+     * This function fill the annotation values.
+     * <p>
+     * 01. when field has some override media type
+     * <pre> @http:Payload{mediaType: "application/x-www-form-urlencoded"} User payload</pre>
+     * 02. when field has list media value
+     * <pre> @http:Payload{mediaType: ["application/json", "application/snowflake+json"]} User payload</pre>
      */
     private SeparatedNodeList<MappingFieldNode> fillRequestAnnotationValues(List<Node> literals,
                                                                             HashSet<Map.Entry<String,
                                                                                     MediaType>> equalDataTypes) {
+
         Token comma = createToken(SyntaxKind.COMMA_TOKEN);
-        IdentifierToken mediaType = createIdentifierToken(MEDIA_TYPE_KEYWORD);
+        IdentifierToken mediaType = createIdentifierToken(GeneratorConstants.MEDIA_TYPE_KEYWORD);
 
         Iterator<Map.Entry<String, MediaType>> iter = equalDataTypes.iterator();
         SpecificFieldNode specificFieldNode;
         while (iter.hasNext()) {
             Map.Entry<String, MediaType> next = iter.next();
-            literals.add(createIdentifierToken('"' + next.getKey().trim() + '"', SINGLE_WS_MINUTIAE,
-                    SINGLE_WS_MINUTIAE));
+            literals.add(createIdentifierToken('"' + next.getKey().trim() + '"', GeneratorUtils.SINGLE_WS_MINUTIAE,
+                    GeneratorUtils.SINGLE_WS_MINUTIAE));
             literals.add(comma);
         }
         literals.remove(literals.size() - 1);
@@ -218,6 +217,7 @@ public class RequestBodyGenerator {
     //Extract same datatype
     private HashSet<Map.Entry<String, MediaType>> filterMediaTypes(RequestBody requestBody)
             throws BallerinaOpenApiException {
+
         HashSet<Map.Entry<String, MediaType>> equalDataType = new HashSet<>();
         Set<Map.Entry<String, MediaType>> entries = requestBody.getContent().entrySet();
         Iterator<Map.Entry<String, MediaType>> iterator = entries.iterator();
@@ -240,6 +240,7 @@ public class RequestBodyGenerator {
     private void getSameDataTypeMedia(HashSet<Map.Entry<String, MediaType>> equalDataType,
                                       List<Map.Entry<String, MediaType>> updatedEntries,
                                       Map.Entry<String, MediaType> mediaTypeEntry) throws BallerinaOpenApiException {
+
         for (Map.Entry<String, MediaType> updateNext : updatedEntries) {
             MediaType parentValue = mediaTypeEntry.getValue();
             MediaType childValue = updateNext.getValue();

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ReturnTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ReturnTypeTests.java
@@ -23,7 +23,6 @@ import io.ballerina.openapi.cmd.Filter;
 import io.ballerina.openapi.exception.BallerinaOpenApiException;
 import io.ballerina.openapi.generators.GeneratorUtils;
 import io.swagger.v3.oas.models.OpenAPI;
-import org.ballerinalang.formatter.core.FormatterException;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -45,7 +44,7 @@ public class ReturnTypeTests {
 
     // Response scenarios
     @Test(description = "Scenario 01 - Response has single response without content type")
-    public void generateResponseScenario01() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario01() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_01_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -54,7 +53,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 02 - Single response with content type")
-    public void generateResponseScenario02() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario02() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_02_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -63,7 +62,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 03 - Single response with content type application/json")
-    public void generateResponseScenario03() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario03() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_03_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -72,7 +71,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 04 - Response has multiple responses without content type")
-    public void generateResponseScenario04() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario04() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_04_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -81,7 +80,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 05 - Error response with a schema")
-    public void generateResponseScenario05() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario05() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_05_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -90,7 +89,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 06 - Error response with a schema with application/json")
-    public void generateResponseScenario06() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario06() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_06_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -99,7 +98,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 07 - Single response has multiple content types")
-    public void generateResponseScenario07() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario07() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_07_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -108,7 +107,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 08 - Single response has inline record for dataType")
-    public void generateResponseScenario08() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario08() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_08_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -117,7 +116,8 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 09 - Single response has inline record for dataType with different status code")
-    public void generateResponseScenario09() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario09() throws IOException, BallerinaOpenApiException {
+
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_09_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -126,7 +126,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 10 - Response with a custom media type")
-    public void generateResponseScenario10() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario10() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_10_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -135,7 +135,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 11 - Response has OneOf and AnyOf type 200 ok")
-    public void generateResponseScenario11() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario11() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_11_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -144,7 +144,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 12 - Response has OneOf and AnyOf type for error status code")
-    public void generateResponseScenario12() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario12() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_12_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -153,7 +153,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 13 - Single response has multiple content types with different error code")
-    public void generateResponseScenario13() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario13() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_13_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -162,7 +162,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 14 - Multiple response with same mediaType")
-    public void generateResponseScenario14() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario14() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_14_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -171,7 +171,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 15 - Response has array type data Binding")
-    public void generateResponseScenario15() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario15() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_15_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -180,7 +180,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 16 - Response has array type data Binding with error code")
-    public void generateResponseScenario16() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario16() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_16_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -189,7 +189,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Scenario 19 - Multiple response with different mediaType")
-    public void generateResponseScenario19() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void generateResponseScenario19() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/scenario_19_rs.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -216,8 +216,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Default response handling")
-    public void generateResponseDefault() throws IOException, BallerinaOpenApiException,
-            FormatterException {
+    public void generateResponseDefault() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/petstore_default.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -227,7 +226,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Path with special characters ")
-    public void testWithSpecialCharacters() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void testWithSpecialCharacters() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/path_with_special_characters.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -237,7 +236,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Response has different status code except 200")
-    public void testWithDifferentStatusCode() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void testWithDifferentStatusCode() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/different_status_code.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -256,7 +255,7 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Response and Request body have inline object schema")
-    public void testWithInlineObjectSchema() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void testWithInlineObjectSchema() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/inline_record_type_request_response.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
@@ -276,11 +275,21 @@ public class ReturnTypeTests {
     }
 
     @Test(description = "Single response without content type.")
-    public void singleResponseWithOutContent() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void singleResponseWithOutContent() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/response/content_null.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
         syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("response/content_null.bal", syntaxTree);
+    }
+
+    @Test
+    public void testForUnsupportedReturnPayload() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/response/unsupportedPayloadType.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(openAPI, filter);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("response/unsupportedPayload.bal",
+                syntaxTree);
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_requestBody.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_requestBody.bal
@@ -3,7 +3,7 @@ import ballerina/http;
 listener http:Listener ep0 = new (9090, config = {host: "localhost"});
 
 service / on ep0 {
-    resource function put storageSpaces01(@http:Payload json payload) returns http:Ok {
+    resource function put storageSpaces01(http:Request payload) returns http:Ok {
     }
     resource function post storageSpaces01(@http:Payload json payload) returns http:Ok {
     }
@@ -11,6 +11,8 @@ service / on ep0 {
     }
     resource function post storageSpaces02(@http:Payload xml payload) returns http:Ok {
     }
-    resource function put storageSpaces/[string  name](@http:Payload json payload) returns http:Ok|http:BadRequest {
+    resource function put storageSpaces/[string name](@http:Payload json payload) returns http:Ok|http:BadRequest {
+    }
+    resource function post storageSpaces03(http:Request payload) returns http:Ok {
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/response/scenario_10_rs.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/response/scenario_10_rs.bal
@@ -3,6 +3,6 @@ import ballerina/http;
 listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
 
 service /v1 on ep0 {
-    resource function post pets() returns json {
+    resource function post pets() returns http:Response {
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/response/scenario_15_rs.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/response/scenario_15_rs.bal
@@ -5,4 +5,10 @@ listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
 service /v1 on ep0 {
     resource function post pets() returns Pet[] {
     }
+    resource function post pets02() returns string[] {
+    }
+    resource function post pets03() returns json {
+    }
+    resource function post pets04() returns http:Response {
+    }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/response/unsupportedPayload.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/response/unsupportedPayload.bal
@@ -1,0 +1,14 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
+
+service /v1 on ep0 {
+    resource function get store/inventory() returns json {
+    }
+    resource function put store/inventory() returns http:Response {
+    }
+    resource function post store/inventory() returns http:Response {
+    }
+    resource function delete store/inventory() returns json|http:Response {
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/swagger/requestBody/oneOf_request_body.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/requestBody/oneOf_request_body.yaml
@@ -88,6 +88,21 @@ paths:
           description: Successful operation.
         400:
           description: Invalid storage space name supplied
+  /storageSpaces03:
+    post:
+      summary: "Unsupported scenario 03: Request body with oneOf schema"
+      operationId: postKey03
+      requestBody:
+        description: "Ballerina not support for oneOf data type in request body"
+        content:
+          application/snowflake+xml:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        200:
+          description: Successful operation.
 components:
   schemas:
     HandleRequest_RequestBody:

--- a/openapi-cli/src/test/resources/generators/service/swagger/response/scenario_15_rs.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/response/scenario_15_rs.yaml
@@ -36,7 +36,44 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Pet'
-
+  /pets02:
+    post:
+      summary: Creates a new pets.
+      responses:
+        '200':
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /pets03:
+    post:
+      summary: Creates a new pets.
+      responses:
+        '200':
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: {}
+  /pets04:
+    post:
+      summary: Creates a new pets.
+      responses:
+        '200':
+          description: A list of pets.
+          content:
+            application/snowflake+json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: { }
 
 
 components:

--- a/openapi-cli/src/test/resources/generators/service/swagger/response/unsupportedPayloadType.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/response/unsupportedPayloadType.yaml
@@ -1,0 +1,113 @@
+openapi: 3.0.0
+info:
+  title: refComponent
+  description: refComponent
+  version: 1.0.0
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+paths:
+  /store/inventory:
+    get:
+      tags:
+        - store
+        - pet
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: "id_01"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+    put:
+      tags:
+        - store
+        - pet
+      operationId: "id_02"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/snowflake+json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+    delete:
+      tags:
+        - store
+        - pet
+      operationId: "id_03"
+      responses:
+       "200":
+         description: successful operation
+         content:
+           application/json:
+             schema:
+               type: object
+               additionalProperties:
+                 type: integer
+                 format: int32
+           application/snowflake+json:
+             schema:
+              type: object
+              additionalProperties:
+                type: integer
+                format: int32
+           application/snowflake+xml:
+             schema:
+               type: object
+               additionalProperties:
+                 type: integer
+                 format: int32
+    post:
+      tags:
+        - store
+        - pet
+      operationId: "id_04"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json+v:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+            application/snowflake+json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+            application/snowflake+xml:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32


### PR DESCRIPTION
## Purpose
> There are two types of unsupported return type scenarios.

Scenario 01 : When the response schema type is unsupported and its content type is supported. 
```openapi
/store/inventory:
    get:
      tags:
        - store
      summary: Returns pet inventories by status
      description: Returns a map of status codes to quantities
      operationId: getInventory
      responses:
        '200':
          description: successful operation
          content:
            application/json:
              schema:
                type: object
                additionalProperties:
                  type: integer
                  format: int32
```
generated invalid cod is there
```ballerina
resource function get store/inventory() returns object {
    }
```
Expected code for the unsupported schema type response
```ballerina
resource function get store/inventory() returns json {
    }
```
Scenario 02 : When the response both schema type and media type are unsupported. 

```openapi
/store/inventory:
    get:
      tags:
        - store
      summary: Returns pet inventories by status
      description: Returns a map of status codes to quantities
      operationId: getInventory
      responses:
        '200':
          description: successful operation
          content:
            application/snowflake+json:
              schema:
                type: object
                additionalProperties:
                  type: integer
                  format: int32
```
generated invalid code is there
```ballerina
resource function get store/inventory() returns object {
    }
```
Expected code for the unsupported media type  response
```ballerina
resource function get store/inventory() returns http:Response {
    }
```

Fix #https://github.com/wso2-enterprise/internal-support-ballerina/issues/219 , Therefore this mentioned issue is handled when we fix scenario 01. because the above response content type can be handled via http responses. 

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.