### PR TITLE
[1.3.x] Support OpenAPI operations with no response

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -153,6 +153,11 @@ public class FunctionBodyNodeTests {
                 {"swagger/any_type_response.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
                         "        // TODO: Update the request as needed;\n" +
                         "        http:Response response = check self.clientEp->post(resourcePath, request);\n" +
+                        "        return response;}"},
+                {"swagger/return_type/no_response.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
+                        "        map<anydata> queryParam = {\"limit\": 'limit};\n" +
+                        "        resourcePath = resourcePath + check getPathForQueryParam(queryParam);\n" +
+                        "        http:Response response = check self.clientEp->get(resourcePath);\n" +
                         "        return response;}"}
         };
     }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureReturnTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureReturnTypeTests.java
@@ -108,4 +108,14 @@ public class FunctionSignatureReturnTypeTests {
                 true);
         Assert.assertEquals(returnType, "json|error");
     }
+
+    @Test(description = "Tests for the empty response")
+    public void getReturnTypeForEmptyResponse() throws IOException, BallerinaOpenApiException {
+        OpenAPI array = getOpenAPI(RES_DIR.resolve("swagger/return_type/no_response.yaml"));
+        FunctionReturnTypeGenerator functionReturnType = new FunctionReturnTypeGenerator(array,
+                new BallerinaTypesGenerator(array), new ArrayList<>());
+        String returnType = functionReturnType.getReturnType(array.getPaths().get("/pets").getGet(),
+                true);
+        Assert.assertEquals(returnType, "http:Response|error");
+    }
 }

--- a/openapi-cli/src/test/resources/generators/client/swagger/return_type/no_response.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/return_type/no_response.yaml
@@ -1,0 +1,26 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://localhost:9090/petstore/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      description: Show a list of pets in the system
+      operationId: listPets
+      tags:
+        - pets
+        - list
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses: {}

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
@@ -163,11 +163,14 @@ public class FunctionSignatureGenerator {
         ApiResponses responses = operation.getResponses();
         Collection<ApiResponse> values = responses.values();
         Iterator<ApiResponse> iteratorRes = values.iterator();
-        ApiResponse next = iteratorRes.next();
-        if (next.getDescription() != null && !next.getDescription().isBlank()) {
-            MarkdownParameterDocumentationLineNode returnDoc = DocCommentsGenerator.createAPIParamDoc("return",
-                    next.getDescription());
-            remoteFunctionDoc.add(returnDoc);
+        if (iteratorRes.hasNext()) {
+            ApiResponse response = iteratorRes.next();
+            if (response.getDescription() != null && !response.getDescription().isBlank()) {
+                MarkdownParameterDocumentationLineNode returnDoc =
+                        DocCommentsGenerator.createAPIParamDoc("return",
+                        response.getDescription());
+                remoteFunctionDoc.add(returnDoc);
+            }
         }
 
         // Return Type


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/ballerina-platform/openapi-tools/issues/1150 in OpenAPI version 1.3

## Goals

**Sample OpenAPI**
```yaml
  /pets:
    get:
      summary: List all pets
      description: Show a list of pets in the system
      operationId: listPets
      tags:
        - pets
        - list
      parameters:
        - name: limit
          in: query
          description: How many items to return at one time (max 100)
          required: false
          schema:
            type: integer
      responses: {}
```

**Generated function**
```bal
    remote isolated function listPets(int? 'limit = ()) returns http:Response|error {
        string resourcePath = string `/pets`;
        map<anydata> queryParam = {"limit": 'limit};
        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
        http:Response response = check self.clientEp->get(resourcePath);
        return response;
    }
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11