### PR TITLE
[1.4.x] Bug fix in additional property mapping when invalid number format is given

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/PrimitiveDataTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/PrimitiveDataTypeTests.java
@@ -89,6 +89,17 @@ public class PrimitiveDataTypeTests {
                 syntaxTree);
     }
 
+    @Test(description = "Test for unsupported primitive type additional properties")
+    public void generateSchemaForInvalidAdditionalProperty() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/additional_properties_invalid_format.yaml");
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(definitionPath, true);
+        BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
+        syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
+        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree("schema/ballerina/" +
+                        "additional_properties_invalid_format.bal",
+                syntaxTree);
+    }
+
     @AfterTest
     public void clean() {
         System.setErr(null);

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_invalid_format.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/additional_properties_invalid_format.bal
@@ -1,0 +1,3 @@
+public type Mark record {|
+    decimal...;
+|};

--- a/openapi-cli/src/test/resources/generators/schema/swagger/additional_properties_invalid_format.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/additional_properties_invalid_format.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.11
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore3.swagger.io/api/v3
+paths:
+  /marks:
+    post:
+      tags:
+        - pet
+      summary: Add marks
+      description: Add marks
+      operationId: addMarks
+      requestBody:
+        description: Add mark
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Mark'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Mark'
+components:
+  schemas:
+    Mark:
+      type: object
+      additionalProperties:
+        format: double
+        type: number

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
@@ -199,7 +199,8 @@ public class RecordTypeGenerator extends TypeGenerator {
         if (additionalPropSchema instanceof NumberSchema && additionalPropSchema.getFormat() != null) {
             // this is special for `NumberSchema` because it has format with its expected type.
             String type = additionalPropSchema.getFormat();
-            SimpleNameReferenceNode numberNode = NodeFactory.createSimpleNameReferenceNode(createIdentifierToken(type));
+            SimpleNameReferenceNode numberNode = NodeFactory.createSimpleNameReferenceNode(
+                    createIdentifierToken(GeneratorUtils.convertOpenAPITypeToBallerina(type)));
             recordRestDescNode = NodeFactory.createRecordRestDescriptorNode(
                     TypeGeneratorUtils.getNullableType(additionalPropSchema, numberNode),
                     createToken(ELLIPSIS_TOKEN),


### PR DESCRIPTION
## Purpose
> $subject
Resolves https://github.com/ballerina-platform/openapi-tools/issues/1285

## Goals
Sample OpenAPI

```yaml
  schemas:
    Mark:
      type: object
      additionalProperties:
        format: double
        type: number
```

Generated record 

```bal
public type Mark record {|
    decimal...;
|};
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11