### PR TITLE
[master] Revamp default request payload / response mapping in client generation

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -119,8 +119,7 @@ public class FunctionBodyNodeTests {
                         "json response = check self.clientEp->post(resourcePath, request);" +
                         "return response;}"},
                 {"swagger/pdf_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
-                        "http:Request request = new;" +
-                        "request.setPayload(payload, \"application/pdf\");" +
+                        "// TODO: Update the request as needed;\n" +
                         "http:Response response = check self.clientEp->post(resourcePath, request);" +
                         "return response;}"},
                 {"swagger/image_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
@@ -186,6 +186,20 @@ public class FunctionSignatureNodeTests {
         Assert.assertEquals(param01.typeName().toString(), "CreatedPet");
     }
 
+    @Test(description = "Test parameter generation for request body with unsupported (application/pdf) media type")
+    public void getFunctionSignatureForUnsupportedRequests() throws IOException, BallerinaOpenApiException {
+        OpenAPI openAPI = getOpenAPI(RESDIR.resolve("swagger/pdf_payload.yaml"));
+        FunctionSignatureGenerator functionSignatureGenerator = new FunctionSignatureGenerator(openAPI,
+                new BallerinaTypesGenerator(openAPI), new ArrayList<>(), false);
+        FunctionSignatureNode signature = functionSignatureGenerator.getFunctionSignatureNode(openAPI.getPaths()
+                .get("/pets").getPost(), new ArrayList<>());
+        SeparatedNodeList<ParameterNode> parameters = signature.parameters();
+        Assert.assertFalse(parameters.isEmpty());
+        RequiredParameterNode param01 = (RequiredParameterNode) parameters.get(0);
+        Assert.assertEquals(param01.paramName().orElseThrow().text(), "request");
+        Assert.assertEquals(param01.typeName().toString(), "http:Request");
+    }
+
     @Test(description = "Test unsupported nested array type query parameter generation",
             expectedExceptions = BallerinaOpenApiException.class,
             expectedExceptionsMessageRegExp = "Unsupported parameter type is found in the parameter : .*")

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -240,6 +240,21 @@ public class RequestBodyTests {
         compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
     }
 
+    @Test(description = "Test for generating request body when operation has unsupported text/xx media type")
+    public void testRequestBodyWithUnsupportedTextMediaType() throws IOException, BallerinaOpenApiException {
+        Path expectedPath = RES_DIR.resolve("ballerina/unsupported_text_media_type.bal");
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(
+                RES_DIR.resolve("swagger/unsupported_text_media_type.yaml"), true);
+        OASClientConfig.Builder clientMetaDataBuilder = new OASClientConfig.Builder();
+        OASClientConfig oasClientConfig = clientMetaDataBuilder
+                .withFilters(filter)
+                .withOpenAPI(openAPI)
+                .withResourceMode(false).build();
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(oasClientConfig);
+        syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
+    }
+
     @Test(description = "Test for generating request body when operation has multipart form-data media type")
     public void testRequestBodyWithMultipartMediaType()
             throws IOException, BallerinaOpenApiException {

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -224,6 +224,22 @@ public class RequestBodyTests {
         compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
     }
 
+    @Test(description = "Test for generating request body when operation has vendor specific media type " +
+            "which is a subtype of JSON")
+    public void testRequestBodyWithVendorSpecificMimeTypeWithJSON() throws IOException, BallerinaOpenApiException {
+        Path expectedPath = RES_DIR.resolve("ballerina/vendor_specific_json.bal");
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(
+                RES_DIR.resolve("swagger/vendor_specific_json.yaml"), true);
+        OASClientConfig.Builder clientMetaDataBuilder = new OASClientConfig.Builder();
+        OASClientConfig oasClientConfig = clientMetaDataBuilder
+                .withFilters(filter)
+                .withOpenAPI(openAPI)
+                .withResourceMode(false).build();
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(oasClientConfig);
+        syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
+    }
+
     @Test(description = "Test for generating request body when operation has multipart form-data media type")
     public void testRequestBodyWithMultipartMediaType()
             throws IOException, BallerinaOpenApiException {

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -126,9 +126,9 @@ public class RequestBodyTests {
         compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
     }
 
-    @Test(description = "Test client generation for unsupported request body media type",
-            expectedExceptions = BallerinaOpenApiException.class)
+    @Test(description = "Test client generation for unsupported request body media type")
     public void testRequestBodyWithUnsupportedMediaType() throws IOException, BallerinaOpenApiException {
+        Path expectedPath = RES_DIR.resolve("ballerina/unsupported_request_body.bal");
         Path definitionPath = RES_DIR.resolve("swagger/unsupported_request_body.yaml");
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(definitionPath, true);
         OASClientConfig.Builder clientMetaDataBuilder = new OASClientConfig.Builder();
@@ -137,7 +137,8 @@ public class RequestBodyTests {
                 .withOpenAPI(openAPI)
                 .withResourceMode(false).build();
         BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(oasClientConfig);
-        ballerinaClientGenerator.generateSyntaxTree();
+        syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
     }
 
     @Test(description = "Test requestBody validation in GET/DELETE/HEAD operations",
@@ -229,6 +230,23 @@ public class RequestBodyTests {
         Path expectedPath = RES_DIR.resolve("ballerina/multipart_formdata.bal");
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(
                 RES_DIR.resolve("utils/swagger/multipart_formdata.yaml"), true);
+        OASClientConfig.Builder clientMetaDataBuilder = new OASClientConfig.Builder();
+        OASClientConfig oasClientConfig = clientMetaDataBuilder
+                .withFilters(filter)
+                .withOpenAPI(openAPI)
+                .withResourceMode(false).build();
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(oasClientConfig);
+        syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
+    }
+
+    @Test(description = "Test for generating request body when operation has multipart form-data media type " +
+            "with no schema")
+    public void testRequestBodyWithMultipartMediaTypeAndNoSchema()
+            throws IOException, BallerinaOpenApiException {
+        Path expectedPath = RES_DIR.resolve("ballerina/multipart_formdata_empty.bal");
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(
+                RES_DIR.resolve("swagger/mutipart_formdata_empty.yaml"), true);
         OASClientConfig.Builder clientMetaDataBuilder = new OASClientConfig.Builder();
         OASClientConfig oasClientConfig = clientMetaDataBuilder
                 .withFilters(filter)

--- a/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata_empty.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata_empty.bal
@@ -36,6 +36,7 @@ public isolated client class Client {
     }
     # Create a pet
     #
+    # + request - Pet
     # + return - Null response
     remote isolated function createPet(http:Request request) returns http:Response|error {
         string resourcePath = string `/pets`;

--- a/openapi-cli/src/test/resources/generators/client/ballerina/unsupported_request_body.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/unsupported_request_body.bal
@@ -1,5 +1,6 @@
 import ballerina/http;
 
+# The Stripe REST API. Please see https://stripe.com/docs/api for more details.
 public isolated client class Client {
     final http:Client clientEp;
     # Gets invoked to initialize the `connector`.
@@ -7,7 +8,7 @@ public isolated client class Client {
     # + config - The configurations to be used when initializing the `connector`
     # + serviceUrl - URL of the target service
     # + return - An error if connector initialization failed
-    public isolated function init(ConnectionConfig config =  {}, string serviceUrl = "http://petstore.{host}.io/v1") returns error? {
+    public isolated function init(string serviceUrl, ConnectionConfig config =  {}) returns error? {
         http:ClientConfiguration httpClientConfig = {httpVersion: config.httpVersion, timeout: config.timeout, forwarded: config.forwarded, poolConfig: config.poolConfig, compression: config.compression, circuitBreaker: config.circuitBreaker, retryConfig: config.retryConfig, validation: config.validation};
         do {
             if config.http1Settings is ClientHttp1Settings {
@@ -34,13 +35,15 @@ public isolated client class Client {
         self.clientEp = httpEp;
         return;
     }
-    # Create a pet
+    # <p>Creates a new customer object.</p>
     #
-    # + return - Null response
-    remote isolated function createPet(http:Request request) returns http:Response|error {
-        string resourcePath = string `/pets`;
+    # + customer - Customer ID
+    # + request - Customer Details
+    # + return - Successful response.
+    remote isolated function postCustomers(string customer, http:Request request) returns Customer|error {
+        string resourcePath = string `/v1/customer/${getEncodedUri(customer)}`;
         // TODO: Update the request as needed;
-        http:Response response = check self.clientEp->post(resourcePath, request);
+        Customer response = check self.clientEp->post(resourcePath, request);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/unsupported_text_media_type.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/unsupported_text_media_type.bal
@@ -1,0 +1,47 @@
+import ballerina/http;
+
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + config - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(ConnectionConfig config =  {}, string serviceUrl = "http://petstore.{host}.io/v1") returns error? {
+        http:ClientConfiguration httpClientConfig = {httpVersion: config.httpVersion, timeout: config.timeout, forwarded: config.forwarded, poolConfig: config.poolConfig, compression: config.compression, circuitBreaker: config.circuitBreaker, retryConfig: config.retryConfig, validation: config.validation};
+        do {
+            if config.http1Settings is ClientHttp1Settings {
+                ClientHttp1Settings settings = check config.http1Settings.ensureType(ClientHttp1Settings);
+                httpClientConfig.http1Settings = {...settings};
+            }
+            if config.http2Settings is http:ClientHttp2Settings {
+                httpClientConfig.http2Settings = check config.http2Settings.ensureType(http:ClientHttp2Settings);
+            }
+            if config.cache is http:CacheConfig {
+                httpClientConfig.cache = check config.cache.ensureType(http:CacheConfig);
+            }
+            if config.responseLimits is http:ResponseLimitConfigs {
+                httpClientConfig.responseLimits = check config.responseLimits.ensureType(http:ResponseLimitConfigs);
+            }
+            if config.secureSocket is http:ClientSecureSocket {
+                httpClientConfig.secureSocket = check config.secureSocket.ensureType(http:ClientSecureSocket);
+            }
+            if config.proxy is http:ProxyConfig {
+                httpClientConfig.proxy = check config.proxy.ensureType(http:ProxyConfig);
+            }
+        }
+        http:Client httpEp = check new (serviceUrl, httpClientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Create a pet
+    #
+    # + return - Response of create pet
+    remote isolated function createPet(string payload) returns string|error {
+        string resourcePath = string `/pets`;
+        http:Request request = new;
+        request.setPayload(payload, "text/xxx");
+        string response = check self.clientEp->post(resourcePath, request);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/ballerina/vendor_specific_json.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/vendor_specific_json.bal
@@ -1,0 +1,47 @@
+import ballerina/http;
+
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + config - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(ConnectionConfig config =  {}, string serviceUrl = "http://petstore.{host}.io/v1") returns error? {
+        http:ClientConfiguration httpClientConfig = {httpVersion: config.httpVersion, timeout: config.timeout, forwarded: config.forwarded, poolConfig: config.poolConfig, compression: config.compression, circuitBreaker: config.circuitBreaker, retryConfig: config.retryConfig, validation: config.validation};
+        do {
+            if config.http1Settings is ClientHttp1Settings {
+                ClientHttp1Settings settings = check config.http1Settings.ensureType(ClientHttp1Settings);
+                httpClientConfig.http1Settings = {...settings};
+            }
+            if config.http2Settings is http:ClientHttp2Settings {
+                httpClientConfig.http2Settings = check config.http2Settings.ensureType(http:ClientHttp2Settings);
+            }
+            if config.cache is http:CacheConfig {
+                httpClientConfig.cache = check config.cache.ensureType(http:CacheConfig);
+            }
+            if config.responseLimits is http:ResponseLimitConfigs {
+                httpClientConfig.responseLimits = check config.responseLimits.ensureType(http:ResponseLimitConfigs);
+            }
+            if config.secureSocket is http:ClientSecureSocket {
+                httpClientConfig.secureSocket = check config.secureSocket.ensureType(http:ClientSecureSocket);
+            }
+            if config.proxy is http:ProxyConfig {
+                httpClientConfig.proxy = check config.proxy.ensureType(http:ProxyConfig);
+            }
+        }
+        http:Client httpEp = check new (serviceUrl, httpClientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Create a pet
+    #
+    # + return - List of existing pets
+    remote isolated function createPet(Pet payload) returns Pets|error {
+        string resourcePath = string `/pets`;
+        http:Request request = new;
+        request.setPayload(payload, "application/vnd.petstore.v3.diff+json");
+        Pets response = check self.clientEp->post(resourcePath, request);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/swagger/mutipart_formdata_empty.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/mutipart_formdata_empty.yaml
@@ -1,0 +1,26 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        description: Pet
+        content:
+          multipart/form-data:
+            example:
+              name:
+                "Tony"
+              Age:
+                "22"
+      responses:
+        '201':
+          description: Null response

--- a/openapi-cli/src/test/resources/generators/client/swagger/unsupported_request_body.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/unsupported_request_body.yaml
@@ -11,28 +11,6 @@ info:
   version: '2020-08-27'
   x-stripeSpecFilename: spec3
 paths:
-  "/v1/payment_methods/{payment_method}":
-    get:
-      description: "<p>Retrieves a PaymentMethod object.</p>"
-      operationId: GetPaymentMethodsPaymentMethod
-      tags:
-        - "Payment_Methods"
-      parameters:
-        - in: path
-          name: payment_method
-          description: Payment Method
-          required: true
-          schema:
-            maxLength: 5000
-            type: string
-          style: simple
-
-      responses:
-        '200':
-          content:
-            application/json:
-              schema: {}
-          description: Successful response.
   "/v1/customer/{customer}":
     post:
       description: "<p>Creates a new customer object.</p>"

--- a/openapi-cli/src/test/resources/generators/client/swagger/unsupported_text_media_type.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/unsupported_text_media_type.yaml
@@ -1,0 +1,62 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        content:
+          text/xxx:
+            example:
+              name : "Tommy"
+      responses:
+        '200':
+          description: Response of create pet
+          content:
+            text/xxx:
+              schema: {}
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+    Dog:
+      allOf:
+        - $ref: "#/components/schemas/Pet"
+        - type: object
+          properties:
+            bark:
+              type: boolean
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/openapi-cli/src/test/resources/generators/client/swagger/vendor_specific_json.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/vendor_specific_json.yaml
@@ -1,0 +1,56 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        content:
+          application/vnd.petstore.v3.diff+json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: List of existing pets
+          content:
+            application/vnd.petstore.v3.diff+json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -446,13 +446,11 @@ public class GeneratorUtils {
      * Generate BallerinaMediaType for all the return mediaTypes.
      */
     public static String getBallerinaMediaType(String mediaType, boolean isRequest) {
-        if (mediaType.equals(MediaType.APPLICATION_JSON) || mediaType.matches("application/.*\\+json") ||
-                mediaType.matches(".*/json")) {
+        if (mediaType.matches(".*/json") || mediaType.matches("application/.*\\+json")) {
             return SyntaxKind.JSON_KEYWORD.stringValue();
-        } else if (mediaType.equals(MediaType.APPLICATION_XML) || mediaType.matches("application/.*\\+xml")) {
+        } else if (mediaType.matches(".*/xml")  || mediaType.matches("application/.*\\+xml")) {
             return SyntaxKind.XML_KEYWORD.stringValue();
-        } else if (mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED) || mediaType.equals(MediaType.TEXT_HTML)
-                || mediaType.equals(MediaType.TEXT_PLAIN)) {
+        } else if (mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED) || mediaType.matches("text/.*")) {
             return STRING_KEYWORD.stringValue();
         } else if (mediaType.equals(MediaType.APPLICATION_OCTET_STREAM) ||
                 mediaType.equals(IMAGE_PNG) || mediaType.matches("application/.*\\+octet-stream")) {

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -123,8 +123,6 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_BRACKET_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SLASH_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.STRING_KEYWORD;
-import static io.ballerina.openapi.core.GeneratorConstants.ANY_TYPE;
-import static io.ballerina.openapi.core.GeneratorConstants.APPLICATION_PDF;
 import static io.ballerina.openapi.core.GeneratorConstants.BALLERINA;
 import static io.ballerina.openapi.core.GeneratorConstants.BALLERINA_TOML;
 import static io.ballerina.openapi.core.GeneratorConstants.BALLERINA_TOML_CONTENT;
@@ -143,6 +141,7 @@ import static io.ballerina.openapi.core.GeneratorConstants.OPEN_CURLY_BRACE;
 import static io.ballerina.openapi.core.GeneratorConstants.SERVICE_FILE_NAME;
 import static io.ballerina.openapi.core.GeneratorConstants.SLASH;
 import static io.ballerina.openapi.core.GeneratorConstants.SPECIAL_CHARACTERS_REGEX;
+import static io.ballerina.openapi.core.GeneratorConstants.SQUARE_BRACKETS;
 import static io.ballerina.openapi.core.GeneratorConstants.STRING;
 import static io.ballerina.openapi.core.GeneratorConstants.STYLE;
 import static io.ballerina.openapi.core.GeneratorConstants.TYPE_FILE_NAME;
@@ -426,26 +425,40 @@ public class GeneratorUtils {
     }
 
     /**
+     * Check whether the given media type is currently supported in the tool.
+     *
+     * @param mediaTypeEntry
+     * @return
+     */
+    public static boolean isSupportedMediaType(Map.Entry<String,
+            io.swagger.v3.oas.models.media.MediaType> mediaTypeEntry) {
+        String mediaType = mediaTypeEntry.getKey();
+        String defaultBallerinaType = getBallerinaMediaType(mediaType, true);
+        if (defaultBallerinaType.equals(HTTP_REQUEST) &&
+                !(mediaTypeEntry.getValue().getSchema() != null && mediaType.equals(MediaType.MULTIPART_FORM_DATA))) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /**
      * Generate BallerinaMediaType for all the return mediaTypes.
      */
     public static String getBallerinaMediaType(String mediaType, boolean isRequest) {
-
-        switch (mediaType) {
-            case MediaType.APPLICATION_JSON:
-                return SyntaxKind.JSON_KEYWORD.stringValue();
-            case MediaType.APPLICATION_XML:
-                return SyntaxKind.XML_KEYWORD.stringValue();
-            case MediaType.APPLICATION_FORM_URLENCODED:
-            case MediaType.TEXT_HTML:
-            case MediaType.TEXT_PLAIN:
-                return STRING_KEYWORD.stringValue();
-            case IMAGE_PNG:
-            case MediaType.APPLICATION_OCTET_STREAM:
-            case APPLICATION_PDF:
-            case ANY_TYPE:
-                return isRequest ? HTTP_REQUEST : HTTP_RESPONSE;
-            default:
-                return SyntaxKind.JSON_KEYWORD.stringValue();
+        if (mediaType.equals(MediaType.APPLICATION_JSON) || mediaType.matches("application/.*\\+json") ||
+                mediaType.matches(".*/json")) {
+            return SyntaxKind.JSON_KEYWORD.stringValue();
+        } else if (mediaType.equals(MediaType.APPLICATION_XML) || mediaType.matches("application/.*\\+xml")) {
+            return SyntaxKind.XML_KEYWORD.stringValue();
+        } else if (mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED) || mediaType.equals(MediaType.TEXT_HTML)
+                || mediaType.equals(MediaType.TEXT_PLAIN)) {
+            return STRING_KEYWORD.stringValue();
+        } else if (mediaType.equals(MediaType.APPLICATION_OCTET_STREAM) ||
+                mediaType.equals(IMAGE_PNG) || mediaType.matches("application/.*\\+octet-stream")) {
+            return SyntaxKind.BYTE_KEYWORD.stringValue() + SQUARE_BRACKETS;
+        } else {
+            return isRequest ? HTTP_REQUEST : HTTP_RESPONSE;
         }
     }
 

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionBodyGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionBodyGenerator.java
@@ -100,7 +100,6 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_BRACE_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUESTION_MARK_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.STRING_KEYWORD;
-import static io.ballerina.openapi.core.GeneratorConstants.ANY_TYPE;
 import static io.ballerina.openapi.core.GeneratorConstants.API_KEYS_CONFIG;
 import static io.ballerina.openapi.core.GeneratorConstants.API_KEY_CONFIG_PARAM;
 import static io.ballerina.openapi.core.GeneratorConstants.DELETE;
@@ -649,12 +648,12 @@ public class FunctionBodyGenerator {
 
         //Create Request statement
         Map.Entry<String, MediaType> next = iterator.next();
-        if (!next.getKey().contains(ANY_TYPE)) {
+        if (GeneratorUtils.isSupportedMediaType(next)) {
             VariableDeclarationNode requestVariable = GeneratorUtils.getSimpleStatement(HTTP_REQUEST,
                     REQUEST, NEW);
             statementsList.add(requestVariable);
         }
-        if (next.getValue() != null && !next.getKey().contains(ANY_TYPE)) {
+        if (next.getValue() != null && GeneratorUtils.isSupportedMediaType(next)) {
             genStatementsForRequestMediaType(statementsList, next);
             // TODO:Fill with other mime type
         } else {

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionBodyGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionBodyGenerator.java
@@ -647,14 +647,14 @@ public class FunctionBodyGenerator {
             throws BallerinaOpenApiException {
 
         //Create Request statement
-        Map.Entry<String, MediaType> next = iterator.next();
-        if (GeneratorUtils.isSupportedMediaType(next)) {
+        Map.Entry<String, MediaType> mediaTypeEntry = iterator.next();
+        if (GeneratorUtils.isSupportedMediaType(mediaTypeEntry)) {
             VariableDeclarationNode requestVariable = GeneratorUtils.getSimpleStatement(HTTP_REQUEST,
                     REQUEST, NEW);
             statementsList.add(requestVariable);
         }
-        if (next.getValue() != null && GeneratorUtils.isSupportedMediaType(next)) {
-            genStatementsForRequestMediaType(statementsList, next);
+        if (mediaTypeEntry.getValue() != null && GeneratorUtils.isSupportedMediaType(mediaTypeEntry)) {
+            genStatementsForRequestMediaType(statementsList, mediaTypeEntry);
             // TODO:Fill with other mime type
         } else {
             // Add default value comment

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
@@ -491,11 +491,11 @@ public class FunctionSignatureGenerator {
         Iterator<Map.Entry<String, MediaType>> iterator = requestBodyContent.entrySet().iterator();
         while (iterator.hasNext()) {
             // This implementation currently for first content type
-            Map.Entry<String, MediaType> next = iterator.next();
-            Schema schema = next.getValue().getSchema();
+            Map.Entry<String, MediaType> mediaTypeEntry = iterator.next();
+            Schema schema = mediaTypeEntry.getValue().getSchema();
             String paramType = "";
             //Take payload type
-            if (schema != null && GeneratorUtils.isSupportedMediaType(next)) {
+            if (schema != null && GeneratorUtils.isSupportedMediaType(mediaTypeEntry)) {
                 if (schema.get$ref() != null) {
                     paramType = getValidName(extractReferenceType(schema.get$ref().trim()), true);
                 } else if (schema.getType() != null && !schema.getType().equals(ARRAY) && !schema.getType().equals(
@@ -510,16 +510,16 @@ public class FunctionSignatureGenerator {
                 } else if (schema instanceof ArraySchema) {
                     //TODO: handle nested array - this is impossible to handle
                     ArraySchema arraySchema = (ArraySchema) schema;
-                    paramType = getRequestBodyParameterForArraySchema(operationId, next, arraySchema);
+                    paramType = getRequestBodyParameterForArraySchema(operationId, mediaTypeEntry, arraySchema);
                 } else if (schema instanceof ObjectSchema) {
                     ObjectSchema objectSchema = (ObjectSchema) schema;
                     paramType = referencedRequestBodyName.isBlank() ? paramType : referencedRequestBodyName;
                     getRequestBodyParameterForObjectSchema(referencedRequestBodyName, objectSchema);
                 } else { // composed and object schemas are handled by the flatten
-                    paramType = GeneratorUtils.getBallerinaMediaType(next.getKey(), true);
+                    paramType = GeneratorUtils.getBallerinaMediaType(mediaTypeEntry.getKey(), true);
                 }
             } else {
-                paramType = GeneratorUtils.getBallerinaMediaType(next.getKey(), true);
+                paramType = GeneratorUtils.getBallerinaMediaType(mediaTypeEntry.getKey(), true);
             }
 
             String paramName = paramType.equals(HTTP_REQUEST) ? REQUEST : PAYLOAD;
@@ -540,10 +540,10 @@ public class FunctionSignatureGenerator {
                 parameterList.add(createToken((COMMA_TOKEN)));
             }
 
-            if (next.getKey().equals(javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA)
-                    && next.getValue().getEncoding() != null) {
+            if (mediaTypeEntry.getKey().equals(javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA)
+                    && mediaTypeEntry.getValue().getEncoding() != null) {
                 List<String> headerList = new ArrayList<>();
-                for (Map.Entry<String, Encoding> entry : next.getValue().getEncoding().entrySet()) {
+                for (Map.Entry<String, Encoding> entry : mediaTypeEntry.getValue().getEncoding().entrySet()) {
                     if (entry.getValue().getHeaders() != null) {
                         for (Map.Entry<String, Header> header : entry.getValue().getHeaders().entrySet()) {
                             if (!headerList.contains(header.getKey())) {


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/ballerina-platform/openapi-tools/issues/1121, https://github.com/ballerina-platform/openapi-tools/issues/1148

## Goals
### Scenario 1 - Unsupported mime type

**OpenAPI sample** 
```yaml
      requestBody:
        content:
          multipart/byteranges:  # This mime is not supported for client generation
            schema:
              properties:
                address:
                  $ref: "#/components/schemas/customer_adresss"
                balance:
                  type: integer
        description: Customer Details
      
```

**Generated bal code**

```bal
remote isolated function postCustomers(string customer, http:Request request) returns Customer|error {
        string resourcePath = string `/v1/customer/${getEncodedUri(customer)}`;
        // TODO: Update the request as needed;
        Customer response = check self.clientEp->post(resourcePath, request);
        return response;
    }
```

Currently we also generate the remote/resource functions for `application/pdf` mime type as above

### Scenario 2 - Vendor specific mime type

**OpenAPI sample** 

```yaml
  /pets:
    post:
      summary: Create a pet
      operationId: createPet
      requestBody:
        content:
          application/vnd.ms-excel:
            schema:
              properties:
                name:
                  type: string
      responses:
        '201':
          description: Null response
```

**Generated bal code**

```bal
    remote isolated function createPet(http:Request request) returns http:Response|error {
        string resourcePath = string `/pets`;
        // TODO: Update the request as needed;
        http:Response response = check self.clientEp->post(resourcePath, request);
        return response;
    }
```

### Scenario 3 - Vendor specific mime type with known subtype 

**OpenAPI sample** 

```yaml
  /pets:
    post:
      summary: Create a pet
      operationId: createPet
      requestBody:
        content:
          application/vnd.petstore.v3.diff+json:
            schema:
              $ref: "#/components/schemas/Pet"
      responses:
        '200':
          description: List of existing pets
          content:
            application/vnd.petstore.v3.diff+json:
              schema:
                $ref: "#/components/schemas/Pets"
```

**Generated bal code**

```bal
    remote isolated function createPet(Pet payload) returns Pets|error {
        string resourcePath = string `/pets`;
        http:Request request = new;
        request.setPayload(payload, "application/vnd.petstore.v3.diff+json");
        Pets response = check self.clientEp->post(resourcePath, request);
        return response;
    }
```

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11