### PR TITLE
[master]Add a fix for changing `'version` into `version` to align with Ballerina Lang changes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ group=io.ballerina
 version=1.4.1-SNAPSHOT
 
 #dependency
-ballerinaLangVersion=2201.4.0
+ballerinaLangVersion=2201.5.0-20230319-021600-0c2656a8
 testngVersion=7.4.0
 slf4jVersion=1.7.30
 org.gradle.jvmargs=-Xmx4096M

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_param_duplicated_name.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_param_duplicated_name.bal
@@ -35,11 +35,11 @@ public isolated client class Client {
         return;
     }
     #
-    # + 'version - Version Id
+    # + version - Version Id
     # + versionName - Version Name
     # + return - Ok
-    remote isolated function operationId04(int 'version, string versionName) returns string|error {
-        string resourcePath = string `/v1/${getEncodedUri('version)}/version-name/${getEncodedUri(versionName)}`;
+    remote isolated function operationId04(int version, string versionName) returns string|error {
+        string resourcePath = string `/v1/${getEncodedUri(version)}/version-name/${getEncodedUri(versionName)}`;
         string response = check self.clientEp-> get(resourcePath);
         return response;
     }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_valid.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_valid.bal
@@ -63,15 +63,15 @@ public isolated client class Client {
     }
     #
     # + return - Ok
-    remote isolated function operationId04(int 'version, string name) returns string|error {
-        string resourcePath = string `/v1/${getEncodedUri('version)}/v2/${getEncodedUri(name)}`;
+    remote isolated function operationId04(int version, string name) returns string|error {
+        string resourcePath = string `/v1/${getEncodedUri(version)}/v2/${getEncodedUri(name)}`;
         string response = check self.clientEp-> get(resourcePath);
         return response;
     }
     #
     # + return - Ok
-    remote isolated function operationId05(int 'version, int 'limit) returns string|error {
-        string resourcePath = string `/v1/${getEncodedUri('version)}/v2/${getEncodedUri('limit)}`;
+    remote isolated function operationId05(int version, int 'limit) returns string|error {
+        string resourcePath = string `/v1/${getEncodedUri(version)}/v2/${getEncodedUri('limit)}`;
         string response = check self.clientEp-> get(resourcePath);
         return response;
     }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_with_special_name.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/path_parameter_with_special_name.bal
@@ -35,11 +35,11 @@ public isolated client class Client {
         return;
     }
     #
-    # + 'version - Version Id
+    # + version - Version Id
     # + versionName - Version Name
     # + return - Ok
-    remote isolated function operationId04(int 'version, string versionName) returns string|error {
-        string resourcePath = string `/v1/${getEncodedUri('version)}/v2/${getEncodedUri(versionName)}`;
+    remote isolated function operationId04(int version, string versionName) returns string|error {
+        string resourcePath = string `/v1/${getEncodedUri(version)}/v2/${getEncodedUri(versionName)}`;
         string response = check self.clientEp-> get(resourcePath);
         return response;
     }

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/multiple_pathparam.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/multiple_pathparam.bal
@@ -1,4 +1,4 @@
-import  ballerina/http;
+import ballerina/http;
 
 # Title
 public isolated client class Client {
@@ -36,12 +36,12 @@ public isolated client class Client {
         return;
     }
     #
-    # + 'version - test
+    # + version - test
     # + name - test
     # + return - Ok
-    remote isolated function pathParameter(int 'version, string name) returns string|error {
-        string resourcePath = string `/v1/${getEncodedUri('version)}/v2/${getEncodedUri(name)}`;
-        string response = check self.clientEp-> get(resourcePath);
+    remote isolated function pathParameter(int version, string name) returns string|error {
+        string resourcePath = string `/v1/${getEncodedUri(version)}/v2/${getEncodedUri(name)}`;
+        string response = check self.clientEp->get(resourcePath);
         return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/pathParameters.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/pathParameters.bal
@@ -62,15 +62,15 @@ public isolated client class Client {
     }
     #
     # + return - Ok
-    resource isolated function get v1/[int 'version]/v2/[string name]() returns string|error {
-        string resourcePath = string `/v1/${getEncodedUri('version)}/v2/${getEncodedUri(name)}`;
+    resource isolated function get v1/[int version]/v2/[string name]() returns string|error {
+        string resourcePath = string `/v1/${getEncodedUri(version)}/v2/${getEncodedUri(name)}`;
         string response = check self.clientEp->get(resourcePath);
         return response;
     }
     #
     # + return - Ok
-    resource isolated function get v1/[int 'version]/v2/[int 'limit]() returns string|error {
-        string resourcePath = string `/v1/${getEncodedUri('version)}/v2/${getEncodedUri('limit)}`;
+    resource isolated function get v1/[int version]/v2/[int 'limit]() returns string|error {
+        string resourcePath = string `/v1/${getEncodedUri(version)}/v2/${getEncodedUri('limit)}`;
         string response = check self.clientEp->get(resourcePath);
         return response;
     }


### PR DESCRIPTION
## Purpose
> Ballerina Lang will not consider `version` as keyword along with 2201.5.0(Update 05)
Reference PR : https://github.com/ballerina-platform/ballerina-lang/pull/39840


## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.