### PR TITLE
[master] Fix to improve nillable field support in OpenAPI to Ballerina schema generation 

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/FieldGenWithNullableOption.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/FieldGenWithNullableOption.java
@@ -53,7 +53,7 @@ public class FieldGenWithNullableOption {
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI, true);
         SyntaxTree syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
         TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
-                "schema/ballerina/nullale_option_array_schema.bal", syntaxTree);
+                "schema/ballerina/nullable_option_array_schema.bal", syntaxTree);
     }
 
     @Test(description = "Test for nullable record fields")

--- a/openapi-cli/src/test/resources/expected_gen/nullable_false_types.bal
+++ b/openapi-cli/src/test/resources/expected_gen/nullable_false_types.bal
@@ -7,12 +7,12 @@ public type Error record {|
 
 public type Dog record {|
     *Pet;
-    boolean? bark?;
+    boolean? bark = ();
 |};
 
 public type Pet record {|
     int id;
     string name;
-    string? tag?;
-    string? 'type?;
+    string? tag = ();
+    string? 'type = ();
 |};

--- a/openapi-cli/src/test/resources/expected_gen/nullable_types.bal
+++ b/openapi-cli/src/test/resources/expected_gen/nullable_types.bal
@@ -7,12 +7,13 @@ public type Error record {|
 
 public type Dog record {|
     *Pet;
-    boolean? bark?;
+    boolean? bark = ();
+
 |};
 
 public type Pet record {|
     int? id;
     string? name;
-    string? tag?;
-    string? 'type?;
+    string? tag = ();
+    string? 'type = ();
 |};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_composed_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_composed_schema.bal
@@ -1,81 +1,81 @@
 # Multiple additional fields , result can not have multiple field
 public type User05 record {|
     *Pet;
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     int?|string[]?...;
 |};
 
 # Additional properties with type object without properties
 public type User06 record {|
     *Pet;
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     record {}?...;
 |};
 
 # Additional properties with object with property fields
 public type User07 record {|
     *Pet;
-    string? name?;
-    int? id?;
-    record {|string? country?; string? state?;|}?...;
+    string? name = ();
+    int? id = ();
+    record {|string? country = (); string? state = ();|}?...;
 |};
 
 # Reference has additional properties.
 public type User08 record {|
     *Pet02;
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     Pet?|int...;
 |};
 
 # Reference has additional properties with nullable true.
 public type User09 record {|
     *Pet02;
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     Pet?|int?...;
 |};
 
 # Mock record 02
 public type Pet02 record {|
-    string? name?;
-    int? age?;
+    string? name = ();
+    int? age = ();
     Pet?...;
 |};
 
 # Without any additional field it maps to closed record.
 public type User01 record {|
     *Pet;
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
 |};
 
 # Additional properties with `true` enable
 public type User02 record {
     *Pet;
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
 };
 
 # Mock record
 public type Pet record {|
-    string? name?;
-    int? age?;
+    string? name = ();
+    int? age = ();
 |};
 
 # Additional properties with {}
 public type User03 record {
     *Pet;
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
 };
 
 # Additional properties with type string
 public type User04 record {|
     *Pet;
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     string?...;
 |};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_negative.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_negative.bal
@@ -1,19 +1,19 @@
 # Additional properties with object with reference fields - this is issue https://github.com/swagger-api/swagger-parser/issues/1856
 public type User01 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     User03?...;
 |};
 
 # Additional properties type Array with constraint. constraint won't support for rest filed in record.
 public type User03 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     string[]?...;
 |};
 
 # These Additional properties are complex to map.
 public type User04 record {
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
 };

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_true.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_true.bal
@@ -1,81 +1,81 @@
 # Additional properties with type number
 public type User05 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     float...;
 |};
 
 # Additional properties with type number, nullable true
 public type User16 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     float?...;
 |};
 
 # Additional properties with reference
 public type User06 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     User01?...;
 |};
 
 # Additional properties with type object without properties
 public type User07 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     record {}?...;
 |};
 
 # Mock record
 public type User record {|
-    string? name?;
-    int? age?;
+    string? name = ();
+    int? age = ();
 |};
 
 # Additional properties with object with property fields
 public type User08 record {|
-    string? name?;
-    int? id?;
-    record {|string? country?; string? state?;|}?...;
+    string? name = ();
+    int? id = ();
+    record {|string? country = (); string? state = ();|}?...;
 |};
 
 # Additional properties with object with additional fields
 public type User09 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     record {}?...;
 |};
 
 # Additional properties with object with additional fields type string
 public type User10 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     record {|string?...;|}?...;
 |};
 
 # Additional properties with object with additional fields type with reference
 public type User11 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     record {|User?...;|}?...;
 |};
 
 # Additional properties with `true` enable
 public type User01 record {
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
 };
 
 # Additional properties with `false` enable
 public type User12 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
 |};
 
 # Additional properties with {}
 public type User02 record {
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
 };
 
 # Free-form object
@@ -84,27 +84,27 @@ public type User13 record {
 
 # Without additional properties
 public type User03 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
 |};
 
 # Additional properties with object with additional fields type with inline object
 public type User14 record {|
-    string? name?;
-    int? id?;
-    record {|record {|string? name?; string? place?;|}?...;|}?...;
+    string? name = ();
+    int? id = ();
+    record {|record {|string? name = (); string? place = ();|}?...;|}?...;
 |};
 
 # Additional properties with type string
 public type User04 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     string?...;
 |};
 
 # Additional properties with Array
 public type User15 record {|
-    string? name?;
-    int? id?;
+    string? name = ();
+    int? id = ();
     string[]?...;
 |};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/record_field_02.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/record_field_02.bal
@@ -25,7 +25,7 @@ public type Person record {|
     @constraint:Int {minValue: 1, maxValue: 100}
     int maxDeliveryCount?;
     # scenario 01 - field with nullable.
-    string? service_class?;
+    string? service_class = ();
     # scenario 02 - field with oneOf type.
     TaxratesItemsString[]|int tax_rates?;
     # scenario 03 - field with anyOf.

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_anyof_array_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_anyof_array_schema.bal
@@ -2,7 +2,7 @@ import ballerina/constraint;
 
 public type Customers_customer_body record {|
     # The customer's address.
-    Customer_address|string? address?;
+    Customer_address|string? address = ();
     # An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
     int balance?;
 |};
@@ -24,6 +24,6 @@ public type Customer_address record {|
 
 public type Customer record {|
     # The customer's address.
-    Customer_address[]|string? address?;
+    Customer_address[]|string? address = ();
     string name?;
 |};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_anyof_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_anyof_schema.bal
@@ -2,7 +2,7 @@ import ballerina/constraint;
 
 public type Customers_customer_body record {|
     # The customer's address.
-    Customer_address|string? address?;
+    Customer_address|string? address = ();
     # An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
     int balance?;
 |};
@@ -24,6 +24,6 @@ public type Customer_address record {|
 
 public type Customer record {|
     # The customer's address.
-    Customer_address? address?;
+    Customer_address? address = ();
     string name?;
 |};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_array.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_array.bal
@@ -5,14 +5,14 @@ public type UserPlayListDetails record {|
     # A link to the Web API endpoint returning the full result of the request
     string href?;
     # The requested data.
-    ListObject[]? items?;
+    ListObject[]? items = ();
     # The maximum number of items in the response (as set in the query or by default).
-    int[]? 'limit?;
+    int[]? 'limit = ();
     # URL to the next page of items. ( `null` if none)
     string next?;
     # The offset of the items returned (as set in the query or by default)
     int offset?;
     # URL to the previous page of items. ( `null` if none) //anydata
-    anydata[]? previous?;
+    anydata[]? previous = ();
     ListObject total?;
 |};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_false.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_false.bal
@@ -3,15 +3,15 @@ public type ListObject record {
 
 public type UserPlayListDetails record {|
     # A link to the Web API endpoint returning the full result of the request
-    string? href?;
+    string? href= ();
     # The requested data.
-    ListObject[]? items?;
+    ListObject[]? items = ();
     # The maximum number of items in the response (as set in the query or by default).
-    int? 'limit?;
+    int? 'limit = ();
     # URL to the next page of items. ( `null` if none)
     string next?;
     # The offset of the items returned (as set in the query or by default)
-    int? offset?;
+    int? offset = ();
     # URL to the previous page of items. ( `null` if none) //anydata
     anydata previous?;
     ListObject total?;

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_array_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_array_schema.bal
@@ -3,16 +3,16 @@ public type ListObject record {
 
 public type UserPlayListDetails record {|
     # A link to the Web API endpoint returning the full result of the request
-    string? href?;
+    string? href = ();
     # The requested data.
-    ListObject[]? items?;
+    ListObject[]? items = ();
     # The maximum number of items in the response (as set in the query or by default).
-    int[]? 'limit?;
+    int[]? 'limit = ();
     # URL to the next page of items. ( `null` if none)
-    string? next?;
+    string? next = ();
     # The offset of the items returned (as set in the query or by default)
-    int? offset?;
+    int? offset = ();
     # URL to the previous page of items. ( `null` if none) //anydata
-    anydata[]? previous?;
-    ListObject? total?;
+    anydata[]? previous = ();
+    ListObject? total = ();
 |};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_primitive_fields.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_primitive_fields.bal
@@ -3,16 +3,16 @@ public type ListObject record {
 
 public type UserPlayListDetails record {|
     # A link to the Web API endpoint returning the full result of the request
-    string? href?;
+    string? href= ();
     # The requested data.
-    ListObject[]? items?;
+    ListObject[]? items = ();
     # The maximum number of items in the response (as set in the query or by default).
-    int? 'limit?;
+    int? 'limit = ();
     # URL to the next page of items. ( `null` if none)
-    string? next?;
+    string? next = ();
     # The offset of the items returned (as set in the query or by default)
-    int? offset?;
+    int? offset = ();
     # URL to the previous page of items. ( `null` if none) //anydata
-    anydata? previous?;
-    ListObject? total?;
+    anydata? previous = ();
+    ListObject? total = ();
 |};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_record_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_record_schema.bal
@@ -3,16 +3,16 @@ public type ListObject record {
 
 public type UserPlayListDetails record {|
     # A link to the Web API endpoint returning the full result of the request
-    string? href?;
+    string? href = ();
     # The requested data.
-    ListObject[]? items?;
+    ListObject[]? items = ();
     # The maximum number of items in the response (as set in the query or by default).
-    int? 'limit?;
+    int? 'limit = ();
     # URL to the next page of items. ( `null` if none)
-    string? next?;
+    string? next = ();
     # The offset of the items returned (as set in the query or by default)
-    int? offset?;
+    int? offset = ();
     # URL to the previous page of items. ( `null` if none) //anydata
-    anydata? previous?;
-    ListObject? total?;
+    anydata? previous = ();
+    ListObject? total = ();
 |};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_primitive.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_primitive.bal
@@ -9,10 +9,10 @@ public type UserPlayListDetails record {|
     # The maximum number of items in the response (as set in the query or by default).
     int 'limit?;
     # URL to the next page of items. ( `null` if none)
-    string? next?;
+    string? next = ();
     # The offset of the items returned (as set in the query or by default)
     int offset?;
     # URL to the previous page of items. ( `null` if none) //anydata
-    anydata? previous?;
+    anydata? previous = ();
     ListObject total?;
 |};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_record.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_record.bal
@@ -13,6 +13,6 @@ public type UserPlayListDetails record {|
     # The offset of the items returned (as set in the query or by default)
     int offset?;
     # URL to the previous page of items. ( `null` if none) //anydata
-    anydata? previous?;
-    ListObject? total?;
+    anydata? previous = ();
+    ListObject? total = ();
 |};

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
@@ -71,6 +71,7 @@ import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createToken;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMarkdownDocumentationNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMetadataNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createOptionalTypeDescriptorNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createRecordFieldWithDefaultValueNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createRequiredExpressionNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createSimpleNameReferenceNode;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.AT_TOKEN;
@@ -78,6 +79,7 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.EQUAL_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.MAPPING_CONSTRUCTOR;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUESTION_MARK_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
+import static io.ballerina.openapi.core.GeneratorConstants.NILLABLE;
 
 /**
  * Contains util functions needed for schema generation.
@@ -192,11 +194,23 @@ public class TypeGeneratorUtils {
 
         if (required != null) {
             setRequiredFields(required, recordFieldList, field, fieldSchema, fieldName, fieldTypeName, metadataNode);
+        } else if (fieldTypeName.toString().endsWith(NILLABLE)) {
+            recordFieldList.add(getRecordFieldWithDefaultValue(fieldName, fieldTypeName, metadataNode));
         } else {
             RecordFieldNode recordFieldNode = NodeFactory.createRecordFieldNode(metadataNode, null,
                     fieldTypeName, fieldName, createToken(QUESTION_MARK_TOKEN), createToken(SEMICOLON_TOKEN));
             recordFieldList.add(recordFieldNode);
         }
+    }
+
+    private static RecordFieldWithDefaultValueNode getRecordFieldWithDefaultValue(IdentifierToken fieldName,
+                                                                                  TypeDescriptorNode fieldType,
+                                                                                  MetadataNode metadataNode) {
+        SimpleNameReferenceNode nilExpression = createSimpleNameReferenceNode(
+                createIdentifierToken("()"));
+        return createRecordFieldWithDefaultValueNode(metadataNode,
+                null, fieldType, fieldName, createToken(EQUAL_TOKEN),
+                nilExpression, createToken(SEMICOLON_TOKEN));
     }
 
     private static void setRequiredFields(List<String> required, List<Node> recordFieldList,
@@ -211,6 +225,8 @@ public class TypeGeneratorUtils {
                 RecordFieldWithDefaultValueNode defaultNode =
                         getRecordFieldWithDefaultValueNode(fieldSchema, fieldName, fieldTypeName, metadataNode);
                 recordFieldList.add(defaultNode);
+            } else if (fieldTypeName.toString().endsWith(NILLABLE)) {
+                recordFieldList.add(getRecordFieldWithDefaultValue(fieldName, fieldTypeName, metadataNode));
             } else {
                 RecordFieldNode recordFieldNode = NodeFactory.createRecordFieldNode(metadataNode, null,
                         fieldTypeName, fieldName, createToken(QUESTION_MARK_TOKEN),

--- a/openapi-integration-tests/src/test/resources/schema/array.bal
+++ b/openapi-integration-tests/src/test/resources/schema/array.bal
@@ -57,6 +57,6 @@ public type ProxyConfig record {|
 |};
 
 public type User record {|
-    string? id?;
-    string[]? address?;
+    string? id = ();
+    string[]? address = ();
 |};


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/ballerina-platform/openapi-tools/issues/957

## Goals
> Revamp the code generation when a record field is defined as optional and nullable in a OpenAPI schema

Ex : 
```yaml
    Pet:
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
          nullable: true
        types:
          type: string
          nullable: true
```
**Previous generation**

```bal
public type Pet record {|
    int id;
    string name;
    string? tag?;
    string? types?;
|};
```

**New generation**

```bal
public type Pet record {|
    int id;
    string name;
    string? tag = ();
    string? types = ();
|};
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11
