### PR TITLE
[1.4.x]Changed the request Payload type into `byte[]` for MediaType `application/octet-stream` in client generations

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -165,7 +165,8 @@ public class RequestBodyTests {
     }
 
     @Test(description = "Test for generating request body when operation has binary octet-stream media type")
-    public void testRequestBodyWithBinaryOctetStreamMediaType() throws IOException, BallerinaOpenApiException {
+    public void testRequestBodyWithBinaryOctetStreamMediaType()
+            throws IOException, BallerinaOpenApiException {
         Path expectedPath = RES_DIR.resolve("ballerina/binary_format_octet_stream_payload.bal");
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(
                 RES_DIR.resolve("swagger/binary_format_octet_stream_payload.yaml"), true);
@@ -256,8 +257,7 @@ public class RequestBodyTests {
     }
 
     @Test(description = "Test for generating request body when operation has multipart form-data media type")
-    public void testRequestBodyWithMultipartMediaType()
-            throws IOException, BallerinaOpenApiException {
+    public void testRequestBodyWithMultipartMediaType() throws IOException, BallerinaOpenApiException {
         Path expectedPath = RES_DIR.resolve("ballerina/multipart_formdata.bal");
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(
                 RES_DIR.resolve("utils/swagger/multipart_formdata.yaml"), true);
@@ -313,6 +313,22 @@ public class RequestBodyTests {
                 .withFilters(filter)
                 .withOpenAPI(openAPI)
                 .withResourceMode(false).build();
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(oasClientConfig);
+        syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
+    }
+
+    @Test
+    public void testWithOctetStreamInRequestBody()
+            throws IOException, BallerinaOpenApiException {
+        Path expectedPath = RES_DIR.resolve("ballerina/octet_stream_request_payload.bal");
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(
+                RES_DIR.resolve("swagger/octet_stream_request_payload.yaml"), true);
+        OASClientConfig.Builder clientMetaDataBuilder = new OASClientConfig.Builder();
+        OASClientConfig oasClientConfig = clientMetaDataBuilder
+                .withFilters(filter)
+                .withOpenAPI(openAPI)
+                .withResourceMode(true).build();
         BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(oasClientConfig);
         syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
         compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -318,7 +318,7 @@ public class RequestBodyTests {
         compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
     }
 
-    @Test
+    @Test(description = "Test for generating request body with octet-stream media type")
     public void testWithOctetStreamInRequestBody()
             throws IOException, BallerinaOpenApiException {
         Path expectedPath = RES_DIR.resolve("ballerina/octet_stream_request_payload.bal");

--- a/openapi-cli/src/test/resources/generators/client/ballerina/octet_stream_request_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/octet_stream_request_payload.bal
@@ -1,0 +1,59 @@
+import ballerina/http;
+
+# refComponent
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + config - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(ConnectionConfig config =  {}, string serviceUrl = "https://petstore.swagger.io:443/v2") returns error? {
+        http:ClientConfiguration httpClientConfig = {httpVersion: config.httpVersion, timeout: config.timeout, forwarded: config.forwarded, poolConfig: config.poolConfig, compression: config.compression, circuitBreaker: config.circuitBreaker, retryConfig: config.retryConfig, validation: config.validation};
+        do {
+            if config.http1Settings is ClientHttp1Settings {
+                ClientHttp1Settings settings = check config.http1Settings.ensureType(ClientHttp1Settings);
+                httpClientConfig.http1Settings = {...settings};
+            }
+            if config.http2Settings is http:ClientHttp2Settings {
+                httpClientConfig.http2Settings = check config.http2Settings.ensureType(http:ClientHttp2Settings);
+            }
+            if config.cache is http:CacheConfig {
+                httpClientConfig.cache = check config.cache.ensureType(http:CacheConfig);
+            }
+            if config.responseLimits is http:ResponseLimitConfigs {
+                httpClientConfig.responseLimits = check config.responseLimits.ensureType(http:ResponseLimitConfigs);
+            }
+            if config.secureSocket is http:ClientSecureSocket {
+                httpClientConfig.secureSocket = check config.secureSocket.ensureType(http:ClientSecureSocket);
+            }
+            if config.proxy is http:ProxyConfig {
+                httpClientConfig.proxy = check config.proxy.ensureType(http:ProxyConfig);
+            }
+        }
+        http:Client httpEp = check new (serviceUrl, httpClientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Creates a new user.
+    #
+    # + return - OK
+    resource isolated function post user(byte[] payload) returns http:Response|error {
+        string resourcePath = string `/user`;
+        http:Request request = new;
+        request.setPayload(payload, "application/octet-stream");
+        http:Response response = check self.clientEp->post(resourcePath, request);
+        return response;
+    }
+    # Creates a new payment.
+    #
+    # + payload - Details of the pet to be purchased
+    # + return - OK
+    resource isolated function post payment(byte[] payload) returns http:Response|error {
+        string resourcePath = string `/payment`;
+        http:Request request = new;
+        request.setPayload(payload, "application/octet-stream");
+        http:Response response = check self.clientEp->post(resourcePath, request);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/swagger/octet_stream_request_payload.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/octet_stream_request_payload.yaml
@@ -1,0 +1,86 @@
+openapi: 3.0.0
+info:
+  title: refComponent
+  description: refComponent
+  version: 1.0.0
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+  - url: https://{subdomain}.swagger.io:{port}/{basePath}
+    description: The production API server
+    variables:
+      subdomain:
+        default: petstore
+        description: this value is assigned by the service provider
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '443'
+      basePath:
+        default: v2
+paths:
+  /user:
+    post:
+      summary: Creates a new user.
+      operationId: "addUser"
+      responses:
+        200:
+          description: OK
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+  /payment:
+    post:
+      operationId: "addPayment"
+      summary: Creates a new payment.
+      responses:
+        200:
+          description: OK
+      requestBody:
+        description: Details of the pet to be purchased
+        content:
+          application/octet-stream:
+            schema:
+              $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - userName
+      properties:
+        userName:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+    Pet:
+      type: object
+      required:
+        - userName
+      properties:
+        userName:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+    PetForm:
+      type: object
+      required:
+        - userName
+      properties:
+        userName:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string


### PR DESCRIPTION
## Purpose
> Fix #1188 

Old Generated code
```ballerina
# Creates a new user.
    #
    # + return - OK 
    resource isolated function post user(string payload) returns http:Response|error {
        string resourcePath = string `/user`;
        http:Request request = new;
        request.setPayload(payload, "application/octet-stream");
        http:Response response = check self.clientEp->post(resourcePath, request);
        return response;
    }
    # Creates a new payment.
    #
    # + payload - Details of the pet to be purchased 
    # + return - OK 
    resource isolated function post payment(Pet payload) returns http:Response|error {
        string resourcePath = string `/payment`;
        http:Request request = new;
        request.setPayload(payload, "application/octet-stream");
        http:Response response = check self.clientEp->post(resourcePath, request);
        return response;
    }
```
After applying the change 
```ballerina
# Creates a new user.
    #
    # + return - OK 
    resource isolated function post user(byte[] payload) returns http:Response|error {
        string resourcePath = string `/user`;
        http:Request request = new;
        request.setPayload(payload, "application/octet-stream");
        http:Response response = check self.clientEp->post(resourcePath, request);
        return response;
    }
    # Creates a new payment.
    #
    # + payload - Details of the pet to be purchased 
    # + return - OK 
    resource isolated function post payment(byte[] payload) returns http:Response|error {
        string resourcePath = string `/payment`;
        http:Request request = new;
        request.setPayload(payload, "application/octet-stream");
        http:Response response = check self.clientEp->post(resourcePath, request);
        return response;
    }
```
## Goals
> Change the request Payload type into byte[] for MediaType application/octet-stream in client generations

## Automation tests
 - Unit tests - added
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.