### PR TITLE
[1.3.x] Fix function generation for wildcard (*/*) type request bodies and responses

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -145,6 +145,14 @@ public class FunctionBodyNodeTests {
                 {"swagger/map_schema_response.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
                         "        // TODO: Update the request as needed;\n" +
                         "        json response = check self.clientEp->post(resourcePath, request);\n" +
+                        "        return response;}"},
+                {"swagger/array_response_pdf.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
+                        "        // TODO: Update the request as needed;\n" +
+                        "        http:Response response = check self.clientEp->post(resourcePath, request);\n" +
+                        "        return response;}"},
+                {"swagger/any_type_response.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
+                        "        // TODO: Update the request as needed;\n" +
+                        "        http:Response response = check self.clientEp->post(resourcePath, request);\n" +
                         "        return response;}"}
         };
     }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -108,7 +108,7 @@ public class FunctionBodyNodeTests {
                         "request.setPayload(xmlBody, \"application/xml\");" +
                         "http:Response response = check self.clientEp->post(resourcePath, request);" +
                         "return response;}"},
-                {"swagger/response_type_order.yaml", "/pet/{petId}", 
+                {"swagger/response_type_order.yaml", "/pet/{petId}",
                         "{string resourcePath = string `/pet/${getEncodedUri(petId)}`;" +
                         "Pet response = check self.clientEp->get(resourcePath);" +
                         "return response;}"},
@@ -137,7 +137,15 @@ public class FunctionBodyNodeTests {
                         "mime:Entity[] bodyParts = check createBodyParts(payload, encodingMap);\n" +
                         "request.setBodyParts(bodyParts);\n" +
                         "http:Response response = check self.clientEp->post(resourcePath, request);\n" +
-                        "return response;}"}
+                        "return response;}"},
+                {"swagger/empty_object_responnse.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
+                        "        // TODO: Update the request as needed;\n" +
+                        "        json response = check self.clientEp->post(resourcePath, request);\n" +
+                        "        return response;}"},
+                {"swagger/map_schema_response.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
+                        "        // TODO: Update the request as needed;\n" +
+                        "        json response = check self.clientEp->post(resourcePath, request);\n" +
+                        "        return response;}"}
         };
     }
 

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -194,7 +194,7 @@ public class RequestBodyTests {
     }
 
     @Test(description = "Test for generating request body when operation has */* media type")
-    public void testRequestBodyWithAllTypeMediaType() throws IOException, BallerinaOpenApiException {
+    public void testRequestBodyWithWildCardeMediaType() throws IOException, BallerinaOpenApiException {
         Path expectedPath = RES_DIR.resolve("ballerina/any_types_payload.bal");
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(
                 RES_DIR.resolve("swagger/any_types_payload.yaml"), true);

--- a/openapi-cli/src/test/resources/generators/client/ballerina/any_types_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/any_types_payload.bal
@@ -36,13 +36,11 @@ public isolated client class Client {
     }
     # Create a pet
     #
-    # + return - Null response
-    remote isolated function createPet(byte[] payload) returns http:Response|error {
+    # + return - Successful operation
+    remote isolated function createPet(http:Request request) returns http:Response|error {
         string resourcePath = string `/pets`;
-        http:Request request = new;
-        request.setPayload(payload);
+        // TODO: Update the request as needed;
         http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }
-

--- a/openapi-cli/src/test/resources/generators/client/ballerina/any_types_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/any_types_payload.bal
@@ -36,7 +36,7 @@ public isolated client class Client {
     }
     # Create a pet
     #
-    # + return - Successful operation
+    # + return - Null response
     remote isolated function createPet(http:Request request) returns http:Response|error {
         string resourcePath = string `/pets`;
         // TODO: Update the request as needed;

--- a/openapi-cli/src/test/resources/generators/client/swagger/any_type_response.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/any_type_response.yaml
@@ -20,5 +20,9 @@ paths:
               items:
                 type: string
       responses:
-        '201':
-          description: Null response
+        '200':
+          description: Successful operation
+          content:
+            '*/*':
+              example:
+                summary: Pet Response

--- a/openapi-cli/src/test/resources/generators/client/swagger/any_types_payload.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/any_types_payload.yaml
@@ -20,5 +20,9 @@ paths:
               items:
                 type: string
       responses:
-        '201':
-          description: Null response
+        '200':
+          description: Successful operation
+          content:
+            '*/*':
+              example:
+                summary: Pet Response

--- a/openapi-cli/src/test/resources/generators/client/swagger/array_response_pdf.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/array_response_pdf.yaml
@@ -1,0 +1,93 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - pets
+      requestBody:
+        description: "Request to add a pet"
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/Pets"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            'application/pdf':
+              schema:
+                type: array
+                items:
+                  description: "Pet records"
+
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+    Dog:
+      allOf:
+        - $ref: "#/components/schemas/Pet"
+        - type: object
+          properties:
+            bark:
+              type: boolean
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/openapi-cli/src/test/resources/generators/client/swagger/empty_object_responnse.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/empty_object_responnse.yaml
@@ -1,0 +1,90 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - pets
+      requestBody:
+        description: "Request to add a pet"
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/Pets"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            'application/json':
+              schema:
+                type: object
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+    Dog:
+      allOf:
+        - $ref: "#/components/schemas/Pet"
+        - type: object
+          properties:
+            bark:
+              type: boolean
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/openapi-cli/src/test/resources/generators/client/swagger/map_schema_response.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/map_schema_response.yaml
@@ -1,0 +1,97 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - pets
+      requestBody:
+        description: "Request to add a pet"
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/Pets"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            'application/json':
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    code:
+                      type: integer
+                    text:
+                      type: string
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+    Dog:
+      allOf:
+        - $ref: "#/components/schemas/Pet"
+        - type: object
+          properties:
+            bark:
+              type: boolean
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorConstants.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorConstants.java
@@ -122,6 +122,8 @@ public class GeneratorConstants {
     public static final String HEADER_VALUES = "headerValues";
     public static final String PAYLOAD = "payload";
     public static final String PAYLOAD_KEYWORD = "Payload";
+    public static final String REQUEST = "request";
+    public static final String HTTP_REQUEST = "http:Request";
     public static final String PDF = "pdf";
     public static final String QUERY_PARAM = "queryParam";
     public static final String SELF = "self";

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -133,6 +133,8 @@ import static io.ballerina.openapi.core.GeneratorConstants.DOUBLE_LINE_SEPARATOR
 import static io.ballerina.openapi.core.GeneratorConstants.EXPLODE;
 import static io.ballerina.openapi.core.GeneratorConstants.GET;
 import static io.ballerina.openapi.core.GeneratorConstants.HEAD;
+import static io.ballerina.openapi.core.GeneratorConstants.HTTP_REQUEST;
+import static io.ballerina.openapi.core.GeneratorConstants.HTTP_RESPONSE;
 import static io.ballerina.openapi.core.GeneratorConstants.IDENTIFIER;
 import static io.ballerina.openapi.core.GeneratorConstants.IMAGE_PNG;
 import static io.ballerina.openapi.core.GeneratorConstants.JSON_EXTENSION;
@@ -141,7 +143,6 @@ import static io.ballerina.openapi.core.GeneratorConstants.OPEN_CURLY_BRACE;
 import static io.ballerina.openapi.core.GeneratorConstants.SERVICE_FILE_NAME;
 import static io.ballerina.openapi.core.GeneratorConstants.SLASH;
 import static io.ballerina.openapi.core.GeneratorConstants.SPECIAL_CHARACTERS_REGEX;
-import static io.ballerina.openapi.core.GeneratorConstants.SQUARE_BRACKETS;
 import static io.ballerina.openapi.core.GeneratorConstants.STRING;
 import static io.ballerina.openapi.core.GeneratorConstants.STYLE;
 import static io.ballerina.openapi.core.GeneratorConstants.TYPE_FILE_NAME;
@@ -409,9 +410,9 @@ public class GeneratorUtils {
     }
 
     /**
-     * Generate BallerinaMediaType for all the mediaTypes.
+     * Generate BallerinaMediaType for all the return mediaTypes.
      */
-    public static String getBallerinaMediaType(String mediaType) {
+    public static String getBallerinaMediaType(String mediaType, boolean isRequest) {
 
         switch (mediaType) {
             case MediaType.APPLICATION_JSON:
@@ -426,10 +427,9 @@ public class GeneratorUtils {
             case MediaType.APPLICATION_OCTET_STREAM:
             case APPLICATION_PDF:
             case ANY_TYPE:
-                return SyntaxKind.BYTE_KEYWORD.stringValue() + SQUARE_BRACKETS;
+                return isRequest ? HTTP_REQUEST : HTTP_RESPONSE;
             default:
                 return SyntaxKind.JSON_KEYWORD.stringValue();
-            // TODO: fill other types
         }
     }
 

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionBodyGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionBodyGenerator.java
@@ -100,6 +100,7 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_BRACE_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUESTION_MARK_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.STRING_KEYWORD;
+import static io.ballerina.openapi.core.GeneratorConstants.ANY_TYPE;
 import static io.ballerina.openapi.core.GeneratorConstants.API_KEYS_CONFIG;
 import static io.ballerina.openapi.core.GeneratorConstants.API_KEY_CONFIG_PARAM;
 import static io.ballerina.openapi.core.GeneratorConstants.DELETE;
@@ -109,12 +110,15 @@ import static io.ballerina.openapi.core.GeneratorConstants.HEAD;
 import static io.ballerina.openapi.core.GeneratorConstants.HEADER;
 import static io.ballerina.openapi.core.GeneratorConstants.HEADER_VALUES;
 import static io.ballerina.openapi.core.GeneratorConstants.HTTP_HEADERS;
+import static io.ballerina.openapi.core.GeneratorConstants.HTTP_REQUEST;
+import static io.ballerina.openapi.core.GeneratorConstants.NEW;
 import static io.ballerina.openapi.core.GeneratorConstants.NILLABLE;
 import static io.ballerina.openapi.core.GeneratorConstants.PATCH;
 import static io.ballerina.openapi.core.GeneratorConstants.POST;
 import static io.ballerina.openapi.core.GeneratorConstants.PUT;
 import static io.ballerina.openapi.core.GeneratorConstants.QUERY;
 import static io.ballerina.openapi.core.GeneratorConstants.QUERY_PARAM;
+import static io.ballerina.openapi.core.GeneratorConstants.REQUEST;
 import static io.ballerina.openapi.core.GeneratorConstants.RESOURCE_PATH;
 import static io.ballerina.openapi.core.GeneratorConstants.RESPONSE;
 import static io.ballerina.openapi.core.GeneratorConstants.SELF;
@@ -645,10 +649,12 @@ public class FunctionBodyGenerator {
 
         //Create Request statement
         Map.Entry<String, MediaType> next = iterator.next();
-        VariableDeclarationNode requestVariable = GeneratorUtils.getSimpleStatement("http:Request",
-                "request", "new");
-        statementsList.add(requestVariable);
-        if (next.getValue() != null) {
+        if (!next.getKey().contains(ANY_TYPE)) {
+            VariableDeclarationNode requestVariable = GeneratorUtils.getSimpleStatement(HTTP_REQUEST,
+                    REQUEST, NEW);
+            statementsList.add(requestVariable);
+        }
+        if (next.getValue() != null && !next.getKey().contains(ANY_TYPE)) {
             genStatementsForRequestMediaType(statementsList, next);
             // TODO:Fill with other mime type
         } else {

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
@@ -206,12 +206,12 @@ public class FunctionReturnTypeGenerator {
                     media.getKey().trim().equals("image/png") ||
                     media.getKey().trim().equals("application/octet-stream")) {
                 String typeName = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false) + "Arr";
-                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false);
-                type = generateCustomTypeDefine(type, typeName, isSignature);
+                String mappedType = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false);
+                type = generateCustomTypeDefine(mappedType, typeName, isSignature);
             } else {
                 String typeName = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false) + "Arr";
-                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false) + "[]";
-                type = generateCustomTypeDefine(type, typeName, isSignature);
+                String mappedType = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false) + "[]";
+                type = generateCustomTypeDefine(mappedType, typeName, isSignature);
             }
         } else {
             String typeName;

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
@@ -106,7 +106,7 @@ public class FunctionReturnTypeGenerator {
                                 Schema schema = media.getValue().getSchema();
                                 type = getDataType(operation, isSignature, response, media, type, schema);
                             } else {
-                                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim());
+                                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false);
                             }
                             returnTypes.add(type);
                             // Currently support for first media type
@@ -173,7 +173,7 @@ public class FunctionReturnTypeGenerator {
         } else if (media.getKey().trim().equals("application/xml")) {
             type = generateCustomTypeDefine("xml", "XML", isSignature);
         } else {
-            type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim());
+            type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false);
         }
         return type;
     }
@@ -205,12 +205,12 @@ public class FunctionReturnTypeGenerator {
             } else if (media.getKey().trim().equals("application/pdf") ||
                     media.getKey().trim().equals("image/png") ||
                     media.getKey().trim().equals("application/octet-stream")) {
-                String typeName = GeneratorUtils.getBallerinaMediaType(media.getKey().trim()) + "Arr";
-                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim());
+                String typeName = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false) + "Arr";
+                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false);
                 type = generateCustomTypeDefine(type, typeName, isSignature);
             } else {
-                String typeName = GeneratorUtils.getBallerinaMediaType(media.getKey().trim()) + "Arr";
-                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim()) + "[]";
+                String typeName = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false) + "Arr";
+                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false) + "[]";
                 type = generateCustomTypeDefine(type, typeName, isSignature);
             }
         } else {
@@ -274,7 +274,7 @@ public class FunctionReturnTypeGenerator {
             type = extractReferenceType(ref.trim());
         } else if (properties != null) {
             if (properties.isEmpty()) {
-                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim());
+                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false);
             } else {
                 List<Node> returnTypeDocs = new ArrayList<>();
                 String description = operation.getResponses().entrySet().iterator().next().getValue().getDescription();
@@ -287,7 +287,7 @@ public class FunctionReturnTypeGenerator {
                 updateTypeDefinitionNodeList(type, recordNode);
             }
         } else {
-            type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim());
+            type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false);
         }
         return type;
     }
@@ -306,7 +306,7 @@ public class FunctionReturnTypeGenerator {
             type = extractReferenceType(ref.trim());
         } else if (properties != null) {
             if (properties.isEmpty()) {
-                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim());
+                type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false);
             } else {
                 List<Node> schemaDocs = new ArrayList<>();
                 String description = operation.getResponses().entrySet().iterator().next().getValue().getDescription();
@@ -319,7 +319,7 @@ public class FunctionReturnTypeGenerator {
                 updateTypeDefinitionNodeList(type, recordNode);
             }
         } else {
-            type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim());
+            type = GeneratorUtils.getBallerinaMediaType(media.getKey().trim(), false);
         }
         return type;
     }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
@@ -90,11 +90,13 @@ import static io.ballerina.openapi.core.GeneratorConstants.ARRAY;
 import static io.ballerina.openapi.core.GeneratorConstants.BINARY;
 import static io.ballerina.openapi.core.GeneratorConstants.BOOLEAN;
 import static io.ballerina.openapi.core.GeneratorConstants.BYTE;
+import static io.ballerina.openapi.core.GeneratorConstants.HTTP_REQUEST;
 import static io.ballerina.openapi.core.GeneratorConstants.INTEGER;
 import static io.ballerina.openapi.core.GeneratorConstants.NILLABLE;
 import static io.ballerina.openapi.core.GeneratorConstants.NUMBER;
 import static io.ballerina.openapi.core.GeneratorConstants.OBJECT;
 import static io.ballerina.openapi.core.GeneratorConstants.PAYLOAD;
+import static io.ballerina.openapi.core.GeneratorConstants.REQUEST;
 import static io.ballerina.openapi.core.GeneratorConstants.SQUARE_BRACKETS;
 import static io.ballerina.openapi.core.GeneratorConstants.STRING;
 import static io.ballerina.openapi.core.GeneratorConstants.VENDOR_SPECIFIC_TYPE;
@@ -490,9 +492,12 @@ public class FunctionSignatureGenerator {
             Map.Entry<String, MediaType> next = iterator.next();
             Schema schema = next.getValue().getSchema();
             String paramType = "";
+            String paramName = next.getKey().equals(ANY_TYPE) ? REQUEST : PAYLOAD;
             //Take payload type
             if (schema != null) {
-                if (next.getKey().equals(ANY_TYPE) || next.getKey().contains(VENDOR_SPECIFIC_TYPE)) {
+                if (next.getKey().equals(ANY_TYPE)) {
+                    paramType = HTTP_REQUEST;
+                } else if (next.getKey().contains(VENDOR_SPECIFIC_TYPE)) {
                     paramType = SyntaxKind.BYTE_KEYWORD.stringValue() + SQUARE_BRACKETS;
                 } else if (schema.get$ref() != null) {
                     paramType = getValidName(extractReferenceType(schema.get$ref().trim()), true);
@@ -510,21 +515,21 @@ public class FunctionSignatureGenerator {
                     ArraySchema arraySchema = (ArraySchema) schema;
                     paramType = getRequestBodyParameterForArraySchema(operationId, next, arraySchema);
                 } else { // composed and object schemas are handled by the flatten
-                    paramType = GeneratorUtils.getBallerinaMediaType(next.getKey());
+                    paramType = GeneratorUtils.getBallerinaMediaType(next.getKey(), true);
                 }
             } else {
-                paramType = GeneratorUtils.getBallerinaMediaType(next.getKey());
+                paramType = GeneratorUtils.getBallerinaMediaType(next.getKey(), true);
             }
             if (!paramType.isBlank()) {
                 List<AnnotationNode> annotationNodes = new ArrayList<>();
                 DocCommentsGenerator.extractDisplayAnnotation(requestBody.getExtensions(), annotationNodes);
                 SimpleNameReferenceNode typeName = createSimpleNameReferenceNode(createIdentifierToken(paramType));
-                IdentifierToken paramName = createIdentifierToken(PAYLOAD);
+                IdentifierToken paramNameToken = createIdentifierToken(paramName);
                 RequiredParameterNode payload = createRequiredParameterNode(
-                        createNodeList(annotationNodes), typeName, paramName);
+                        createNodeList(annotationNodes), typeName, paramNameToken);
                 if (requestBody.getDescription() != null && !requestBody.getDescription().isBlank()) {
                     MarkdownParameterDocumentationLineNode paramAPIDoc =
-                            DocCommentsGenerator.createAPIParamDoc(escapeIdentifier(PAYLOAD),
+                            DocCommentsGenerator.createAPIParamDoc(escapeIdentifier(paramName),
                                     requestBody.getDescription().split("\n")[0]);
                     requestBodyDoc.add(paramAPIDoc);
                 }
@@ -576,7 +581,7 @@ public class FunctionSignatureGenerator {
                     ballerinaSchemaGenerator.getTypeDefinitionNode(arraySchema, paramType, new ArrayList<>());
             functionReturnType.updateTypeDefinitionNodeList(paramType, arrayTypeNode);
         } else {
-            paramType = GeneratorUtils.getBallerinaMediaType(next.getKey().trim()) + SQUARE_BRACKETS;
+            paramType = GeneratorUtils.getBallerinaMediaType(next.getKey().trim(), true) + SQUARE_BRACKETS;
         }
         return paramType;
     }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/MimeFactory.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/MimeFactory.java
@@ -20,7 +20,6 @@ package io.ballerina.openapi.core.generators.client;
 
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
-import io.ballerina.openapi.core.generators.client.mime.AnyType;
 import io.ballerina.openapi.core.generators.client.mime.CustomType;
 import io.ballerina.openapi.core.generators.client.mime.JsonType;
 import io.ballerina.openapi.core.generators.client.mime.MimeType;
@@ -34,7 +33,6 @@ import io.swagger.v3.oas.models.media.Schema;
 import java.util.List;
 import java.util.Map;
 
-import static io.ballerina.openapi.core.GeneratorConstants.ANY_TYPE;
 import static io.ballerina.openapi.core.GeneratorConstants.IMAGE;
 import static io.ballerina.openapi.core.GeneratorConstants.JSON;
 import static io.ballerina.openapi.core.GeneratorConstants.PDF;
@@ -84,8 +82,6 @@ public class MimeFactory {
                 return new OctedStreamType();
             } else if (mediaType.equals(MULTIPART_FORM_DATA)) {
                 return new MultipartFormData(imports, ballerinaUtilGenerator);
-            } else if (mediaType.contains(ANY_TYPE)) {
-                return new AnyType();
             } else {
                 throw new BallerinaOpenApiException(String.format(UNSUPPORTED_MEDIA_ERROR, mediaType));
             }


### PR DESCRIPTION
## Purpose
> $subject
Fixes https://github.com/ballerina-platform/openapi-tools/issues/849 in openapi-tool 1.3.x

## User stories
**OpenAPI schema**
```yaml
/pets:
    post:
      summary: Create a pet
      operationId: createPet
      requestBody:
        content:
          "*/*":
            schema:
              type: array
              items:
                type: string
      responses:
        '200':
          description: Successful operation
          content:
            '*/*':
              example:
                summary: Pet Response
```

**Generated remote function**

```bal
    # Create a pet
    #
    # + request - Request to add a pet 
    # + return - Null response 
    remote isolated function createPet(http:Request request) returns http:Response|error {
        string resourcePath = string `/pets`;
        // TODO: Update the request as needed;
        http:Response response = check self.clientEp->post(resourcePath, request);
        return response;
    }
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/ballerina-platform/openapi-tools/pull/1120

## Test environment
> Java JDK 11
