### PR TITLE
[1.4.x] Revamp the record generation to generate open records by default

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/PrimitiveDataTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/PrimitiveDataTypeTests.java
@@ -73,8 +73,8 @@ public class PrimitiveDataTypeTests {
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(definitionPath, true);
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
         syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
-        String expected = "public type Pet record {| #this is missing dataType anydata id; string name; decimal tag?;" +
-                " string 'type?;|};";
+        String expected = "public type Pet record { #this is missing dataType anydata id; string name; decimal tag?;" +
+                " string 'type?;};";
         Assert.assertTrue(syntaxTree.toString().trim().replaceAll("\\s+", "").
                 contains(expected.trim().replaceAll("\\s+", "")));
     }

--- a/openapi-cli/src/test/resources/expected_gen/non_constraint_import_types.bal
+++ b/openapi-cli/src/test/resources/expected_gen/non_constraint_import_types.bal
@@ -56,7 +56,7 @@ public type ProxyConfig record {|
     string password = "";
 |};
 
-public type Pet record {|
+public type Pet record {
     string name?;
     string owned_by?;
-|};
+};

--- a/openapi-cli/src/test/resources/expected_gen/nullable_false_types.bal
+++ b/openapi-cli/src/test/resources/expected_gen/nullable_false_types.bal
@@ -1,18 +1,18 @@
 public type Pets Pet[]?;
 
-public type Error record {|
+public type Error record {
     int? code;
     string? message;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean? bark = ();
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string? tag = ();
     string? 'type = ();
-|};
+};

--- a/openapi-cli/src/test/resources/expected_gen/nullable_types.bal
+++ b/openapi-cli/src/test/resources/expected_gen/nullable_types.bal
@@ -1,19 +1,19 @@
 public type Pets Pet[]?;
 
-public type Error record {|
+public type Error record {
     int? code;
     string? message;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean? bark = ();
 
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int? id;
     string? name;
     string? tag = ();
     string? 'type = ();
-|};
+};

--- a/openapi-cli/src/test/resources/expected_gen/petstore_schema.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_schema.bal
@@ -58,19 +58,19 @@ public type ProxyConfig record {|
 
 public type Pets Pet[];
 
-public type Error record {|
+public type Error record {
     int code;
     string message;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean bark?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/expected_gen/petstore_schema_type.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_schema_type.bal
@@ -58,8 +58,8 @@ public type ProxyConfig record {|
 
 public type PetArr Pet[];
 
-public type Pet record {|
+public type Pet record {
     int petId;
     string name;
     string petType?;
-|};
+};

--- a/openapi-cli/src/test/resources/expected_gen/petstore_schema_with_license.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_schema_with_license.bal
@@ -60,19 +60,19 @@ public type ProxyConfig record {|
 
 public type Pets Pet[];
 
-public type Error record {|
+public type Error record {
     int code;
     string message;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean bark?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/expected_gen/petstore_wildcard_types.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_wildcard_types.bal
@@ -7,19 +7,19 @@ public type OkAnydata record {|
 
 public type Pets Pet[];
 
-public type Error record {|
+public type Error record {
     int code;
     string message;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean bark?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/expected_gen/type_filtered_by_tags.bal
+++ b/openapi-cli/src/test/resources/expected_gen/type_filtered_by_tags.bal
@@ -1,13 +1,13 @@
 public type Pets Pet[];
 
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean bark?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_composed_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_composed_schema.bal
@@ -19,7 +19,7 @@ public type User07 record {|
     *Pet;
     string? name = ();
     int? id = ();
-    record {|string? country = (); string? state = ();|}?...;
+    record {string? country = (); string? state = ();}?...;
 |};
 
 # Reference has additional properties.
@@ -46,11 +46,11 @@ public type Pet02 record {|
 |};
 
 # Without any additional field it maps to closed record.
-public type User01 record {|
+public type User01 record {
     *Pet;
     string? name = ();
     int? id = ();
-|};
+};
 
 # Additional properties with `true` enable
 public type User02 record {
@@ -60,10 +60,10 @@ public type User02 record {
 };
 
 # Mock record
-public type Pet record {|
+public type Pet record {
     string? name = ();
     int? age = ();
-|};
+};
 
 # Additional properties with {}
 public type User03 record {

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_true.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_true.bal
@@ -27,16 +27,16 @@ public type User07 record {|
 |};
 
 # Mock record
-public type User record {|
+public type User record {
     string? name = ();
     int? age = ();
-|};
+};
 
 # Additional properties with object with property fields
 public type User08 record {|
     string? name = ();
     int? id = ();
-    record {|string? country = (); string? state = ();|}?...;
+    record {string? country = (); string? state = ();}?...;
 |};
 
 # Additional properties with object with additional fields
@@ -83,16 +83,16 @@ public type User13 record {
 };
 
 # Without additional properties
-public type User03 record {|
+public type User03 record {
     string? name = ();
     int? id = ();
-|};
+};
 
 # Additional properties with object with additional fields type with inline object
 public type User14 record {|
     string? name = ();
     int? id = ();
-    record {|record {|string? name = (); string? place = ();|}?...;|}?...;
+    record {|record {string? name = (); string? place = ();}?...;|}?...;
 |};
 
 # Additional properties with type string

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/allOf.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/allOf.bal
@@ -1,23 +1,23 @@
-public type Activities record {|
+public type Activities record {
     # Position in pagination.
     int offset?;
     Activity[] history?;
-|};
+};
 
-public type Activity record {|
+public type Activity record {
     # Unique identifier for the activity
     string uuid?;
-|};
+};
 
-public type Profile record {|
+public type Profile record {
     # First name of the Uber user.
     string first_name?;
     # Last name of the Uber user.
     string last_name?;
-|};
+};
 
-public type Subject record {|
+public type Subject record {
     int id?;
     string name?;
-    record {|*Activity; *Profile;|} subject_type?;
-|};
+    record {*Activity; *Profile;} subject_type?;
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/allOfWithEmptyObject.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/allOfWithEmptyObject.bal
@@ -1,10 +1,10 @@
 public type Pets Pet[];
 
-public type Error record {|
+public type Error record {
     int code;
     string message;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     string[] entries?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/allOfWithNoType.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/allOfWithNoType.bal
@@ -1,14 +1,14 @@
 public type Pets Pet[];
 
-public type Error record {|
+public type Error record {
     int code;
     string message;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id?;
     string name?;
     string tag?;
     string 'type?;
     string[] entries?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/allOf_with_cyclic.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/allOf_with_cyclic.bal
@@ -1,10 +1,10 @@
-public type Activity record {|
+public type Activity record {
     # Unique identifier for the activity
     string uuid?;
-|};
+};
 
-public type Subject record {|
+public type Subject record {
     int id?;
     string name?;
     Subject subject_type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/allOf_with_one_ref.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/allOf_with_one_ref.bal
@@ -1,10 +1,10 @@
-public type Activity record {|
+public type Activity record {
     # Unique identifier for the activity
     string uuid?;
-|};
+};
 
-public type Subject record {|
+public type Subject record {
     int id?;
     string name?;
     Activity subject_type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/array_max_item.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/array_max_item.bal
@@ -1,11 +1,11 @@
 import ballerina/constraint;
 
-public type Address record {|
+public type Address record {
     int streetNo?;
     @constraint:Array {maxLength: 2}
     string[] mainStreet?;
     string country?;
-|};
+};
 
 @constraint:Array {maxLength: 7}
 public type UserAddress int[];

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/array_no_item_type.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/array_no_item_type.bal
@@ -1,8 +1,8 @@
-public type Address record {|
+public type Address record {
     int streetNo?;
     anydata[] street?;
     string country?;
-|};
+};
 
 public type UserAddress anydata[];
 

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/array_with_allOf.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/array_with_allOf.bal
@@ -1,9 +1,9 @@
-public type GetActivitiesResponse200 record {|
+public type GetActivitiesResponse200 record {
     boolean success?;
-    record {| *ActivityResponseObject; *EmployeeDetails; |}[] data?;
-|};
+    record { *ActivityResponseObject; *EmployeeDetails; }[] data?;
+};
 
-public type ActivityResponseObject record {|
+public type ActivityResponseObject record {
     # Due date of the Activity. Format: YYYY-MM-DD
     string due_date?;
     # Due time of the Activity in UTC. Format: HH:MM
@@ -12,11 +12,11 @@ public type ActivityResponseObject record {|
     string duration?;
     # The ID of the Deal this Activity is associated with
     int deal_id?;
-|};
+};
 
-public type EmployeeDetails record {|
+public type EmployeeDetails record {
     # Employee ID
     string employee_id?;
     # Employee Name
     string employee_name?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/array_with_inline_allOf.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/array_with_inline_allOf.bal
@@ -1,6 +1,6 @@
 # List of addresses
-public type Owner record {|
-    record {|
+public type Owner record {
+    record {
         # Street No
         string streetNo?;
         # House number
@@ -12,11 +12,11 @@ public type Owner record {|
         # Zip code
         int zipCode?;
         *NameData;
-    |}[] AdressList?;
+    }[] AdressList?;
     string[] Pets?;
-|};
+};
 
-public type NameData record {|
+public type NameData record {
     string FirstName?;
     string LastName?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/array_with_oneOf.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/array_with_oneOf.bal
@@ -1,9 +1,9 @@
-public type GetActivitiesResponse200 record {|
+public type GetActivitiesResponse200 record {
     boolean success?;
     (ActivityResponseObject|EmployeeDetails)[] data?;
-|};
+};
 
-public type ActivityResponseObject record {|
+public type ActivityResponseObject record {
     # Due date of the Activity. Format: YYYY-MM-DD
     string due_date?;
     # Due time of the Activity in UTC. Format: HH:MM
@@ -12,11 +12,11 @@ public type ActivityResponseObject record {|
     string duration?;
     # The ID of the Deal this Activity is associated with
     int deal_id?;
-|};
+};
 
-public type EmployeeDetails record {|
+public type EmployeeDetails record {
     # Employee ID
     string employee_id?;
     # Employee Name
     string employee_name?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/array_with_oneOf_complex.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/array_with_oneOf_complex.bal
@@ -1,6 +1,6 @@
 public type WorldBankResponse (PaginationData|Indicator[]?)[];
 
-public type PaginationData record {|
+public type PaginationData record {
     int page;
     int pages;
     int per_page;
@@ -8,12 +8,12 @@ public type PaginationData record {|
     string? sourceid;
     string? sourcename;
     string? lastupdated;
-|};
+};
 
 # Data indicator
-public type Indicator record {|
+public type Indicator record {
     # Id of the indicator
     string id;
     # Value represent by the indicator
     string value;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/array.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/array.bal
@@ -15,7 +15,7 @@ public type PersonLimitItemsInteger int;
 @constraint:Array {maxLength: 5, minLength: 2}
 public type Hobby HobbyItemsString[];
 
-public type Person record {|
+public type Person record {
     Hobby hobby?;
     @constraint:Array {maxLength: 5}
     PersonDetailsItemsString[] Details?;
@@ -23,4 +23,4 @@ public type Person record {|
     PersonFeeItemsNumber[] fee?;
     # The maximum number of items in the response (as set in the query or by default).
     PersonLimitItemsInteger[] 'limit?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/nested_array.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/nested_array.bal
@@ -15,22 +15,22 @@ public type Nestedarray02examplesitemsarrayItemsString string;
 public type NoconstraintExamplesItemsArray int[];
 
 # Every array items has constraint validation
-public type NestedArray record {|
+public type NestedArray record {
     string name?;
     @constraint:Array {maxLength: 200, minLength: 2}
     NestedarrayExamplesItemsArray[] examples?;
-|};
+};
 
 # Some array items have constraint
-public type NestedArray02 record {|
+public type NestedArray02 record {
     string name?;
     @constraint:Array {maxLength: 200, minLength: 2}
     Nestedarray02ExamplesItemsArray[] examples?;
-|};
+};
 
 # Last array item hasn't constraint values
-public type NoConstraint record {|
+public type NoConstraint record {
     string name?;
     @constraint:Array {maxLength: 200, minLength: 2}
     NoconstraintExamplesItemsArray[] examples?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/record_field.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/record_field.bal
@@ -3,7 +3,7 @@ import ballerina/constraint;
 @constraint:String {minLength: 5}
 public type Address string;
 
-public type Person record {|
+public type Person record {
     @constraint:String {maxLength: 14}
     string name?;
     @constraint:Array {maxLength: 5, minLength: 2}
@@ -15,4 +15,4 @@ public type Person record {|
     float salary?;
     @constraint:Number {minValue: 500000}
     decimal net?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/record_field_02.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/record_field_02.bal
@@ -12,7 +12,7 @@ public type TaxratesanyofarrayItemsNull int|string;
 
 public type Address string;
 
-public type Person record {|
+public type Person record {
     @constraint:String {maxLength: 14}
     string name?;
     @constraint:Array {maxLength: 5}
@@ -34,4 +34,4 @@ public type Person record {|
     (string|int)[]|string tax_rates_oneOF_array?;
     # scenario 04 - field with a anyOf type array items has anyOf.
     (int|string)[]|int tax_rates_anyOf_array?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/type_def_node.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/type_def_node.bal
@@ -3,14 +3,14 @@ import ballerina/constraint;
 @constraint:String {minLength: 5}
 public type Address string;
 
-public type Book record {|
+public type Book record {
     @constraint:String {maxLength: 67}
     string name?;
     @constraint:Number {maxValue: 89.0}
     decimal price?;
-|};
+};
 
-public type Person record {|
+public type Person record {
     @constraint:String {maxLength: 14}
     string name?;
     @constraint:Array {maxLength: 5, minLength: 2}
@@ -23,4 +23,4 @@ public type Person record {|
     @constraint:Number {minValue: 500000}
     decimal net?;
     Book fav?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/default_optional_array_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/default_optional_array_schema.bal
@@ -1,6 +1,6 @@
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string[] tagArray = ["available", "busy"];
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/default_optional_primitive_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/default_optional_primitive_schema.bal
@@ -1,6 +1,6 @@
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     int tagNumber = 10;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/default_optional_schema_with_doublequote.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/default_optional_schema_with_doublequote.bal
@@ -1,6 +1,6 @@
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string textQualifier = "\"";
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/default_optional_string_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/default_optional_string_schema.bal
@@ -1,6 +1,6 @@
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tagName = "TagName";
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/default_required_field_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/default_required_field_schema.bal
@@ -1,5 +1,5 @@
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/deprecated_schemas.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/deprecated_schemas.bal
@@ -2,30 +2,30 @@
 public type Pets Pet[];
 
 @deprecated
-public type Owner record {|
+public type Owner record {
     string Name?;
     string Address?;
-|};
+};
 
-public type Error record {|
+public type Error record {
     int code;
     string message;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean bark?;
     *Owner;
-|};
+};
 
 # Pet Object
 #
 # # Deprecated
 # Pet object is deprecated from version 2
 @deprecated
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/empty_record.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/empty_record.bal
@@ -1,9 +1,9 @@
 public type Dog record {
 };
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nested_all_of.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nested_all_of.bal
@@ -1,7 +1,7 @@
-public type Address record {|
+public type Address record {
     string streetNo?;
     string houseNo?;
     string streatName?;
     string country?;
     int zipCode?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nested_oneOf_with_allOf.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nested_oneOf_with_allOf.bal
@@ -1,4 +1,4 @@
-public type Address record {|
+public type Address record {
     # Street No
     string streetNo?;
     # House number
@@ -7,7 +7,7 @@ public type Address record {|
     string streatName?;
     # Countri Name
     string country?;
-|}|record {|
+}|record {
     # Zip code
     int zipCode?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nested_schema_refs.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nested_schema_refs.bal
@@ -1,4 +1,4 @@
-public type ProjectStatusBase record {|
+public type ProjectStatusBase record {
     *ProjectStatusCompact;
     UserCompact author?;
     # The time at which this project status was last modified.
@@ -8,30 +8,30 @@ public type ProjectStatusBase record {|
     string html_text?;
     # The color associated with the status update.
     string color;
-|};
+};
 
 public type ProjectStatusRequest ProjectStatusBase;
 
-public type UserCompact record {|
+public type UserCompact record {
     *AsanaResource;
     # Read-only except when same user as requester.
     string name?;
-|};
+};
 
-public type Project_gid_project_statuses_body record {|
+public type Project_gid_project_statuses_body record {
     ProjectStatusRequest data?;
-|};
+};
 
 # A generic Asana Resource, containing a globally unique identifier.
-public type AsanaResource record {|
+public type AsanaResource record {
     # Globally unique identifier of the resource, as a string.
     string gid?;
     # The base type of this resource.
     string resource_type?;
-|};
+};
 
-public type ProjectStatusCompact record {|
+public type ProjectStatusCompact record {
     *AsanaResource;
     # The title of the project status update.
     string title?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/null_empty_record.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/null_empty_record.bal
@@ -1,7 +1,7 @@
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
     record {}? details = ();
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_anyof_array_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_anyof_array_schema.bal
@@ -1,13 +1,13 @@
 import ballerina/constraint;
 
-public type Customers_customer_body record {|
+public type Customers_customer_body record {
     # The customer's address.
     Customer_address|string? address = ();
     # An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
     int balance?;
-|};
+};
 
-public type Customer_address record {|
+public type Customer_address record {
     @constraint:String {maxLength: 5000}
     string city?;
     @constraint:String {maxLength: 5000}
@@ -20,10 +20,10 @@ public type Customer_address record {|
     string postal_code?;
     @constraint:String {maxLength: 5000}
     string state?;
-|};
+};
 
-public type Customer record {|
+public type Customer record {
     # The customer's address.
     Customer_address[]|string? address = ();
     string name?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_anyof_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_anyof_schema.bal
@@ -1,13 +1,13 @@
 import ballerina/constraint;
 
-public type Customers_customer_body record {|
+public type Customers_customer_body record {
     # The customer's address.
     Customer_address|string? address = ();
     # An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
     int balance?;
-|};
+};
 
-public type Customer_address record {|
+public type Customer_address record {
     @constraint:String {maxLength: 5000}
     string city?;
     @constraint:String {maxLength: 5000}
@@ -20,10 +20,10 @@ public type Customer_address record {|
     string postal_code?;
     @constraint:String {maxLength: 5000}
     string state?;
-|};
+};
 
-public type Customer record {|
+public type Customer record {
     # The customer's address.
     Customer_address? address = ();
     string name?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_array.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_array.bal
@@ -1,7 +1,7 @@
 public type ListObject record {
 };
 
-public type UserPlayListDetails record {|
+public type UserPlayListDetails record {
     # A link to the Web API endpoint returning the full result of the request
     string href?;
     # The requested data.
@@ -15,4 +15,4 @@ public type UserPlayListDetails record {|
     # URL to the previous page of items. ( `null` if none) //anydata
     anydata[]? previous = ();
     ListObject total?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_false.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_false.bal
@@ -1,7 +1,7 @@
 public type ListObject record {
 };
 
-public type UserPlayListDetails record {|
+public type UserPlayListDetails record {
     # A link to the Web API endpoint returning the full result of the request
     string? href= ();
     # The requested data.
@@ -15,4 +15,4 @@ public type UserPlayListDetails record {|
     # URL to the previous page of items. ( `null` if none) //anydata
     anydata previous?;
     ListObject total?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_array_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_array_schema.bal
@@ -1,7 +1,7 @@
 public type ListObject record {
 };
 
-public type UserPlayListDetails record {|
+public type UserPlayListDetails record {
     # A link to the Web API endpoint returning the full result of the request
     string? href = ();
     # The requested data.
@@ -15,4 +15,4 @@ public type UserPlayListDetails record {|
     # URL to the previous page of items. ( `null` if none) //anydata
     anydata[]? previous = ();
     ListObject? total = ();
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_primitive_fields.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_primitive_fields.bal
@@ -1,7 +1,7 @@
 public type ListObject record {
 };
 
-public type UserPlayListDetails record {|
+public type UserPlayListDetails record {
     # A link to the Web API endpoint returning the full result of the request
     string? href= ();
     # The requested data.
@@ -15,4 +15,4 @@ public type UserPlayListDetails record {|
     # URL to the previous page of items. ( `null` if none) //anydata
     anydata? previous = ();
     ListObject? total = ();
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_record_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_option_record_schema.bal
@@ -1,7 +1,7 @@
 public type ListObject record {
 };
 
-public type UserPlayListDetails record {|
+public type UserPlayListDetails record {
     # A link to the Web API endpoint returning the full result of the request
     string? href = ();
     # The requested data.
@@ -15,4 +15,4 @@ public type UserPlayListDetails record {|
     # URL to the previous page of items. ( `null` if none) //anydata
     anydata? previous = ();
     ListObject? total = ();
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_primitive.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_primitive.bal
@@ -1,7 +1,7 @@
 public type ListObject record {
 };
 
-public type UserPlayListDetails record {|
+public type UserPlayListDetails record {
     # A link to the Web API endpoint returning the full result of the request
     string href?;
     # The requested data.
@@ -15,4 +15,4 @@ public type UserPlayListDetails record {|
     # URL to the previous page of items. ( `null` if none) //anydata
     anydata? previous = ();
     ListObject total?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_record.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_record.bal
@@ -1,7 +1,7 @@
 public type ListObject record {
 };
 
-public type UserPlayListDetails record {|
+public type UserPlayListDetails record {
     # A link to the Web API endpoint returning the full result of the request
     string href?;
     # The requested data.
@@ -15,4 +15,4 @@ public type UserPlayListDetails record {|
     # URL to the previous page of items. ( `null` if none) //anydata
     anydata? previous = ();
     ListObject? total = ();
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_ref_array.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/nullable_ref_array.bal
@@ -1,18 +1,18 @@
 public type Pets Pet[]?;
 
-public type Error record {|
+public type Error record {
     int code;
     string message;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean bark?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/object_without_fields_reference.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/object_without_fields_reference.bal
@@ -1,16 +1,16 @@
-public type YouthLiteracyRate record {|
+public type YouthLiteracyRate record {
     record {} indicator?;
     Country country?;
     string date?;
     int value?;
     int 'decimal?;
-|};
+};
 
-public type Country record {|
+public type Country record {
     string id?;
     string value?;
-|};
+};
 
-public type Error record {|
+public type Error record {
     string name?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/oneOf.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/oneOf.bal
@@ -1,25 +1,25 @@
-public type Activities record {|
+public type Activities record {
     # Position in pagination.
     int offset?;
     Activity[] history?;
-|};
+};
 
-public type Activity record {|
+public type Activity record {
     # Unique identifier for the activity
     string uuid?;
-|};
+};
 
 public type Error Activity|Profile01;
 
-public type Profile01 record {|
+public type Profile01 record {
     # First name of the Uber user.
     string first_name?;
     # Last name of the Uber user.
     string last_name?;
-|};
+};
 
-public type Subject record {|
+public type Subject record {
     int id?;
     string name?;
     Activity|Profile01 subject_type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/oneOf_with_inline_schemas.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/oneOf_with_inline_schemas.bal
@@ -1,19 +1,19 @@
-public type Address record {|
+public type Address record {
     # Street Number
     string streetNo?;
     # House Number
     string houseNo?;
-|}|record {|
+}|record {
     # Street Name
     string streatName?;
     # Country Name
     string country?;
-|}|record {|
+}|record {
     # Zipcode
     int zipCode?;
-|}|record {}|CountryDetails;
+}|record {}|CountryDetails;
 
-public type CountryDetails record {|
+public type CountryDetails record {
     string iso_code?;
     string name?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/openapi.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/openapi.bal
@@ -1,18 +1,18 @@
-public type VaccineCountryCoverage record {|
+public type VaccineCountryCoverage record {
     string country?;
     # One of
     SimpleVaccineTimeline|FullVaccineTimeline timeline?;
-|};
+};
 
 # Covid-19 Vaccine timeline briefly
-public type SimpleVaccineTimeline record {|
+public type SimpleVaccineTimeline record {
     decimal date?;
-|};
+};
 
 # Descriptive Covid-19 vaccine timeline
 #
 # + fullvaccinetimelinelist - Descriptive Covid-19 vaccine timeline
-public type FullVaccineTimeline record {|
+public type FullVaccineTimeline record {
     record  {| decimal total?; decimal daily?; decimal totalPerHundred?; decimal dailyPerMillion?; string date?;|} []
     fullvaccinetimelinelist;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/openapi_weather_api_schema.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/openapi_weather_api_schema.bal
@@ -1,5 +1,5 @@
 # Successful response
-public type CurrentWeatherDataResponse record {|
+public type CurrentWeatherDataResponse record {
     # coord
     Coord coord?;
     # (more info Weather condition codes)
@@ -28,4 +28,4 @@ public type CurrentWeatherDataResponse record {|
     string name?;
     # Internal parameter
     int cod?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/recordName.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/recordName.bal
@@ -1,5 +1,5 @@
-public type Pet_details record {|
+public type Pet_details record {
     int id;
     string name;
     string[][][]tag?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/referred_inclusion.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/referred_inclusion.bal
@@ -8,19 +8,19 @@ public type TestDog Dog;
 
 public type ReferredSimpleType SimpleType;
 
-public type Error record {|
+public type Error record {
     int code;
     string message;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean bark?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/resolve_reference_docs.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/resolve_reference_docs.bal
@@ -1,18 +1,18 @@
-public type Pets record {|
+public type Pets record {
     Pet[] pet_details?;
     int numer_of_pets?;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     # Pet details
     Pet pet_details?;
     boolean bark?;
-|};
+};
 
 # Pet details
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema01.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema01.bal
@@ -1,5 +1,5 @@
 # Test description
-public type Pet record {|
+public type Pet record {
     # tests
     int id;
     # tests
@@ -8,4 +8,4 @@ public type Pet record {|
     decimal tag?;
     # tests
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema02.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema02.bal
@@ -1,11 +1,11 @@
-public type Error record {|
+public type Error record {
     int code;
     string message;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema03.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema03.bal
@@ -1,6 +1,6 @@
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string[] tag?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema04.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema04.bal
@@ -1,6 +1,6 @@
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string[][][] tag?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema05.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema05.bal
@@ -1,12 +1,12 @@
-public type Dog record {|
+public type Dog record {
     # Pet details
     Pet pets?;
     boolean bark;
-|};
+};
 
 # Pet details
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema06.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema06.bal
@@ -1,11 +1,11 @@
-public type Dog record {|
+public type Dog record {
     # Pet array
     Pet[] pets?;
     boolean bark;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema07.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema07.bal
@@ -1,17 +1,17 @@
 
-public type Tag record {|
+public type Tag record {
     int id?;
     string tagType?;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     Pet[] pets?;
     boolean bark;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     Tag 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema08.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema08.bal
@@ -1,8 +1,8 @@
 public type Pets Pet[];
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema09.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema09.bal
@@ -1,11 +1,11 @@
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean bark?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema10.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema10.bal
@@ -1,3 +1,3 @@
-public type Pets record {|
+public type Pets record {
      anydata pet_type;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema11.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema11.bal
@@ -1,13 +1,13 @@
-public type Pet_type record {|
+public type Pet_type record {
     # type id
     string typeId?;
     string tagType?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     # name field
     string name;
     string tag?;
     Pet_type 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema14.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema14.bal
@@ -1,7 +1,7 @@
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
-    record {| string id?; string tagType?;|} 'type?;
-|};
+    record { string id?; string tagType?;} 'type?;
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema15.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema15.bal
@@ -6,25 +6,25 @@ public type TaxratesItemsString string;
 @constraint:String {maxLength: 5000}
 public type SubscriptiondefaulttaxratesItemsString string;
 
-public type Activities record {|
+public type Activities record {
     # Position in pagination.
     int offset?;
     Activity[] history?;
-|};
+};
 
-public type User record {|
+public type User record {
     # First name of the Uber user.
     string first_name?;
     # Last name of the Uber user.
     string last_name?;
     TaxratesItemsString[]|string tax_rates?;
-|};
+};
 
 public type AnyOF User|Activity;
 
-public type Activity record {|
+public type Activity record {
     # Unique identifier for the activity
     string uuid?;
-|};
+};
 
 public type Subscription_default_tax_rates SubscriptiondefaulttaxratesItemsString[]|string;

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema_with_array.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema_with_array.bal
@@ -1,8 +1,8 @@
-public type Address record {|
+public type Address record {
     int streetNo?;
     string mainStreet?;
     string country?;
-|};
+};
 
 public type UserAddress Address[];
 

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema_with_nested_array.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema_with_nested_array.bal
@@ -1,8 +1,8 @@
-public type Address record {|
+public type Address record {
     int streetNo?;
     string mainStreet?;
     string country?;
-|};
+};
 
 public type UserAddress Address[][][];
 

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema_with_request_body_ref.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema_with_request_body_ref.bal
@@ -1,23 +1,23 @@
-public type CreatedPet record {|
+public type CreatedPet record {
     string petId?;
     string createdDate?;
-|};
+};
 
 public type Pets Pet[];
 
-public type Error record {|
+public type Error record {
     int code;
     string message;
-|};
+};
 
-public type Dog record {|
+public type Dog record {
     *Pet;
     boolean bark?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     int id;
     string name;
     string tag?;
     string 'type?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/world_bank.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/world_bank.bal
@@ -1,53 +1,53 @@
-public type PrimaryEducationExpenditure record {|
+public type PrimaryEducationExpenditure record {
     Indicator indicator?;
     Country country?;
     string date?;
     int value?;
     int 'decimal?;
-|};
+};
 
-public type YouthLiteracyRate record {|
+public type YouthLiteracyRate record {
     Indicator indicator?;
     Country country?;
     string date?;
     int value?;
     int 'decimal?;
-|};
+};
 
-public type AccessToElectricity record {|
+public type AccessToElectricity record {
     Indicator indicator?;
     Country country?;
     string date?;
     int value?;
     int 'decimal?;
-|};
+};
 
-public type GrossDomesticProduct record {|
+public type GrossDomesticProduct record {
     Indicator indicator?;
     Country country?;
     string date?;
     int value?;
     int 'decimal?;
-|};
+};
 
-public type Country record {|
+public type Country record {
     string id?;
     string value?;
-|};
+};
 
-public type Error record {|
+public type Error record {
     string name?;
-|};
+};
 
-public type CountryPolutation record {|
+public type CountryPolutation record {
     Indicator indicator?;
     Country country?;
     string date?;
     int value?;
     int 'decimal?;
-|};
+};
 
-public type Indicator record {|
+public type Indicator record {
     string id?;
     string value?;
-|};
+};

--- a/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_request_body_types.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/requestBody/oneof_request_body_types.bal
@@ -4,15 +4,15 @@ public type Pet_body_1 Dog|Bird;
 
 public type Pet04_body string|int|decimal;
 
-public type Bird record {|
+public type Bird record {
     string name?;
     boolean isFly?;
-|};
+};
 
-public type Cat record {|
+public type Cat record {
     string name?;
     string kind?;
-|};
+};
 
 public type Pet02_body_1 Dog|Cat;
 
@@ -20,7 +20,7 @@ public type Pet_name_body (string|int|decimal)[];
 
 public type Pet_body Dog|Cat;
 
-public type Dog record {|
+public type Dog record {
     string name?;
     string age?;
-|};
+};

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
@@ -58,7 +58,6 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_BRACE_PIPE_TOKEN
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_BRACE_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.RECORD_KEYWORD;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
-import static io.ballerina.openapi.core.GeneratorConstants.OBJECT;
 
 /**
  * Generate TypeDefinitionNode and TypeDescriptorNode for object type schema.
@@ -142,41 +141,37 @@ public class RecordTypeGenerator extends TypeGenerator {
      * @throws BallerinaOpenApiException throws when process has some failure.
      */
     public RecordMetadata getRecordMetadata() throws BallerinaOpenApiException {
-        boolean isOpenRecord = false;
+        boolean isOpenRecord = true;
         RecordRestDescriptorNode recordRestDescNode = null;
 
         if (schema.getAdditionalProperties() != null) {
             Object additionalProperties = schema.getAdditionalProperties();
-            if (additionalProperties.equals(true)) {
-                isOpenRecord = true;
-            } else if (additionalProperties instanceof Schema) {
+            if (additionalProperties instanceof Schema) {
                 Schema<?> additionalPropSchema = (Schema<?>) additionalProperties;
                 if (GeneratorUtils.hasConstraints(additionalPropSchema)) {
                     // use printStream to echo the error, because current openapi to ballerina implementation doesn't
                     // handle diagnostic message.
+                    isOpenRecord = false;
                     OUT_STREAM.println("WARNING: constraints in the OpenAPI contract will be ignored for the " +
                             "additionalProperties field, as constraints are not supported on Ballerina rest record " +
                             "field.");
                 }
                 if (additionalPropSchema.get$ref() != null) {
+                    isOpenRecord = false;
                     recordRestDescNode = getRestDescriptorNodeForReference(additionalPropSchema);
                 } else if (additionalPropSchema.getType() != null) {
+                    isOpenRecord = false;
                     recordRestDescNode = getRecordRestDescriptorNode(additionalPropSchema);
                 } else if (additionalPropSchema instanceof ComposedSchema) {
-                    isOpenRecord = true;
                     OUT_STREAM.println("WARNING: generating Ballerina rest record field will be ignored for the " +
                             "OpenAPI contract additionalProperties type `ComposedSchema`, as it is not supported on " +
                             "Ballerina rest record field.");
-                } else {
-                    isOpenRecord = true;
                 }
+            } else if (additionalProperties.equals(false)) {
+                isOpenRecord = false;
             }
-        } else if (schema.getType() != null && schema.getType().equals(OBJECT) && schema.getProperties() == null &&
-                schema.getAdditionalProperties() == null) {
-            // this above condition is to check the free-form object [ex: type:object without any fields or
-            // additional fields], that object should be mapped to the open record.
-            isOpenRecord = true;
         }
+
         return new RecordMetadata.Builder()
                         .withIsOpenRecord(isOpenRecord)
                         .withRestDescriptorNode(recordRestDescNode).build();

--- a/openapi-integration-tests/src/test/resources/schema/array.bal
+++ b/openapi-integration-tests/src/test/resources/schema/array.bal
@@ -56,7 +56,7 @@ public type ProxyConfig record {|
     string password = "";
 |};
 
-public type User record {|
+public type User record {
     string? id = ();
     string[]? address = ();
-|};
+};

--- a/openapi-integration-tests/src/test/resources/schema/union.bal
+++ b/openapi-integration-tests/src/test/resources/schema/union.bal
@@ -67,7 +67,7 @@ public type TaxratesoneofarrayItemsNull string|int;
 
 public type TaxratesanyofarrayItemsNull int|string;
 
-public type Person record {|
+public type Person record {
     # scenario 01 - field with nullable.
     string? service_class;
     # scenario 02 - field with oneOf type.
@@ -78,4 +78,4 @@ public type Person record {|
     (string|int)[]|string tax_rates_oneOF_array?;
     # scenario 04 - field with a anyOf type array items has anyOf.
     (int|string)[]|int tax_rates_anyOf_array?;
-|};
+};

--- a/openapi-integration-tests/src/test/resources/service/return/ballerina/content_schema_has_one_of_type.bal
+++ b/openapi-integration-tests/src/test/resources/service/return/ballerina/content_schema_has_one_of_type.bal
@@ -1,19 +1,19 @@
-public type User record {|
+public type User record {
     string userName;
     string firstName?;
     string lastName?;
-|};
+};
 
-public type PetForm record {|
+public type PetForm record {
     string userName;
     string firstName?;
     string lastName?;
-|};
+};
 
 public type Inline_response_200 User|Pet|PetForm;
 
-public type Pet record {|
+public type Pet record {
     string userName;
     string firstName?;
     string lastName?;
-|};
+};

--- a/openapi-integration-tests/src/test/resources/service/return/ballerina/multiple_mediatype_for_one_response_code.bal
+++ b/openapi-integration-tests/src/test/resources/service/return/ballerina/multiple_mediatype_for_one_response_code.bal
@@ -5,20 +5,20 @@ public type BadRequestUserXmlString record {|
     User|xml|string body;
 |};
 
-public type User record {|
+public type User record {
     string userName;
     string firstName?;
     string lastName?;
-|};
+};
 
-public type PetForm record {|
+public type PetForm record {
     string userName;
     string firstName?;
     string lastName?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     string userName;
     string firstName?;
     string lastName?;
-|};
+};

--- a/openapi-integration-tests/src/test/resources/service/return/ballerina/response_has_inline_additional_properties.bal
+++ b/openapi-integration-tests/src/test/resources/service/return/ballerina/response_has_inline_additional_properties.bal
@@ -1,11 +1,9 @@
-import ballerina/http;
-
 public type Response record {|
     Inline_response_map200...;
 |};
 
 public type StoreInventory03Response record {|
-    record {|record {|string name?; string place?;|}...;|}...;
+    record {|record {string name?; string place?;}...;|}...;
 |};
 
 public type BadRequestStoreInventory05Response record {|
@@ -21,15 +19,15 @@ public type StoreInventory04Response record {|
     User...;
 |};
 
-public type User record {|
+public type User record {
     string name?;
     int id?;
-|};
+};
 
-public type Inline_response_map200 record {|
+public type Inline_response_map200 record {
     int id?;
     int age?;
-|};
+};
 
 public type Inline_response_200 record {|
     string name?;

--- a/openapi-integration-tests/src/test/resources/service/return/ballerina/response_has_inline_record.bal
+++ b/openapi-integration-tests/src/test/resources/service/return/ballerina/response_has_inline_record.bal
@@ -5,27 +5,27 @@ public type BadRequestInline_response_400 record {|
     Inline_response_400 body;
 |};
 
-public type User record {|
+public type User record {
     string userName;
     string firstName?;
     string lastName?;
-|};
+};
 
-public type PetForm record {|
+public type PetForm record {
     string userName;
     string firstName?;
     string lastName?;
-|};
+};
 
-public type Inline_response_400 record {|
+public type Inline_response_400 record {
     # The error ID.
     int id?;
     # The error name.
     string errorType?;
-|};
+};
 
-public type Pet record {|
+public type Pet record {
     string userName;
     string firstName?;
     string lastName?;
-|};
+};


### PR DESCRIPTION
## Purpose
> $subject
Resolves https://github.com/ballerina-platform/openapi-tools/issues/1232

## Goals

**Sample schema**

```bal
    Pet:
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
        type:
          type: string
```

**Current generation**

```bal
public type Pet record {|
    int id;
    string name;
    string tag?;
    string 'type?;
|};
```

**Proposed generation**

```bal
public type Pet record {
    int id;
    string name;
    string tag?;
    string 'type?;
};
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? Yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.