### PR TITLE
[master] Support OpenAPI operations with empty response in service generation

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ReturnTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ReturnTypeTests.java
@@ -443,4 +443,17 @@ public class ReturnTypeTests {
         syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("response/post_method.bal", syntaxTree);
     }
+
+    @Test(description = "Test for the resource function return generation when the response is empty")
+    public void testForEmptyResponse() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/response/empty_response.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
+                .withOpenAPI(openAPI)
+                .withFilters(filter)
+                .build();
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("response/empty_response.bal", syntaxTree);
+    }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/response/empty_response.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/response/empty_response.bal
@@ -1,0 +1,8 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (9090, config = {host: "localhost"});
+
+service /petstore/v1 on ep0 {
+    resource function get pets(int? 'limit) returns http:Response {
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/swagger/response/empty_response.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/response/empty_response.yaml
@@ -1,0 +1,26 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://localhost:9090/petstore/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      description: Show a list of pets in the system
+      operationId: listPets
+      tags:
+        - pets
+        - list
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses: {}

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ReturnTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ReturnTypeGenerator.java
@@ -133,11 +133,14 @@ public class ReturnTypeGenerator {
                 //handle multiple response scenarios ex: status code 200, 400, 500
                 TypeDescriptorNode type = handleMultipleResponse(responses);
                 returnNode = createReturnTypeDescriptorNode(createToken(RETURNS_KEYWORD), annotations, type);
-            } else {
+            } else if (responses.size() == 1) {
                 //handle single response
                 Iterator<Map.Entry<String, ApiResponse>> responseIterator = responses.entrySet().iterator();
                 Map.Entry<String, ApiResponse> response = responseIterator.next();
                 returnNode = handleSingleResponse(annotations, response);
+            } else {
+                TypeDescriptorNode defaultType = createSimpleNameReferenceNode(createIdentifierToken(HTTP_RESPONSE));
+                returnNode = createReturnTypeDescriptorNode(createToken(RETURNS_KEYWORD), annotations, defaultType);
             }
         } else {
             // --error node TypeDescriptor


### PR DESCRIPTION
## Purpose
> $subject
Resolves https://github.com/ballerina-platform/openapi-tools/issues/1174

## Goals

**Sample OpenAPI**
```yaml
  /pets:
    get:
      summary: List all pets
      description: Show a list of pets in the system
      operationId: listPets
      tags:
        - pets
        - list
      parameters:
        - name: limit
          in: query
          description: How many items to return at one time (max 100)
          required: false
          schema:
            type: integer
            format: int32
      responses: {}
```

**Generated resource in service**

```bal
    resource function get pets(int? 'limit) returns http:Response {
    }
```

## Test environment
> Java JDK 11
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.