### PR TITLE
[1.4.x]Handle multiple mediaType in swagger request body for ballerina service generations

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/RequestBodyTests.java
@@ -185,7 +185,7 @@ public class RequestBodyTests {
     }
 
 
-    @Test
+    @Test(description = "RequestBody has unhandled media type ex: application/zip")
     public void testForUnhandledMediaType() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/requestBody/unhandled_media_type.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
@@ -197,5 +197,19 @@ public class RequestBodyTests {
         syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
                 "requestBody/unhandled_media_type.bal", syntaxTree);
+    }
+
+    @Test(description = "RequestBody has anyOF type")
+    public void testForAnyOF() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/requestBody/any_of.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
+                .withOpenAPI(openAPI)
+                .withFilters(filter)
+                .build();
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "requestBody/any_of.bal", syntaxTree);
     }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/RequestBodyTests.java
@@ -209,8 +209,8 @@ public class RequestBodyTests {
                 "requestBody/unhandled_media_type.bal", syntaxTree);
     }
 
-    @Test(description = "RequestBody has anyOF type")
-    public void testForAnyOF() throws IOException, BallerinaOpenApiException {
+    @Test(description = "RequestBody has anyOf type")
+    public void testForAnyOf() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/requestBody/any_of.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/RequestBodyTests.java
@@ -88,7 +88,7 @@ public class RequestBodyTests {
 
     @Test(description = "Scenario 03 - Request Body has multiple content types with Different dataBind schema types.")
     public void generateMultipleContent() throws IOException, BallerinaOpenApiException {
-        Path definitionPath = RES_DIR.resolve("swagger/requestBody/scenario03_rb.yaml");
+        Path definitionPath = RES_DIR.resolve("swagger/requestBody/multiple_content.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
         OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
                 .withOpenAPI(openAPI)
@@ -182,5 +182,20 @@ public class RequestBodyTests {
         syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
                 "requestBody/multipart_form_data.bal", syntaxTree);
+    }
+
+
+    @Test
+    public void testForUnhandledMediaType() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/requestBody/unhandled_media_type.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
+                .withOpenAPI(openAPI)
+                .withFilters(filter)
+                .build();
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "requestBody/unhandled_media_type.bal", syntaxTree);
     }
 }

--- a/openapi-cli/src/test/resources/expected_gen/petstore_service_swagger.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_service_swagger.bal
@@ -3,9 +3,9 @@ import ballerina/http;
 listener http:Listener ep0 = new (443, config = {host: "petstore.swagger.io"});
 
 service /v2 on ep0 {
-    resource function put pet(@http:Payload {mediaType: ["application/json", "application/xml"]} Pet payload) returns http:BadRequest|http:NotFound|http:MethodNotAllowed {
+    resource function put pet(@http:Payload Pet|xml payload) returns http:BadRequest|http:NotFound|http:MethodNotAllowed {
     }
-    resource function post pet(@http:Payload {mediaType: ["application/json", "application/xml"]} Pet payload) returns http:MethodNotAllowed {
+    resource function post pet(@http:Payload Pet|xml payload) returns http:MethodNotAllowed {
     }
     resource function get pet/findByStatus(string[] status) returns Pet[]|http:BadRequest {
     }
@@ -13,7 +13,7 @@ service /v2 on ep0 {
     }
     resource function get pet/[int petId]() returns Pet|http:BadRequest|http:NotFound {
     }
-    resource function post pet/[int petId](@http:Payload {mediaType: "application/x-www-form-urlencoded"} Pet_petId_body payload) returns http:MethodNotAllowed {
+    resource function post pet/[int petId](@http:Payload map<string> payload) returns http:MethodNotAllowed {
     }
     resource function delete pet/[int petId](@http:Header string? api_key) returns http:BadRequest|http:NotFound {
     }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/any_of.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/any_of.bal
@@ -1,0 +1,8 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (443, config = {host: "api.example.com"});
+
+service / on ep0 {
+    resource function post pets03(@http:Payload Pets03_body payload) returns http:Created {
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/scenario_02_rb.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/scenario_02_rb.bal
@@ -3,7 +3,6 @@ import ballerina/http;
 listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
 
 service /v1 on ep0 {
-    resource function post pets(@http:Payload{mediaType: ["application/json", "application/xml"]} Pet payload)
-    returns http:Ok {
+    resource function post pets(@http:Payload Pet|xml|map<string>|string payload) returns http:Ok {
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/scenario_03_rb.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/scenario_03_rb.bal
@@ -3,6 +3,8 @@ import ballerina/http;
 listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
 
 service /v1 on ep0 {
-    resource function post pets(@http:Payload Pet payload) returns http:Ok {
+    resource function put pets(http:Request request) returns http:Ok {
+    }
+    resource function post pets(@http:Payload Pet|xml|PetForm|string payload) returns http:Ok {
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/scenario_03_rb.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/scenario_03_rb.bal
@@ -5,6 +5,8 @@ listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
 service /v1 on ep0 {
     resource function put pets(http:Request request) returns http:Ok {
     }
-    resource function post pets(@http:Payload Pet|xml|PetForm|string payload) returns http:Ok {
+    resource function post pets(@http:Payload Pet|xml|map<string>|string payload) returns http:Ok {
+    }
+    resource function post pets02(@http:Payload Pet|xml payload) returns http:Created {
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/unhandled_media_type.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/unhandled_media_type.bal
@@ -1,0 +1,12 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (443, config = {host: "api.example.com"});
+
+service / on ep0 {
+    resource function put users(http:Request request) returns http:Ok {
+    }
+    resource function post users(http:Request request) returns http:Ok {
+    }
+    resource function put users/[string id](http:Request request) returns http:Ok {
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/url_encode.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/url_encode.bal
@@ -3,10 +3,10 @@ import ballerina/http;
 listener http:Listener ep0 = new (9090, config = {host: "localhost"});
 
 service / on ep0 {
-    resource function post user(@http:Payload {mediaType: "application/x-www-form-urlencoded"} User_body payload) returns OkJson {
+    resource function post user(@http:Payload map<string> payload) returns OkJson {
     }
-    resource function post user02(@http:Payload {mediaType: "application/x-www-form-urlencoded"} User payload) returns OkJson {
+    resource function post user02(@http:Payload map<string> payload) returns OkJson {
     }
-    resource function post user03(@http:Payload {mediaType: "application/x-www-form-urlencoded"} map<string> payload) returns OkJson {
+    resource function post user03(@http:Payload map<string> payload) returns OkJson {
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/swagger/requestBody/any_of.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/requestBody/any_of.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.1
+info:
+  title: Sample API
+  description: API description in Markdown.
+  version: 1.0.0
+servers:
+  - url: 'https://api.example.com'
+paths:
+  /pets03:
+    post:
+      summary: List all pets
+      description: Show a list of pets in the system
+      operationId: listPets1
+      requestBody:
+        content:
+          "application/json":
+            schema:
+              anyOf:
+                - $ref: "#/components/schemas/Dog"
+                - $ref: "#/components/schemas/Cat"
+      responses:
+        "201":
+          description: OK
+components:
+  schemas:
+    Dog:
+      type: object
+      required:
+        - userName
+      properties:
+        userName:
+          type: string
+        kind:
+          type: string
+    Cat:
+      type: object
+      required:
+        - userName
+      properties:
+        name:
+          type: string
+        kind:
+          type: string

--- a/openapi-cli/src/test/resources/generators/service/swagger/requestBody/multiple_content.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/requestBody/multiple_content.yaml
@@ -67,6 +67,22 @@ paths:
           text/plain:
             schema:
               type: string
+  /pets02:
+    post:
+      summary: List all pets
+      description: Show a list of pets in the system
+      operationId: listPets
+      requestBody:
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/Pet"
+          "application/xml":
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "201":
+          description: OK
 components:
   schemas:
     User:

--- a/openapi-cli/src/test/resources/generators/service/swagger/requestBody/multiple_content.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/requestBody/multiple_content.yaml
@@ -46,6 +46,27 @@ paths:
           text/plain:
             schema:
               type: string
+    put:
+      summary: Add a new pet
+      responses:
+        200:
+          description: OK
+      requestBody:
+        description: Optional description in *Markdown*
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/zip:
+            schema:
+              $ref: '#/components/schemas/PetForm'
+          text/plain:
+            schema:
+              type: string
 components:
   schemas:
     User:

--- a/openapi-cli/src/test/resources/generators/service/swagger/requestBody/unhandled_media_type.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/requestBody/unhandled_media_type.yaml
@@ -1,0 +1,90 @@
+openapi: 3.0.1
+info:
+  title: Sample API
+  description: API description in Markdown.
+  version: 1.0.0
+servers:
+  - url: 'https://api.example.com'
+paths:
+  /users:
+    post:
+      summary: Returns a list of users.
+      description: Optional extended description in Markdown.
+      requestBody:
+        content:
+          multipart/mixed:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                address:
+                  type: object
+                  properties: { }
+                historyMetadata:
+                  description: metadata in XML format
+                  type: object
+                  properties: { }
+                profileImage:
+                  type: string
+                  format: binary
+            encoding:
+              historyMetadata:
+                # require XML Content-Type in utf-8 encoding
+                contentType: application/xml; charset=utf-8
+              profileImage:
+                # only accept png/jpeg
+                contentType: image/png, image/jpeg
+                headers:
+                  X-Rate-Limit-Limit:
+                    description: The number of allowed requests in the current period
+      responses:
+        '200':
+          description: OK
+    put:
+      summary: Update a user image.
+      requestBody:
+        content:
+          image/png:
+            schema:
+              type: string
+              format: binary
+      responses:
+        200:
+          description: OK
+
+
+  /users/{id}:
+    put:
+      summary: Returns a user by ID.
+      description: Optional extended description in Markdown.
+      parameters:
+        - name: id
+          in: path
+          description: ID of user to fetch
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/epub+zip:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '200':
+          description: OK
+
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        address:
+          type: string

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
@@ -20,20 +20,12 @@ package io.ballerina.openapi.core.generators.service;
 
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
 import io.ballerina.compiler.syntax.tree.ArrayDimensionNode;
-import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.IdentifierToken;
-import io.ballerina.compiler.syntax.tree.ListConstructorExpressionNode;
-import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
-import io.ballerina.compiler.syntax.tree.MappingFieldNode;
-import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeFactory;
 import io.ballerina.compiler.syntax.tree.NodeList;
 import io.ballerina.compiler.syntax.tree.NodeParser;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
-import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
-import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
-import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import io.ballerina.openapi.core.GeneratorConstants;
@@ -44,12 +36,9 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyNodeList;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createIdentifierToken;

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
@@ -86,11 +86,11 @@ public class RequestBodyGenerator {
                 types.add(HTTP_REQUEST);
             }
         }
-        if (types.size() > 1 && !types.contains(HTTP_REQUEST)) {
+        if (types.size() > 1 && types.contains(HTTP_REQUEST)) {
+            typeName = Optional.of(NodeParser.parseTypeDescriptor(HTTP_REQUEST));
+        } else if (types.size() > 1) {
             String result = String.join(PIPE, types);
             typeName = Optional.of(NodeParser.parseTypeDescriptor(result));
-        } else if (types.size() > 1 && types.contains(HTTP_REQUEST)) {
-            typeName = Optional.of(NodeParser.parseTypeDescriptor(HTTP_REQUEST));
         } else {
             typeName = Optional.of(NodeParser.parseTypeDescriptor(types.get(0)));
         }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/RequestBodyGenerator.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.StringJoiner;
 
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyNodeList;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createIdentifierToken;
@@ -173,7 +172,7 @@ public class RequestBodyGenerator {
                 case GeneratorConstants.APPLICATION_URL_ENCODE:
                     typeName = Optional.ofNullable(createSimpleNameReferenceNode(createIdentifierToken(MAP_STRING)));
                     //Commented due to the data binding issue in the ballerina http module
-                    //Related issue:https://github.com/ballerina-platform/ballerina-standard-library/issues/4090
+                    //TODO: Related issue:https://github.com/ballerina-platform/ballerina-standard-library/issues/4090
 //                    typeName = Optional.ofNullable(createSimpleNameReferenceNode(createIdentifierToken(
 //                            GeneratorUtils.getValidName(schemaName, true))));
                     break;


### PR DESCRIPTION
## Purpose
> FIx #942 
Changed  form-url-encode mapping record into `map<string>`, due to this issue https://github.com/ballerina-platform/ballerina-standard-library/issues/4090, now it map into `map<string>`

## Goals
> Through this fix we are generating a union type for the request body if it has multiple content types.
```openapi
/pets:
    post:
      summary: List all pets
      description: Show a list of pets in the system
      operationId: listPets
      requestBody:
        content:
          "application/json":
           schema:
            $ref: "#components/schemas/Pet"
          "application/xml":
           schema:
            $ref: "#components/schemas/Dog"  
      responses: 
       "201":
        description: OK
```
Generated code
```ballerina
service /petstore/v1 on ep0 {
    resource function post pets(@http:Payload Pet|xml payload) returns string {
        io:println(payload);
        return "correct " + payload.name;
    }
}
```
## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.