### PR TITLE
[1.4.x] Add support for the handle service generation when requestBody  has `oneOf` schema type

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
@@ -16,8 +16,10 @@
 package io.ballerina.openapi;
 
 import io.ballerina.openapi.cmd.BallerinaCodeGenerator;
+import io.ballerina.openapi.core.GeneratorConstants;
 import io.ballerina.openapi.core.GeneratorUtils;
 import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
+import io.ballerina.openapi.core.generators.service.ServiceGenerationUtils;
 import io.ballerina.openapi.core.model.Filter;
 import io.ballerina.openapi.core.model.GenSrcFile;
 import io.ballerina.openapi.generators.common.TestUtils;
@@ -610,6 +612,13 @@ public class CodeGeneratorTest {
         Assert.assertEquals(GeneratorUtils.escapeIdentifier("foo_bar$_baz"), "'foo_bar\\$_baz");
     }
 
+    @Test
+    public void testForSelectMediaType() {
+        Assert.assertEquals(ServiceGenerationUtils.selectMediaType("text/json"),
+                GeneratorConstants.APPLICATION_JSON);
+        Assert.assertEquals(ServiceGenerationUtils.selectMediaType("text/xml"),
+                GeneratorConstants.APPLICATION_XML);
+    }
     private String getStringFromGivenBalFile(Path expectedServiceFile, String s) throws IOException {
 
         Stream<String> expectedServiceLines = Files.lines(expectedServiceFile.resolve(s));

--- a/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/CodeGeneratorTest.java
@@ -619,6 +619,7 @@ public class CodeGeneratorTest {
         Assert.assertEquals(ServiceGenerationUtils.selectMediaType("text/xml"),
                 GeneratorConstants.APPLICATION_XML);
     }
+
     private String getStringFromGivenBalFile(Path expectedServiceFile, String s) throws IOException {
 
         Stream<String> expectedServiceLines = Files.lines(expectedServiceFile.resolve(s));

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/RequestBodyTests.java
@@ -19,8 +19,10 @@
 package io.ballerina.openapi.generators.service;
 
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import io.ballerina.openapi.core.GeneratorUtils;
 import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
+import io.ballerina.openapi.core.generators.schema.BallerinaTypesGenerator;
 import io.ballerina.openapi.core.generators.service.BallerinaServiceGenerator;
 import io.ballerina.openapi.core.generators.service.model.OASServiceMetadata;
 import io.ballerina.openapi.core.model.Filter;
@@ -135,10 +137,18 @@ public class RequestBodyTests {
                 .withOpenAPI(GeneratorUtils.normalizeOpenAPI(definitionPath, false))
                 .withFilters(filter)
                 .build();
-        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
-        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        BallerinaServiceGenerator serviceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
+        syntaxTree = serviceGenerator.generateSyntaxTree();
+        //Generate records according to schemas
+        List<TypeDefinitionNode> typeInclusionRecords = serviceGenerator.getTypeInclusionRecords();
+        BallerinaTypesGenerator recordGenerator = new BallerinaTypesGenerator(
+                oasServiceMetadata.getOpenAPI(), oasServiceMetadata.isNullable(), typeInclusionRecords);
+        SyntaxTree typeSyntaxTree = recordGenerator.generateSyntaxTree();
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
                 "requestBody/oneof_requestBody.bal", syntaxTree);
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "requestBody/oneof_request_body_types.bal", typeSyntaxTree);
+
     }
 
     @Test(description = "RequestBody has url encode media type  scenarios")

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_requestBody.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_requestBody.bal
@@ -3,18 +3,16 @@ import ballerina/http;
 listener http:Listener ep0 = new (9090, config = {host: "localhost"});
 
 service / on ep0 {
-    resource function put storageSpaces01(@http:Payload json payload) returns http:Ok {
+    resource function put pet(@http:Payload Pet_body payload) returns http:Ok {
     }
-    resource function post storageSpaces01(@http:Payload StorageSpaces01_body payload) returns http:Ok {
+    resource function post pet(@http:Payload Pet_body_1 payload) returns http:Ok {
     }
-    resource function put storageSpaces02(@http:Payload string payload) returns http:Ok {
+    resource function put pet02(@http:Payload Pet02_body payload) returns http:Ok {
     }
-    resource function post storageSpaces02(@http:Payload xml payload) returns http:Ok {
+    resource function post pet02(@http:Payload xml payload) returns http:Ok {
     }
-    resource function put storageSpaces/[string name](@http:Payload json payload) returns http:Ok|http:BadRequest {
+    resource function put pet/[string name](@http:Payload Pet_name_body payload) returns http:Ok|http:BadRequest {
     }
-    resource function post storageSpaces03(@http:Payload xml payload) returns http:Ok {
-    }
-    resource function post storageSpaces04(http:Request request) returns http:Ok {
+    resource function post pet04(http:Request request) returns http:Ok {
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_request_body_types.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_request_body_types.bal
@@ -1,0 +1,26 @@
+public type Pet02_body string|int|decimal;
+
+public type Pet_body_1 Dog|Bird;
+
+public type Pet04_body string|int|decimal;
+
+public type Bird record {|
+    string name?;
+    boolean isFly?;
+|};
+
+public type Cat record {|
+    string name?;
+    string kind?;
+|};
+
+public type Pet02_body_1 Dog|Cat;
+
+public type Pet_name_body (string|int|decimal)[];
+
+public type Pet_body Dog|Cat;
+
+public type Dog record {|
+    string name?;
+    string age?;
+|};

--- a/openapi-cli/src/test/resources/generators/service/swagger/requestBody/oneOf_request_body.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/requestBody/oneOf_request_body.yaml
@@ -1,25 +1,27 @@
 openapi: 3.0.1
 info:
-  title:  Storage Space
+  title:  Pets store
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: 1.0.0
 paths:
-  /storageSpaces01:
+  /pet:
     put:
-      summary: "Unsupported scenario 01: Customised request body with empty schema"
+      summary: "scenario 01: Request body is with oneOf schema for application/json"
       operationId: putKey
       requestBody:
-        description: "Customised request body with empty schema"
         content:
-          application/snowflake+json:
-            schema: {}
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/Dog"
+                - $ref: "#/components/schemas/Cat"
       responses:
         200:
           description: Successful operation.
     post:
-      summary: "Unsupported scenario 02: Customised request body with oneOf schema"
+      summary: "scenario 02: Customised request body with oneOf schema"
       operationId: post
       requestBody:
         description: "Customised request body"
@@ -27,14 +29,14 @@ paths:
           application/snowflake+json:
             schema:
               oneOf:
-                - $ref: "#/components/schemas/HandleRequest_RequestBody"
-                - $ref: "#/components/schemas/HandleRequest_RequestBody02"
+                - $ref: "#/components/schemas/Dog"
+                - $ref: "#/components/schemas/Bird"
       responses:
         200:
           description: Successful operation.
-  /storageSpaces02:
+  /pet02:
     post:
-      summary: "Unsupported scenario 03: Request body with oneOf schema"
+      summary: "scenario 03: Request body with oneOf schema with application/xml"
       operationId: postKey
       requestBody:
         description: "Ballerina not support for oneOf data type in request body"
@@ -42,13 +44,13 @@ paths:
           application/xml:
             schema:
               oneOf:
-                - $ref: "#/components/schemas/HandleRequest_RequestBody"
-                - $ref: "#/components/schemas/HandleRequest_RequestBody02"
+                - $ref: "#/components/schemas/Dog"
+                - $ref: "#/components/schemas/Cat"
       responses:
         200:
           description: Successful operation.
     put:
-      summary: "Unsupported scenario 04: Request body with oneOf schema with integer, number"
+      summary: "scenario 04: Request body with oneOf schema with integer, number (primitives)"
       operationId: put
       requestBody:
         description: "Ballerina not support for oneOf data type in request body"
@@ -62,75 +64,68 @@ paths:
       responses:
         200:
           description: Successful operation.
-  /storageSpaces/{name}:
+  /pet/{name}:
     put:
-      summary: Put key value
+      summary: "scenarios05: requestBody is with oneOf array type"
       operationId: key
       parameters:
         - name: name
           in: path
-          description: name of the storage space
           required: true
           schema:
             type: string
       requestBody:
-        description: Value to be added
+        description: ""
         content:
-          application/json:
+          text/plain:
             schema:
               oneOf:
-                - type: string
-                - type: integer
-                - type: number
-                - type: object
+                - type: array
+                  items:
+                    oneOf:
+                      - type: string
+                      - type: integer
+                      - type: number
       responses:
         200:
           description: Successful operation.
         400:
           description: Invalid storage space name supplied
-  /storageSpaces03:
-    post:
-      summary: "Request body content type is with subset of xml"
-      operationId: postKey03
-      requestBody:
-        content:
-          application/snowflake+xml:
-            schema:
-              type: object
-              additionalProperties:
-                type: string
-      responses:
-        200:
-          description: Successful operation.
-  /storageSpaces04:
+  /pet04:
     post:
       operationId: postKey04
       requestBody:
-        description: "Media type is with not main standard type. "
+        description: "scenario04: Media type is with not main standard type. "
         content:
           application/zip:
             schema:
-              type: object
-              additionalProperties:
-                type: string
+              oneOf:
+                - type: string
+                - type: integer
+                - type: number
       responses:
         200:
           description: Successful operation.
 components:
   schemas:
-    HandleRequest_RequestBody:
-      title: Request/Response handler
+    Dog:
       type: object
       properties:
-        headers:
+        name:
           type: string
-        body:
+        age:
           type: string
-    HandleRequest_RequestBody02:
-      title: Request/Response handler
+    Cat:
       type: object
       properties:
-        headers:
+        name:
           type: string
-        body:
+        kind:
           type: string
+    Bird:
+      type: object
+      properties:
+        name:
+          type: string
+        isFly:
+          type: boolean

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/BallerinaServiceGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/BallerinaServiceGenerator.java
@@ -250,8 +250,7 @@ public class BallerinaServiceGenerator {
             RequestBody requestBody = operation.getValue().getRequestBody();
             requestBody = resolveRequestBodyReference(requestBody);
             if (requestBody.getContent() != null) {
-                RequestBodyGenerator requestBodyGen = new RequestBodyGenerator(this.openAPI.getComponents(),
-                        requestBody);
+                RequestBodyGenerator requestBodyGen = new RequestBodyGenerator(requestBody);
                 params.add(requestBodyGen.createNodeForRequestBody());
                 params.add(createToken(SyntaxKind.COMMA_TOKEN));
             }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
@@ -38,7 +38,6 @@ import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import io.ballerina.openapi.core.GeneratorConstants;
 import io.ballerina.openapi.core.GeneratorUtils;
 import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -64,7 +63,7 @@ import static io.ballerina.openapi.core.GeneratorConstants.REQUEST;
 import static io.ballerina.openapi.core.generators.service.ServiceGenerationUtils.extractReferenceType;
 import static io.ballerina.openapi.core.generators.service.ServiceGenerationUtils.getAnnotationNode;
 import static io.ballerina.openapi.core.generators.service.ServiceGenerationUtils.handleMediaType;
-import static io.ballerina.openapi.core.generators.service.ServiceGenerationUtils.seleteMediaType;
+import static io.ballerina.openapi.core.generators.service.ServiceGenerationUtils.selectMediaType;
 
 /**
  * This class for generating request body payload for OAS requestBody section.
@@ -72,11 +71,9 @@ import static io.ballerina.openapi.core.generators.service.ServiceGenerationUtil
  * @since 1.3.0
  */
 public class RequestBodyGenerator {
-    private final Components components;
     private final RequestBody requestBody;
 
-    public RequestBodyGenerator(Components components, RequestBody requestBody) {
-        this.components = components;
+    public RequestBodyGenerator(RequestBody requestBody) {
         this.requestBody = requestBody;
     }
 
@@ -130,7 +127,7 @@ public class RequestBodyGenerator {
                 mediaType.getValue().getSchema().get$ref() != null) {
             String reference = mediaType.getValue().getSchema().get$ref();
             String schemaName = GeneratorUtils.getValidName(extractReferenceType(reference), true);
-            String mediaTypeContent = seleteMediaType(mediaType.getKey().trim());
+            String mediaTypeContent = selectMediaType(mediaType.getKey().trim());
             IdentifierToken identifierToken;
             switch (mediaTypeContent) {
                 case GeneratorConstants.APPLICATION_XML:

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceGenerationUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceGenerationUtils.java
@@ -216,7 +216,7 @@ public class ServiceGenerationUtils {
 
     public static ImmutablePair<Optional<TypeDescriptorNode>, Optional<TypeDefinitionNode>> handleMediaType(
             Map.Entry<String, MediaType> mediaType, String recordName) throws BallerinaOpenApiException {
-        String mediaTypeContent = seleteMediaType(mediaType.getKey().trim());
+        String mediaTypeContent = selectMediaType(mediaType.getKey().trim());
 
         MediaType value = mediaType.getValue();
         Schema<?> schema = value.getSchema();
@@ -266,17 +266,17 @@ public class ServiceGenerationUtils {
 
     /**
      *
-     * This util uses for selecting standard media type by looking at the user defined media type.
+     * This util is used for selecting standard media type by looking at the user defined media type.
      */
-    public static String seleteMediaType(String mediaTypeContent) {
+    public static String selectMediaType(String mediaTypeContent) {
 
-        if (mediaTypeContent.matches("text/.*")) {
-            mediaTypeContent = GeneratorConstants.TEXT;
-        } else if (mediaTypeContent.matches("application/.*\\+json")) {
+        if (mediaTypeContent.matches("application/.*\\+json") || mediaTypeContent.matches(".*/json")) {
             mediaTypeContent = GeneratorConstants.APPLICATION_JSON;
-        } else if (mediaTypeContent.matches("application/.*\\+xml")) {
+        } else if (mediaTypeContent.matches("application/.*\\+xml") || mediaTypeContent.matches(".*/xml")) {
             mediaTypeContent = GeneratorConstants.APPLICATION_XML;
-        } else if (mediaTypeContent.matches("application/.*\\+octet-stream")) {
+        } else if (mediaTypeContent.matches("text/.*")) {
+            mediaTypeContent = GeneratorConstants.TEXT;
+        }  else if (mediaTypeContent.matches("application/.*\\+octet-stream")) {
             mediaTypeContent = GeneratorConstants.APPLICATION_OCTET_STREAM;
         } else if (mediaTypeContent.matches("application/.*\\+x-www-form-urlencoded")) {
             mediaTypeContent = GeneratorConstants.APPLICATION_URL_ENCODE;

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceGenerationUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceGenerationUtils.java
@@ -216,18 +216,7 @@ public class ServiceGenerationUtils {
 
     public static ImmutablePair<Optional<TypeDescriptorNode>, Optional<TypeDefinitionNode>> handleMediaType(
             Map.Entry<String, MediaType> mediaType, String recordName) throws BallerinaOpenApiException {
-        String mediaTypeContent = mediaType.getKey().trim();
-        if (mediaTypeContent.matches("text/.*")) {
-            mediaTypeContent = GeneratorConstants.TEXT;
-        } else if (mediaTypeContent.matches("application/.*\\+json")) {
-            mediaTypeContent = GeneratorConstants.APPLICATION_JSON;
-        } else if (mediaTypeContent.matches("application/.*\\+xml")) {
-            mediaTypeContent = GeneratorConstants.APPLICATION_XML;
-        } else if (mediaTypeContent.matches("application/.*\\+octet-stream")) {
-            mediaTypeContent = GeneratorConstants.APPLICATION_OCTET_STREAM;
-        } else if (mediaTypeContent.matches("application/.*\\+x-www-form-urlencoded")) {
-            mediaTypeContent = GeneratorConstants.APPLICATION_URL_ENCODE;
-        }
+        String mediaTypeContent = seleteMediaType(mediaType.getKey().trim());
 
         MediaType value = mediaType.getValue();
         Schema<?> schema = value.getSchema();
@@ -273,6 +262,26 @@ public class ServiceGenerationUtils {
             default:
                 return ImmutablePair.of(Optional.empty(), Optional.empty());
         }
+    }
+
+    /**
+     *
+     * This util uses for selecting standard media type by looking at the user defined media type.
+     */
+    public static String seleteMediaType(String mediaTypeContent) {
+
+        if (mediaTypeContent.matches("text/.*")) {
+            mediaTypeContent = GeneratorConstants.TEXT;
+        } else if (mediaTypeContent.matches("application/.*\\+json")) {
+            mediaTypeContent = GeneratorConstants.APPLICATION_JSON;
+        } else if (mediaTypeContent.matches("application/.*\\+xml")) {
+            mediaTypeContent = GeneratorConstants.APPLICATION_XML;
+        } else if (mediaTypeContent.matches("application/.*\\+octet-stream")) {
+            mediaTypeContent = GeneratorConstants.APPLICATION_OCTET_STREAM;
+        } else if (mediaTypeContent.matches("application/.*\\+x-www-form-urlencoded")) {
+            mediaTypeContent = GeneratorConstants.APPLICATION_URL_ENCODE;
+        }
+        return mediaTypeContent;
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Fix #https://github.com/ballerina-platform/openapi-tools/issues/909

## Goals
> Generate service generation with request body has oneOf type
```openapi
  /pet:
    put:
      summary: "scenario 01: Request body is with oneOf schema for application/json"
      operationId: putKey
      requestBody:
        content:
          application/json:
            schema:
              oneOf:
                - $ref: "#/components/schemas/Dog"
                - $ref: "#/components/schemas/Cat"
      responses:
        200:
          description: Successful operation.
```
Generated service
```ballerina
public type Cat record {|
    string name?;
    string kind?;
|};

public type Dog record {|
    string name?;
    string age?;
|};

public type Pet_body Dog|Cat;

resource function put pet(@http:Payload Pet_body payload) returns http:Ok {
    }
```
Note: Here `oneOf` schema has been sent under the component section with the name `Pet_body` in OAS by the swagger parser itself.

## Automation tests
 - Unit tests - added
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.