### PR TITLE
[1.4.x] Bug fix in nullable constraints

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
@@ -134,4 +134,19 @@ public class ConstraintTests {
     }
     //TODO current tool doesn't handle union type: therefore union type constraint will handle once union type
     // generation available in tool.
+
+    @Test
+    public void testNullableArrayRefTypeWithConstraint() throws IOException, BallerinaOpenApiException,
+            FormatterException {
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(RES_DIR.resolve("swagger/constraint" +
+                "/constraint_with_nullable.yaml"), true);
+        BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
+        SyntaxTree syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
+        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "schema/ballerina/constraint/constraint_with_nullable.bal", syntaxTree);
+        List<Diagnostic> diagnostics = getDiagnostics(syntaxTree);
+        boolean hasErrors = diagnostics.stream()
+                .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));
+        assertFalse(hasErrors);
+    }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
@@ -135,7 +135,7 @@ public class ConstraintTests {
     //TODO current tool doesn't handle union type: therefore union type constraint will handle once union type
     // generation available in tool.
 
-    @Test
+    @Test(description = "Tests for nullable reference types with constraint.")
     public void testNullableRefTypesWithConstraint() throws IOException, BallerinaOpenApiException,
             FormatterException {
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(RES_DIR.resolve("swagger/constraint" +

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
@@ -136,7 +136,7 @@ public class ConstraintTests {
     // generation available in tool.
 
     @Test
-    public void testNullableArrayRefTypeWithConstraint() throws IOException, BallerinaOpenApiException,
+    public void testNullableRefTypesWithConstraint() throws IOException, BallerinaOpenApiException,
             FormatterException {
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(RES_DIR.resolve("swagger/constraint" +
                 "/constraint_with_nullable.yaml"), true);

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/constraint_with_nullable.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/constraint_with_nullable.bal
@@ -1,8 +1,12 @@
 # At least one entry should be non-null.
-public type NullableNumberInterval decimal[]?;
+public type Scores decimal[]?;
+
+public type Average float?;
 
 public type Pet record {
     int id;
     string name;
     decimal[]? tag?;
 };
+
+public type Name string?;

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/constraint_with_nullable.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/constraint_with_nullable.bal
@@ -1,0 +1,8 @@
+# At least one entry should be non-null.
+public type NullableNumberInterval decimal[]?;
+
+public type Pet record {
+    int id;
+    string name;
+    decimal[]? tag?;
+};

--- a/openapi-cli/src/test/resources/generators/schema/swagger/constraint/constraint_with_nullable.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/constraint/constraint_with_nullable.yaml
@@ -28,7 +28,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NullableNumberInterval'
+              $ref: '#/components/schemas/Scores'
         required: true
       responses:
         '200':
@@ -36,10 +36,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NullableNumberInterval'
+                $ref: '#/components/schemas/Scores'
 components:
   schemas:
-    NullableNumberInterval:
+    Scores:
       type: array
       items:
         type: number
@@ -48,6 +48,17 @@ components:
       minItems: 2
       nullable: true
       description: At least one entry should be non-null.
+    Name:
+      type: string
+      maxLength: 0
+      minLength: 10
+      nullable: true
+    Average:
+      type: number
+      format: float
+      minimum: 0.0
+      maximum: 12.0
+      nullable: true
     Pet:
       required:
         - id
@@ -56,7 +67,6 @@ components:
         id:
           type: integer
           format: int64
-
         name:
           type: string
         tag:

--- a/openapi-cli/src/test/resources/generators/schema/swagger/constraint/constraint_with_nullable.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/constraint/constraint_with_nullable.yaml
@@ -1,0 +1,69 @@
+openapi: 3.0.3
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.11
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore3.swagger.io/api/v3
+paths:
+  /marks:
+    post:
+      tags:
+        - pet
+      summary: Add marks
+      description: Add marks
+      operationId: addMarks
+      requestBody:
+        description: Add mark
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NullableNumberInterval'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullableNumberInterval'
+components:
+  schemas:
+    NullableNumberInterval:
+      type: array
+      items:
+        type: number
+        nullable: true
+      maxItems: 2
+      minItems: 2
+      nullable: true
+      description: At least one entry should be non-null.
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+
+        name:
+          type: string
+        tag:
+          type: array
+          items:
+            type: number
+            nullable: true
+          maxItems: 2
+          minItems: 2
+          nullable: true

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -57,6 +57,7 @@ import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
 import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
 import io.ballerina.openapi.core.generators.client.BallerinaUtilGenerator;
+import io.ballerina.openapi.core.generators.schema.model.GeneratorMetaData;
 import io.ballerina.openapi.core.model.GenSrcFile;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
@@ -693,6 +694,11 @@ public class GeneratorUtils {
 
     private static boolean isConstraintExists(Schema<?> propertyValue) {
 
+        boolean isConstraintSupport = propertyValue.getNullable() != null && propertyValue.getNullable();
+        boolean nullable = GeneratorMetaData.getInstance().isNullable();
+        if (nullable || isConstraintSupport) {
+            return false;
+        }
         return propertyValue.getMaximum() != null ||
                 propertyValue.getMinimum() != null ||
                 propertyValue.getMaxLength() != null ||

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -57,7 +57,6 @@ import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
 import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
 import io.ballerina.openapi.core.generators.client.BallerinaUtilGenerator;
-import io.ballerina.openapi.core.generators.schema.model.GeneratorMetaData;
 import io.ballerina.openapi.core.model.GenSrcFile;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
@@ -694,11 +693,6 @@ public class GeneratorUtils {
 
     private static boolean isConstraintExists(Schema<?> propertyValue) {
 
-        boolean isConstraintSupport = propertyValue.getNullable() != null && propertyValue.getNullable();
-        boolean nullable = GeneratorMetaData.getInstance().isNullable();
-        if (nullable || isConstraintSupport) {
-            return false;
-        }
         return propertyValue.getMaximum() != null ||
                 propertyValue.getMinimum() != null ||
                 propertyValue.getMaxLength() != null ||

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
@@ -211,7 +211,7 @@ public class BallerinaTypesGenerator {
         TypeGenerator typeGenerator = TypeGeneratorUtils.getTypeGenerator(schema, GeneratorUtils.getValidName(
                 typeName.trim(), true), null);
         List<AnnotationNode> typeAnnotations = new ArrayList<>();
-        if (TypeGeneratorUtils.isSupportConstraint(typeName, schema)) {
+        if (TypeGeneratorUtils.allowsConstraints(typeName, schema)) {
             AnnotationNode constraintNode = TypeGeneratorUtils.generateConstraintNode(typeName, schema);
             if (constraintNode != null) {
                 typeAnnotations.add(constraintNode);

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
@@ -211,7 +211,7 @@ public class BallerinaTypesGenerator {
         TypeGenerator typeGenerator = TypeGeneratorUtils.getTypeGenerator(schema, GeneratorUtils.getValidName(
                 typeName.trim(), true), null);
         List<AnnotationNode> typeAnnotations = new ArrayList<>();
-        if (TypeGeneratorUtils.allowsConstraints(typeName, schema)) {
+        if (TypeGeneratorUtils.isConstraintAllowed(typeName, schema)) {
             AnnotationNode constraintNode = TypeGeneratorUtils.generateConstraintNode(typeName, schema);
             if (constraintNode != null) {
                 typeAnnotations.add(constraintNode);

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
@@ -211,9 +211,11 @@ public class BallerinaTypesGenerator {
         TypeGenerator typeGenerator = TypeGeneratorUtils.getTypeGenerator(schema, GeneratorUtils.getValidName(
                 typeName.trim(), true), null);
         List<AnnotationNode> typeAnnotations = new ArrayList<>();
-        AnnotationNode constraintNode = TypeGeneratorUtils.generateConstraintNode(schema);
-        if (constraintNode != null) {
-            typeAnnotations.add(constraintNode);
+        if (TypeGeneratorUtils.isSupportConstraint(typeName, schema)) {
+            AnnotationNode constraintNode = TypeGeneratorUtils.generateConstraintNode(typeName, schema);
+            if (constraintNode != null) {
+                typeAnnotations.add(constraintNode);
+            }
         }
         TypeGeneratorUtils.getRecordDocs(schemaDocs, schema, typeAnnotations);
         TypeDefinitionNode typeDefinitionNode =

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
@@ -90,6 +90,8 @@ public class TypeGeneratorUtils {
             new ArrayList<>(Arrays.asList(GeneratorConstants.INTEGER, GeneratorConstants.NUMBER,
                     GeneratorConstants.STRING, GeneratorConstants.BOOLEAN));
 
+    public static final PrintStream OUT_STREAM = System.err;
+
     /**
      * Get SchemaType object relevant to the schema given.
      *
@@ -170,7 +172,7 @@ public class TypeGeneratorUtils {
 
         MarkdownDocumentationNode documentationNode = createMarkdownDocumentationNode(schemaDocNodes);
         //Generate constraint annotation.
-        AnnotationNode constraintNode = generateConstraintNode(fieldSchema);
+        AnnotationNode constraintNode = generateConstraintNode(fieldName.text(), fieldSchema);
         MetadataNode metadataNode;
         boolean isConstraintSupport =
                 constraintNode != null && fieldSchema.getNullable() != null && fieldSchema.getNullable() ||
@@ -262,24 +264,41 @@ public class TypeGeneratorUtils {
      * @param fieldSchema Schema for data type
      * @return {@link MetadataNode}
      */
-    public static AnnotationNode generateConstraintNode(Schema<?> fieldSchema) {
-
-        if (fieldSchema instanceof StringSchema) {
-            StringSchema stringSchema = (StringSchema) fieldSchema;
-            // Attributes : maxLength, minLength
-            return generateStringConstraint(stringSchema);
-        } else if (fieldSchema instanceof IntegerSchema || fieldSchema instanceof NumberSchema) {
-            // Attribute : minimum, maximum, exclusiveMinimum, exclusiveMaximum
-            return generateNumberConstraint(fieldSchema);
-        } else if (fieldSchema instanceof ArraySchema) {
-            ArraySchema arraySchema = (ArraySchema) fieldSchema;
-            // Attributes: maxItems, minItems
-            return generateArrayConstraint(arraySchema);
+    public static AnnotationNode generateConstraintNode(String typeName, Schema<?> fieldSchema) {
+        if (isSupportConstraint(typeName, fieldSchema)) {
+            if (fieldSchema instanceof StringSchema) {
+                StringSchema stringSchema = (StringSchema) fieldSchema;
+                // Attributes : maxLength, minLength
+                return generateStringConstraint(stringSchema);
+            } else if (fieldSchema instanceof IntegerSchema || fieldSchema instanceof NumberSchema) {
+                // Attribute : minimum, maximum, exclusiveMinimum, exclusiveMaximum
+                return generateNumberConstraint(fieldSchema);
+            } else if (fieldSchema instanceof ArraySchema) {
+                ArraySchema arraySchema = (ArraySchema) fieldSchema;
+                // Attributes: maxItems, minItems
+                return generateArrayConstraint(arraySchema);
+            }
+            // Ignore Object, Map and Composed schemas.
+            return null;
         }
-        // Ignore Object, Map and Composed schemas.
         return null;
     }
 
+    public static boolean isSupportConstraint(String typeName, Schema schema) {
+
+        boolean isConstraintSupport = schema.getNullable() != null && schema.getNullable() ||
+                (schema instanceof ComposedSchema && (((ComposedSchema) schema).getOneOf() != null ||
+                        ((ComposedSchema) schema).getAnyOf() != null));
+        boolean nullable = GeneratorMetaData.getInstance().isNullable();
+        if (nullable) {
+            return false;
+        } else if (isConstraintSupport) {
+            OUT_STREAM.printf("WARNING: constraints in the OpenAPI contract will be ignored for the " +
+                    "type `%s`%n", typeName);
+            return false;
+        }
+        return true;
+    }
     /**
      * Generate constraint for numbers : int, float, decimal.
      */

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
@@ -294,7 +294,8 @@ public class TypeGeneratorUtils {
             return false;
         } else if (isConstraintSupport) {
             OUT_STREAM.printf("WARNING: constraints in the OpenAPI contract will be ignored for the " +
-                    "type `%s`%n", typeName);
+                            "type `%s`, as constraints are not supported on Ballerina union types%n",
+                    typeName.trim());
             return false;
         }
         return true;

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
@@ -297,13 +297,13 @@ public class TypeGeneratorUtils {
 
     public static boolean isConstraintAllowed(String typeName, Schema schema) {
 
-        boolean isConstraintAllowed = schema.getNullable() != null && schema.getNullable() ||
+        boolean isConstraintNotAllowed = schema.getNullable() != null && schema.getNullable() ||
                 (schema instanceof ComposedSchema && (((ComposedSchema) schema).getOneOf() != null ||
                         ((ComposedSchema) schema).getAnyOf() != null));
         boolean nullable = GeneratorMetaData.getInstance().isNullable();
         if (nullable) {
             return false;
-        } else if (isConstraintAllowed) {
+        } else if (isConstraintNotAllowed) {
             OUT_STREAM.printf("WARNING: constraints in the OpenAPI contract will be ignored for the " +
                             "type `%s`, as constraints are not supported on Ballerina union types%n",
                     typeName.trim());

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
@@ -265,7 +265,7 @@ public class TypeGeneratorUtils {
      * @return {@link MetadataNode}
      */
     public static AnnotationNode generateConstraintNode(String typeName, Schema<?> fieldSchema) {
-        if (allowsConstraints(typeName, fieldSchema)) {
+        if (isConstraintAllowed(typeName, fieldSchema)) {
             if (fieldSchema instanceof StringSchema) {
                 StringSchema stringSchema = (StringSchema) fieldSchema;
                 // Attributes : maxLength, minLength
@@ -284,7 +284,7 @@ public class TypeGeneratorUtils {
         return null;
     }
 
-    public static boolean allowsConstraints(String typeName, Schema schema) {
+    public static boolean isConstraintAllowed(String typeName, Schema schema) {
 
         boolean isConstraintAllowed = schema.getNullable() != null && schema.getNullable() ||
                 (schema instanceof ComposedSchema && (((ComposedSchema) schema).getOneOf() != null ||

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
@@ -265,7 +265,7 @@ public class TypeGeneratorUtils {
      * @return {@link MetadataNode}
      */
     public static AnnotationNode generateConstraintNode(String typeName, Schema<?> fieldSchema) {
-        if (isSupportConstraint(typeName, fieldSchema)) {
+        if (allowsConstraints(typeName, fieldSchema)) {
             if (fieldSchema instanceof StringSchema) {
                 StringSchema stringSchema = (StringSchema) fieldSchema;
                 // Attributes : maxLength, minLength
@@ -284,15 +284,15 @@ public class TypeGeneratorUtils {
         return null;
     }
 
-    public static boolean isSupportConstraint(String typeName, Schema schema) {
+    public static boolean allowsConstraints(String typeName, Schema schema) {
 
-        boolean isConstraintSupport = schema.getNullable() != null && schema.getNullable() ||
+        boolean isConstraintAllowed = schema.getNullable() != null && schema.getNullable() ||
                 (schema instanceof ComposedSchema && (((ComposedSchema) schema).getOneOf() != null ||
                         ((ComposedSchema) schema).getAnyOf() != null));
         boolean nullable = GeneratorMetaData.getInstance().isNullable();
         if (nullable) {
             return false;
-        } else if (isConstraintSupport) {
+        } else if (isConstraintAllowed) {
             OUT_STREAM.printf("WARNING: constraints in the OpenAPI contract will be ignored for the " +
                             "type `%s`, as constraints are not supported on Ballerina union types%n",
                     typeName.trim());

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/ArrayTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/ArrayTypeGenerator.java
@@ -90,17 +90,17 @@ public class ArrayTypeGenerator extends TypeGenerator {
         TypeGenerator typeGenerator;
         if (isConstraintsAvailable) {
             String normalizedTypeName = typeName.replaceAll(GeneratorConstants.SPECIAL_CHARACTER_REGEX, "").trim();
+            List<AnnotationNode> typeAnnotations = new ArrayList<>();
+            AnnotationNode constraintNode = TypeGeneratorUtils.generateConstraintNode(typeName, items);
+            if (constraintNode != null) {
+                typeAnnotations.add(constraintNode);
+            }
             typeName = GeneratorUtils.getValidName(
                     parentType != null ?
                             parentType + "-" + normalizedTypeName + "-Items-" + items.getType() :
                             normalizedTypeName + "-Items-" + items.getType(),
                     true);
             typeGenerator = TypeGeneratorUtils.getTypeGenerator(items, typeName, null);
-            List<AnnotationNode> typeAnnotations = new ArrayList<>();
-            AnnotationNode constraintNode = TypeGeneratorUtils.generateConstraintNode(items);
-            if (constraintNode != null) {
-                typeAnnotations.add(constraintNode);
-            }
             TypeDefinitionNode arrayItemWithConstraint = typeGenerator.generateTypeDefinitionNode(
                     createIdentifierToken(typeName),
                     new ArrayList<>(),


### PR DESCRIPTION
## Purpose
> $subject
 Resolves https://github.com/ballerina-platform/openapi-tools/issues/1290

## Approach

Avoid generating constraints when the type is nullable

Ex:

```yaml
Scores:
      type: array
      items:
        type: number
        nullable: true
      maxItems: 2
      minItems: 2
      nullable: true
      description: At least one entry should be non-null.
```

**Generated bal type**

```bal
# At least one entry should be non-null.
public type Scores decimal[]?;
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11