### PR TITLE
[1.3.x]Fix for OpenAPI spec generation when display annotations are used

### DIFF
--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/utils/ServiceToOpenAPIConverterUtils.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/utils/ServiceToOpenAPIConverterUtils.java
@@ -292,6 +292,10 @@ public class ServiceToOpenAPIConverterUtils {
                     } else {
                         openAPI.setInfo(new Info().version(version).title(normalizeTitle(currentServiceName)));
                     }
+                } else if (currentServiceName.equals(SLASH) || currentServiceName.isBlank()) {
+                    openAPI.setInfo(new Info().version(version).title(normalizeTitle(openapiFileName)));
+                } else {
+                    openAPI.setInfo(new Info().version(version).title(normalizeTitle(currentServiceName)));
                 }
             }
         } else if (currentServiceName.equals(SLASH) || currentServiceName.isBlank()) {

--- a/openapi-integration-tests/src/test/java/io/ballerina/openapi/cmd/BallerinaToOpenAPITests.java
+++ b/openapi-integration-tests/src/test/java/io/ballerina/openapi/cmd/BallerinaToOpenAPITests.java
@@ -125,6 +125,25 @@ public class BallerinaToOpenAPITests {
         Assert.assertFalse(Files.exists(TEST_RESOURCE.resolve("query_openapi.yaml")));
     }
 
+    @Test(description = "Service is with non openapi annotation")
+    public void nonOpenAPIAnnotation() throws IOException, InterruptedException {
+        executeCommand("project_non_openapi_annotation/service.bal", "service_openapi.yaml",
+                "project_non_openapi_annotation/result.yaml");
+    }
+
+    @Test(description = "Service is with non openapi annotation and slash as base path")
+    public void nonOpenAPIAnnotationWithSlash() throws IOException, InterruptedException {
+        executeCommand("project_non_openapi_annotation_with_base_path/service.bal", "payload_openapi.yaml",
+                "project_non_openapi_annotation_with_base_path/result.yaml");
+    }
+
+    @Test(description = "Service is with non openapi annotation and without a base path")
+    public void nonOpenAPIAnnotationWithWithoutBasePath() throws IOException, InterruptedException {
+        executeCommand("project_non_openapi_annotation_without_base_path/service_file.bal",
+                "service_file_openapi.yaml",
+                "project_non_openapi_annotation_without_base_path/result.yaml");
+    }
+
     @AfterClass
     public void cleanUp() throws IOException {
         TestUtil.cleanDistribution();

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation/Ballerina.toml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org= "ballerina"
+name= "openapi"
+version= "2.0.0"

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation/result.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.1
+info:
+  title: Service Openapi Yaml
+  version: 2.0.0
+servers:
+  - url: "{server}:{port}/"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
+paths:
+  /greeting:
+    get:
+      summary: A resource for generating greetings
+      operationId: getGreeting
+      parameters:
+        - name: name
+          in: query
+          description: the input string name
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+components: {}

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation/service.bal
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation/service.bal
@@ -1,0 +1,21 @@
+import ballerina/http;
+
+# A service representing a network-accessible API
+# bound to port `9090`.
+@display {
+	label: "SampleRest2",
+	id: "SampleRest2-a0419d61-26b8-48ad-8696-3a16c9958522"
+}
+service / on new http:Listener(9090) {
+
+    # A resource for generating greetings
+    # + name - the input string name
+    # + return - string name with hello message or error
+    resource function get greeting(string name) returns string|error {
+        // Send a response back to the caller.
+        if name is "" {
+            return error("name should not be empty!");
+        }
+        return "Hello, " + name;
+    }
+}

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_with_base_path/Ballerina.toml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_with_base_path/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org= "ballerina"
+name= "openapi"
+version= "2.0.0"

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_with_base_path/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_with_base_path/result.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.1
+info:
+  title: Payload
+  version: 2.0.0
+servers:
+  - url: "{server}:{port}/payload"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
+paths:
+  /greeting:
+    get:
+      summary: A resource for generating greetings
+      operationId: getGreeting
+      parameters:
+        - name: name
+          in: query
+          description: the input string name
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+components: {}

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_with_base_path/service.bal
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_with_base_path/service.bal
@@ -1,0 +1,21 @@
+import ballerina/http;
+
+# A service representing a network-accessible API
+# bound to port `9090`.
+@display {
+	label: "SampleRest2",
+	id: "SampleRest2-a0419d61-26b8-48ad-8696-3a16c9958522"
+}
+service /payload on new http:Listener(9090) {
+
+    # A resource for generating greetings
+    # + name - the input string name
+    # + return - string name with hello message or error
+    resource function get greeting(string name) returns string|error {
+        // Send a response back to the caller.
+        if name is "" {
+            return error("name should not be empty!");
+        }
+        return "Hello, " + name;
+    }
+}

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_without_base_path/Ballerina.toml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_without_base_path/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org= "ballerina"
+name= "openapi"
+version= "2.0.0"

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_without_base_path/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_without_base_path/result.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.1
+info:
+  title: Service File Openapi Yaml
+  version: 2.0.0
+servers:
+  - url: "{server}:{port}"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9098"
+paths:
+  /greeting:
+    get:
+      summary: A resource for generating greetings
+      operationId: getGreeting
+      parameters:
+        - name: name
+          in: query
+          description: the input string name
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+components: {}

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_without_base_path/service_file.bal
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_without_base_path/service_file.bal
@@ -1,0 +1,21 @@
+import ballerina/http;
+
+# A service representing a network-accessible API
+# bound to port `9090`.
+@display {
+	label: "SampleRest2",
+	id: "SampleRest2-a0419d61-26b8-48ad-8696-3a16c9958522"
+}
+service on new http:Listener(9098) {
+
+    # A resource for generating greetings
+    # + name - the input string name
+    # + return - string name with hello message or error
+    resource function get greeting(string name) returns string|error {
+        // Send a response back to the caller.
+        if name is "" {
+            return error("name should not be empty!");
+        }
+        return "Hello, " + name;
+    }
+}


### PR DESCRIPTION
## Purpose
> Fix #1212 

Parent PR : https://github.com/ballerina-platform/openapi-tools/pull/1213

Support the below services with non-openapi annotations
```ballerina
import ballerina/http;

# A service representing a network-accessible API
# bound to port `9090`.
@display {
	label: "SampleRest2",
	id: "SampleRest2-a0419d61-26b8-48ad-8696-3a16c9958522"
}
service /payload on new http:Listener(9090) {

    # A resource for generating greetings
    # + name - the input string name
    # + return - string name with hello message or error
    resource function get greeting(string name) returns string|error {
        // Send a response back to the caller.
        if name is "" {
            return error("name should not be empty!");
        }
        return "Hello, " + name;
    }
}
```