### PR TITLE
Bug fix in multipart/form-data mime type client generation

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/RequestBodyTests.java
@@ -288,6 +288,23 @@ public class RequestBodyTests {
         compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
     }
 
+    @Test(description = "Test for generating request body when operation has multipart form-data media type " +
+            "with invalid schema")
+    public void testRequestBodyWithMultipartMediaTypeInvalidSchema()
+            throws IOException, BallerinaOpenApiException {
+        Path expectedPath = RES_DIR.resolve("ballerina/multipart_binary.bal");
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(
+                RES_DIR.resolve("swagger/multipart_binary.yaml"), true);
+        OASClientConfig.Builder clientMetaDataBuilder = new OASClientConfig.Builder();
+        OASClientConfig oasClientConfig = clientMetaDataBuilder
+                .withFilters(filter)
+                .withOpenAPI(openAPI)
+                .withResourceMode(false).build();
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(oasClientConfig);
+        syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
+    }
+
     @Test(description = "Test for generating request body when schema is empty")
     public void testRequestBodyWithoutSchema() throws IOException, BallerinaOpenApiException {
         Path expectedPath = RES_DIR.resolve("ballerina/request_body_without_schema.bal");

--- a/openapi-cli/src/test/resources/generators/client/ballerina/multipart_binary.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/multipart_binary.bal
@@ -1,0 +1,47 @@
+import ballerina/http;
+
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + config - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(ConnectionConfig config =  {}, string serviceUrl = "http://petstore.{host}.io/v1") returns error? {
+        http:ClientConfiguration httpClientConfig = {httpVersion: config.httpVersion, timeout: config.timeout, forwarded: config.forwarded, poolConfig: config.poolConfig, compression: config.compression, circuitBreaker: config.circuitBreaker, retryConfig: config.retryConfig, validation: config.validation};
+        do {
+            if config.http1Settings is ClientHttp1Settings {
+                ClientHttp1Settings settings = check config.http1Settings.ensureType(ClientHttp1Settings);
+                httpClientConfig.http1Settings = {...settings};
+            }
+            if config.http2Settings is http:ClientHttp2Settings {
+                httpClientConfig.http2Settings = check config.http2Settings.ensureType(http:ClientHttp2Settings);
+            }
+            if config.cache is http:CacheConfig {
+                httpClientConfig.cache = check config.cache.ensureType(http:CacheConfig);
+            }
+            if config.responseLimits is http:ResponseLimitConfigs {
+                httpClientConfig.responseLimits = check config.responseLimits.ensureType(http:ResponseLimitConfigs);
+            }
+            if config.secureSocket is http:ClientSecureSocket {
+                httpClientConfig.secureSocket = check config.secureSocket.ensureType(http:ClientSecureSocket);
+            }
+            if config.proxy is http:ProxyConfig {
+                httpClientConfig.proxy = check config.proxy.ensureType(http:ProxyConfig);
+            }
+        }
+        http:Client httpEp = check new (serviceUrl, httpClientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Create a pet
+    #
+    # + request - Pet
+    # + return - Null response
+    remote isolated function createPet(http:Request request) returns http:Response|error {
+        string resourcePath = string `/pets`;
+        // TODO: Update the request as needed;
+        http:Response response = check self.clientEp->post(resourcePath, request);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/swagger/multipart_binary.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/multipart_binary.yaml
@@ -1,0 +1,24 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        description: Pet
+        content:
+          multipart/form-data:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '201':
+          description: Null response

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -137,6 +137,7 @@ import static io.ballerina.openapi.core.GeneratorConstants.IDENTIFIER;
 import static io.ballerina.openapi.core.GeneratorConstants.IMAGE_PNG;
 import static io.ballerina.openapi.core.GeneratorConstants.JSON_EXTENSION;
 import static io.ballerina.openapi.core.GeneratorConstants.LINE_SEPARATOR;
+import static io.ballerina.openapi.core.GeneratorConstants.OBJECT;
 import static io.ballerina.openapi.core.GeneratorConstants.OPEN_CURLY_BRACE;
 import static io.ballerina.openapi.core.GeneratorConstants.SERVICE_FILE_NAME;
 import static io.ballerina.openapi.core.GeneratorConstants.SLASH;
@@ -433,8 +434,12 @@ public class GeneratorUtils {
             io.swagger.v3.oas.models.media.MediaType> mediaTypeEntry) {
         String mediaType = mediaTypeEntry.getKey();
         String defaultBallerinaType = getBallerinaMediaType(mediaType, true);
-        if (defaultBallerinaType.equals(HTTP_REQUEST) &&
-                !(mediaTypeEntry.getValue().getSchema() != null && mediaType.equals(MediaType.MULTIPART_FORM_DATA))) {
+        Schema<?> schema = mediaTypeEntry.getValue().getSchema();
+
+        boolean isValidMultipartFormData = mediaType.equals(MediaType.MULTIPART_FORM_DATA) && schema != null &&
+                (schema.get$ref() != null || schema.getProperties() != null || schema.getType().equals(OBJECT));
+
+        if (defaultBallerinaType.equals(HTTP_REQUEST) && !isValidMultipartFormData) {
             return false;
         } else {
             return true;
@@ -447,7 +452,7 @@ public class GeneratorUtils {
     public static String getBallerinaMediaType(String mediaType, boolean isRequest) {
         if (mediaType.matches(".*/json") || mediaType.matches("application/.*\\+json")) {
             return SyntaxKind.JSON_KEYWORD.stringValue();
-        } else if (mediaType.matches(".*/xml")  || mediaType.matches("application/.*\\+xml")) {
+        } else if (mediaType.matches(".*/xml") || mediaType.matches("application/.*\\+xml")) {
             return SyntaxKind.XML_KEYWORD.stringValue();
         } else if (mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED) || mediaType.matches("text/.*")) {
             return STRING_KEYWORD.stringValue();

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
@@ -104,7 +104,6 @@ import static io.ballerina.openapi.core.GeneratorUtils.escapeIdentifier;
 import static io.ballerina.openapi.core.GeneratorUtils.extractReferenceType;
 import static io.ballerina.openapi.core.GeneratorUtils.getBallerinaMediaType;
 import static io.ballerina.openapi.core.GeneratorUtils.getValidName;
-import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
 
 /**
  * This util class uses for generating {@link FunctionSignatureNode} for given OAS
@@ -512,20 +511,13 @@ public class FunctionSignatureGenerator {
                     } else if (schema.getType() != null && !schema.getType().equals(ARRAY) && !schema.getType().equals(
                             OBJECT)) {
                         String typeOfPayload = schema.getType().trim();
-                        // for multipart/formdata media type schema should be an object to support entity mapping
-                        if (mediaTypeEntry.getKey().equals(MULTIPART_FORM_DATA)) {
-                            paramType = getBallerinaMediaType(mediaTypeEntry.getKey(), true);
-                        } else if (typeOfPayload.equals(STRING) && schema.getFormat() != null
+                        if (typeOfPayload.equals(STRING) && schema.getFormat() != null
                                 && (schema.getFormat().equals(BINARY) || schema.getFormat().equals(BYTE))) {
-                            if (mediaTypeEntry.getKey().equals(MULTIPART_FORM_DATA)) {
-                                paramType = getBallerinaMediaType(mediaTypeEntry.getKey(), true);
-                            } else {
-                                paramType = convertOpenAPITypeToBallerina(schema.getFormat());
-                            }
+                            paramType = convertOpenAPITypeToBallerina(schema.getFormat());
                         } else {
                             paramType = convertOpenAPITypeToBallerina(typeOfPayload);
                         }
-                    } else if (schema instanceof ArraySchema && !mediaTypeEntry.getKey().equals(MULTIPART_FORM_DATA)) {
+                    } else if (schema instanceof ArraySchema) {
                         //TODO: handle nested array - this is impossible to handle
                         ArraySchema arraySchema = (ArraySchema) schema;
                         paramType = getRequestBodyParameterForArraySchema(operationId, mediaTypeEntry, arraySchema);
@@ -559,7 +551,7 @@ public class FunctionSignatureGenerator {
                 parameterList.add(createToken((COMMA_TOKEN)));
             }
 
-            if (mediaTypeEntry.getKey().equals(MULTIPART_FORM_DATA)
+            if (mediaTypeEntry.getKey().equals(javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA)
                     && mediaTypeEntry.getValue().getEncoding() != null) {
                 List<String> headerList = new ArrayList<>();
                 for (Map.Entry<String, Encoding> entry : mediaTypeEntry.getValue().getEncoding().entrySet()) {


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/ballerina-platform/openapi-tools/issues/816

## Goals
Currently only object schemas are supported in multipart/form-data mime type in the openapi-to-client generation. This change will generate default request when any other type schema found with multipart/form-data media type.  

**Scenario 1 :** 

```yaml
      requestBody:
        description: Pet
        content:
          multipart/form-data:
            schema:
              type: string
              format: binary
```

**Generation** 

```bal
    remote isolated function createPet(http:Request request) returns http:Response|error {
        string resourcePath = string `/pets`;
        // TODO: Update the request as needed;
        http:Response response = check self.clientEp->post(resourcePath, request);
        return response;
    }
```

Scenario 2 

```yaml
      requestBody:
        description: Pet
        content:
          multipart/form-data:
            schema:
              type: integer
```

Generation is same as the scenario 1

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11