### PR TITLE
[master] Add wildcard support for service generation

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
@@ -540,6 +540,42 @@ public class CodeGeneratorTest {
         }
     }
 
+    @Test(description = "Test service generation for request and responses with wildcard media type")
+    public void testServiceGenerationWhenWildCardMediaTypeGiven() {
+        final String serviceName = "openapipetstore";
+        String definitionPath = RES_DIR.resolve("petstore_wildcard.yaml").toString();
+        BallerinaCodeGenerator generator = new BallerinaCodeGenerator();
+
+        try {
+            String expectedServiceContent = getStringFromGivenBalFile(
+                    expectedServiceFile, "petstore_wildcard_service.bal");
+            String expectedTypesContent = getStringFromGivenBalFile(
+                    expectedServiceFile, "petstore_wildcard_types.bal");
+            generator.generateService(definitionPath, serviceName, resourcePath.toString(), filter, false);
+            if (Files.exists(resourcePath.resolve("openapipetstore_service.bal")) &&
+                    Files.exists(resourcePath.resolve("types.bal"))) {
+                String generatedService = getStringFromGivenBalFile(resourcePath, "openapipetstore_service.bal");
+                generatedService = (generatedService.trim()).replaceAll("\\s+", "");
+                expectedServiceContent = (expectedServiceContent.trim()).replaceAll("\\s+", "");
+                Assert.assertTrue(generatedService.contains(expectedServiceContent),
+                        "Expected service and actual generated service is not matching");
+
+                String generatedTypes = getStringFromGivenBalFile(resourcePath, "types.bal");
+                generatedTypes = (generatedTypes.trim()).replaceAll("\\s+", "");
+                expectedTypesContent = (expectedTypesContent.trim()).replaceAll("\\s+", "");
+                Assert.assertTrue(generatedTypes.contains(expectedTypesContent),
+                        "Expected types and actual generated types are not matching");
+
+            } else {
+                Assert.fail("Service was not generated");
+            }
+        } catch (IOException | BallerinaOpenApiException | FormatterException e) {
+            Assert.fail("Error while generating the service. " + e.getMessage());
+        } finally {
+            deleteGeneratedFiles("openapipetstore_service.bal");
+        }
+    }
+
     @Test(description = "Functionality tests when invalid OpenAPI definition is given",
             expectedExceptions = BallerinaOpenApiException.class,
             expectedExceptionsMessageRegExp = "OpenAPI definition has errors: .*")

--- a/openapi-cli/src/test/resources/expected_gen/petstore_service_swagger.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_service_swagger.bal
@@ -17,17 +17,17 @@ service /v2 on ep0 {
     }
     resource function delete pet/[int petId](@http:Header string? api_key) returns http:BadRequest|http:NotFound {
     }
-    resource function post pet/[int petId]/uploadImage(@http:Payload json payload) returns OkApiResponse {
+    resource function post pet/[int petId]/uploadImage(@http:Payload http:Request request) returns OkApiResponse {
     }
     resource function get store/inventory() returns StoreInventoryResponse {
     }
-    resource function post store/'order(@http:Payload json payload) returns OkOrder|http:BadRequest {
+    resource function post store/'order(@http:Payload http:Request request) returns OkOrder|http:BadRequest {
     }
     resource function get store/'order/[int orderId]() returns Order|http:BadRequest|http:NotFound {
     }
     resource function delete store/'order/[int orderId]() returns http:BadRequest|http:NotFound {
     }
-    resource function post user(@http:Payload json payload) returns http:Response {
+    resource function post user(@http:Payload http:Request request) returns http:Response {
     }
     resource function post user/createWithArray(http:Request payload) returns http:Response {
     }
@@ -39,7 +39,7 @@ service /v2 on ep0 {
     }
     resource function get user/[string username]() returns User|http:BadRequest|http:NotFound {
     }
-    resource function put user/[string username](@http:Payload json payload) returns http:BadRequest|http:NotFound {
+    resource function put user/[string username](@http:Payload http:Request request) returns http:BadRequest|http:NotFound {
     }
     resource function delete user/[string username]() returns http:BadRequest|http:NotFound {
     }

--- a/openapi-cli/src/test/resources/expected_gen/petstore_wildcard_service.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_wildcard_service.bal
@@ -1,0 +1,8 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
+
+service /v1 on ep0 {
+    resource function post pets/my(@http:Payload http:Request request) returns OkAnydata {
+    }
+}

--- a/openapi-cli/src/test/resources/expected_gen/petstore_wildcard_types.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_wildcard_types.bal
@@ -1,0 +1,25 @@
+import ballerina/http;
+
+public type OkAnydata record {|
+    *http:Ok;
+    anydata body;
+|};
+
+public type Pets Pet[];
+
+public type Error record {|
+    int code;
+    string message;
+|};
+
+public type Dog record {|
+    *Pet;
+    boolean bark?;
+|};
+
+public type Pet record {|
+    int id;
+    string name;
+    string tag?;
+    string 'type?;
+|};

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_requestBody.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_requestBody.bal
@@ -5,7 +5,7 @@ listener http:Listener ep0 = new (9090, config = {host: "localhost"});
 service / on ep0 {
     resource function put storageSpaces01(@http:Payload json payload) returns http:Ok {
     }
-    resource function post storageSpaces01(@http:Payload json payload) returns http:Ok {
+    resource function post storageSpaces01(@http:Payload StorageSpaces01_body payload) returns http:Ok {
     }
     resource function put storageSpaces02(@http:Payload string payload) returns http:Ok {
     }

--- a/openapi-cli/src/test/resources/generators/service/swagger/wildcard.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/wildcard.yaml
@@ -1,0 +1,93 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets/my:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - pets
+      requestBody:
+        description: "Request to add a pet"
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/Pets"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  description: "Pet records"
+
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+    Dog:
+      allOf:
+        - $ref: "#/components/schemas/Pet"
+        - type: object
+          properties:
+            bark:
+              type: boolean
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/openapi-cli/src/test/resources/petstore_wildcard.yaml
+++ b/openapi-cli/src/test/resources/petstore_wildcard.yaml
@@ -1,0 +1,93 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /pets/my:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - pets
+      requestBody:
+        description: "Request to add a pet"
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/Pets"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  description: "Pet records"
+
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+    Dog:
+      allOf:
+        - $ref: "#/components/schemas/Pet"
+        - type: object
+          properties:
+            bark:
+              type: boolean
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
@@ -174,11 +174,11 @@ public class RequestBodyGenerator {
                 default:
                     ImmutablePair<Optional<TypeDescriptorNode>, Optional<TypeDefinitionNode>> mediaTypeTokens =
                             handleMediaType(mediaType, null);
-                    if (mediaTypeTokens.left.isEmpty()) {
+                    if (mediaTypeTokens.getLeft().isPresent()) {
+                        typeName = mediaTypeTokens.getLeft();
+                    } else {
                         identifierToken = createIdentifierToken(HTTP_REQUEST);
                         typeName = Optional.ofNullable(createSimpleNameReferenceNode(identifierToken));
-                    } else {
-                        typeName = mediaTypeTokens.left;
                     }
             }
         } else {

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
@@ -62,6 +62,7 @@ import static io.ballerina.compiler.syntax.tree.NodeFactory.createRequiredParame
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createSimpleNameReferenceNode;
 import static io.ballerina.openapi.core.GeneratorConstants.HTTP_REQUEST;
 import static io.ballerina.openapi.core.GeneratorConstants.PAYLOAD;
+import static io.ballerina.openapi.core.GeneratorConstants.REQUEST;
 import static io.ballerina.openapi.core.generators.service.ServiceGenerationUtils.extractReferenceType;
 import static io.ballerina.openapi.core.generators.service.ServiceGenerationUtils.getAnnotationNode;
 import static io.ballerina.openapi.core.generators.service.ServiceGenerationUtils.handleMediaType;
@@ -109,14 +110,14 @@ public class RequestBodyGenerator {
         }
         AnnotationNode annotationNode = getAnnotationNode(GeneratorConstants.PAYLOAD_KEYWORD, annotValue);
         NodeList<AnnotationNode> annotation = NodeFactory.createNodeList(annotationNode);
-        Token paramName = createIdentifierToken(PAYLOAD, GeneratorUtils.SINGLE_WS_MINUTIAE,
-                GeneratorUtils.SINGLE_WS_MINUTIAE);
+        String paramName = typeName.isPresent() && typeName.get().toString().equals(HTTP_REQUEST) ? REQUEST : PAYLOAD;
 
         if (typeName.isEmpty()) {
             return createRequiredParameterNode(createEmptyNodeList(),
                     createSimpleNameReferenceNode(createIdentifierToken(HTTP_REQUEST)), createIdentifierToken(PAYLOAD));
         }
-        return createRequiredParameterNode(annotation, typeName.get(), paramName);
+        return createRequiredParameterNode(annotation, typeName.get(), createIdentifierToken(paramName,
+                GeneratorUtils.SINGLE_WS_MINUTIAE, GeneratorUtils.SINGLE_WS_MINUTIAE));
     }
 
     /**
@@ -127,7 +128,8 @@ public class RequestBodyGenerator {
             throws BallerinaOpenApiException {
 
         Optional<TypeDescriptorNode> typeName;
-        if (mediaType.getValue().getSchema().get$ref() != null) {
+        if (mediaType.getValue() != null && mediaType.getValue().getSchema() != null &&
+                mediaType.getValue().getSchema().get$ref() != null) {
             String schemaName = extractReferenceType(mediaType.getValue().getSchema().get$ref());
             Map<String, Schema> schemas = components.getSchemas();
             String mediaTypeContent = mediaType.getKey().trim();
@@ -170,8 +172,14 @@ public class RequestBodyGenerator {
                             GeneratorUtils.getValidName(schemaName, true))));
                     break;
                 default:
-                    identifierToken = createIdentifierToken(GeneratorConstants.JSON);
-                    typeName = Optional.ofNullable(createSimpleNameReferenceNode(identifierToken));
+                    ImmutablePair<Optional<TypeDescriptorNode>, Optional<TypeDefinitionNode>> mediaTypeTokens =
+                            handleMediaType(mediaType, null);
+                    if (mediaTypeTokens.left.isEmpty()) {
+                        identifierToken = createIdentifierToken(HTTP_REQUEST);
+                        typeName = Optional.ofNullable(createSimpleNameReferenceNode(identifierToken));
+                    } else {
+                        typeName = mediaTypeTokens.left;
+                    }
             }
         } else {
             ImmutablePair<Optional<TypeDescriptorNode>, Optional<TypeDefinitionNode>> mediaTypeTokens =


### PR DESCRIPTION
## Purpose
> $subject
Resolves https://github.com/ballerina-platform/openapi-tools/issues/628

## Goals
**Sample OpenAPI**

```yaml
  /pets/my:
    post:
      summary: Create a pet
      operationId: createPet
      tags:
        - pets
      requestBody:
        description: "Request to add a pet"
        content:
          '*/*':
            schema:
              $ref: "#/components/schemas/Pets"
      responses:
        '200':
          description: Successful operation
          content:
            '*/*':
              schema:
                type: array
                items:
                  description: "Pet records"
```

**Generated Ballerina resource**

service.bal

```bal
import ballerina/http;

listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});

service /v1 on ep0 {
    resource function post pets/my(@http:Payload http:Request request) returns OkAnydata {
    }
}
```
types.bal

```bal
public type OkAnydata record {|
    *http:Ok;
    anydata body;
|};
...
```