### PR TITLE
[1.4.x] Fix for avoiding unnecessary constraint import generation

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/AnyOfDataTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/AnyOfDataTypeTests.java
@@ -27,7 +27,6 @@ import io.ballerina.openapi.core.generators.schema.model.GeneratorMetaData;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
-import org.ballerinalang.formatter.core.FormatterException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -58,7 +57,7 @@ public class AnyOfDataTypeTests {
     }
 
     @Test(description = "Test for the schema generations")
-    public void testAnyOfSchema() throws BallerinaOpenApiException, IOException, FormatterException {
+    public void testAnyOfSchema() throws BallerinaOpenApiException, IOException {
         Path definitionPath = RES_DIR.resolve("swagger/scenario15.yaml");
         Path expectedPath = RES_DIR.resolve("ballerina/schema15.bal");
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(definitionPath, true);

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
@@ -25,6 +25,7 @@ import io.ballerina.openapi.generators.common.TestUtils;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import io.swagger.v3.oas.models.OpenAPI;
+import org.ballerinalang.formatter.core.Formatter;
 import org.ballerinalang.formatter.core.FormatterException;
 import org.testng.annotations.Test;
 
@@ -134,4 +135,33 @@ public class ConstraintTests {
     }
     //TODO current tool doesn't handle union type: therefore union type constraint will handle once union type
     // generation available in tool.
+
+    @Test(description = "Test for invalid constraint value")
+    public void invalidConstraintUses() throws IOException, BallerinaOpenApiException, FormatterException {
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(RES_DIR.resolve("swagger/constraint" +
+                "/invalidConstraintFieldWithDataType.yaml"), true);
+        BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
+        SyntaxTree syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
+        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "schema/ballerina/constraint/invalidConstraintFieldWithDataType.bal", syntaxTree);
+        List<Diagnostic> diagnostics = getDiagnostics(syntaxTree);
+        boolean hasErrors = diagnostics.stream()
+                .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));
+        assertFalse(hasErrors);
+    }
+
+    @Test(description = "Test for invalid constraint value with valid constraint value")
+    public void invalidAndValidBothConstraintUses() throws IOException, BallerinaOpenApiException, FormatterException {
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(RES_DIR.resolve("swagger/constraint" +
+                "/invalidAndValidConstraintFieldWithDataType.yaml"), true);
+        BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
+        SyntaxTree syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
+        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "schema/ballerina/constraint/invalidAndValidConstraintFieldWithDataType.bal", syntaxTree);
+        List<Diagnostic> diagnostics = getDiagnostics(syntaxTree);
+        boolean hasErrors = diagnostics.stream()
+                .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));
+        assertFalse(hasErrors);
+    }
 }
+

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
@@ -177,4 +177,3 @@ public class ConstraintTests {
         assertFalse(hasErrors);
     }
 }
-

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
@@ -136,7 +136,7 @@ public class ConstraintTests {
     // generation available in tool.
 
     @Test(description = "Test for invalid constraint value")
-    public void invalidConstraintUses() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void testInvalidConstraintUses() throws IOException, BallerinaOpenApiException, FormatterException {
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(RES_DIR.resolve("swagger/constraint" +
                 "/invalidConstraintFieldWithDataType.yaml"), true);
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
@@ -150,7 +150,8 @@ public class ConstraintTests {
     }
 
     @Test(description = "Test for invalid constraint value with valid constraint value")
-    public void invalidAndValidBothConstraintUses() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void testInvalidAndValidBothConstraintUses() throws IOException, BallerinaOpenApiException,
+            FormatterException {
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(RES_DIR.resolve("swagger/constraint" +
                 "/invalidAndValidConstraintFieldWithDataType.yaml"), true);
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
@@ -164,7 +165,7 @@ public class ConstraintTests {
     }
 
     @Test(description = "Test for allowing zero value for number and integer type")
-    public void allowedZeroValuesForNumber() throws IOException, BallerinaOpenApiException, FormatterException {
+    public void testAllowedZeroValuesForNumber() throws IOException, BallerinaOpenApiException, FormatterException {
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(RES_DIR.resolve("swagger/constraint" +
                 "/allow_zero_values_for_number_constraint.yaml"), true);
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/ConstraintTests.java
@@ -25,7 +25,6 @@ import io.ballerina.openapi.generators.common.TestUtils;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import io.swagger.v3.oas.models.OpenAPI;
-import org.ballerinalang.formatter.core.Formatter;
 import org.ballerinalang.formatter.core.FormatterException;
 import org.testng.annotations.Test;
 
@@ -143,7 +142,7 @@ public class ConstraintTests {
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
         SyntaxTree syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
         TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
-                "schema/ballerina/constraint/invalidConstraintFieldWithDataType.bal", syntaxTree);
+                "schema/ballerina/constraint/invalidConstraintFieldWithDtaType.bal", syntaxTree);
         List<Diagnostic> diagnostics = getDiagnostics(syntaxTree);
         boolean hasErrors = diagnostics.stream()
                 .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));
@@ -157,7 +156,21 @@ public class ConstraintTests {
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
         SyntaxTree syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
         TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
-                "schema/ballerina/constraint/invalidAndValidConstraintFieldWithDataType.bal", syntaxTree);
+                "schema/ballerina/constraint/invalidAndValidConstraintFieldWithDtaType.bal", syntaxTree);
+        List<Diagnostic> diagnostics = getDiagnostics(syntaxTree);
+        boolean hasErrors = diagnostics.stream()
+                .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));
+        assertFalse(hasErrors);
+    }
+
+    @Test(description = "Test for allowing zero value for number and integer type")
+    public void allowedZeroValuesForNumber() throws IOException, BallerinaOpenApiException, FormatterException {
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(RES_DIR.resolve("swagger/constraint" +
+                "/allow_zero_values_for_number_constraint.yaml"), true);
+        BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
+        SyntaxTree syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
+        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "schema/ballerina/constraint/allow_zero_values_for_number_constraint.bal", syntaxTree);
         List<Diagnostic> diagnostics = getDiagnostics(syntaxTree);
         boolean hasErrors = diagnostics.stream()
                 .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/allow_zero_values_for_number_constraint.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/allow_zero_values_for_number_constraint.bal
@@ -1,0 +1,13 @@
+public type Address string;
+
+public type Person record {
+    string name?;
+    string[] hobby?;
+    @constraint:Int {maxValue: 0}
+    int id;
+    Address address?;
+    @constraint:Float {maxValue: 0}
+    float salary?;
+    @constraint:Number {minValue: 0}
+    decimal net?;
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/allow_zero_values_for_number_constraint.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/allow_zero_values_for_number_constraint.bal
@@ -1,3 +1,5 @@
+import ballerina/constraint;
+
 public type Address string;
 
 public type Person record {

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/invalidAndValidConstraintFieldWithDtaType.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/invalidAndValidConstraintFieldWithDtaType.bal
@@ -1,0 +1,10 @@
+import ballerina/constraint;
+
+@constraint:String {maxLength: 5}
+public type Address string;
+
+public type Person record {
+    string name?;
+    @constraint:Int {maxValue: 5}
+    int id;
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/invalidConstraintFieldWithDtaType.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/invalidConstraintFieldWithDtaType.bal
@@ -1,0 +1,6 @@
+public type Address string;
+
+public type Person record {
+    string name?;
+    int id;
+};

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/record_field_02.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/record_field_02.bal
@@ -1,3 +1,5 @@
+import ballerina/constraint;
+
 @constraint:String {maxLength: 5000}
 public type TaxratesItemsString string;
 

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/record_field_02.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/record_field_02.bal
@@ -1,5 +1,3 @@
-import ballerina/constraint;
-
 @constraint:String {maxLength: 5000}
 public type TaxratesItemsString string;
 
@@ -20,7 +18,9 @@ public type Person record {
     @constraint:Int {maxValue: 5}
     int id;
     Address address?;
+    @constraint:Float {maxValue: 0}
     float salary?;
+    @constraint:Number {minValueExclusive: 0}
     decimal net?;
     @constraint:Int {minValue: 1, maxValue: 100}
     int maxDeliveryCount?;

--- a/openapi-cli/src/test/resources/generators/schema/swagger/constraint/allow_zero_values_for_number_constraint.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/constraint/allow_zero_values_for_number_constraint.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: Shopify Admin API
+  version: "2021-10"
+tags:
+  - name: customers
+  - name: products
+  - name: orders
+  - name: fulfillments
+  - name: order_risks
+paths:
+  /admin:
+    post:
+      operationId: "test1"
+      requestBody:
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/Person"
+      responses:
+        200:
+          description: Status OK
+
+components:
+  schemas:
+    Address:  # Use case 02 : Annotations on a type
+      type: string
+      minLength: 0
+    Person:
+      type: object
+      required:
+        - id
+      properties:
+        name:
+          type: string
+          maxLength: 0 # Use case 01 : Annotations on a record field
+        hobby:
+          type: array
+          items:
+            type: string
+          maxItems: 0
+          minItems: 0
+        id:
+          type: integer
+          maximum: 0
+        address:  # Use case 03 : Annotations on a type used as a record field
+          $ref: "#/components/schemas/Address"
+        salary:
+          type: number
+          format: float
+          maximum: 0
+        net:
+          type: number
+          minimum: 0

--- a/openapi-cli/src/test/resources/generators/schema/swagger/constraint/invalidAndValidConstraintFieldWithDataType.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/constraint/invalidAndValidConstraintFieldWithDataType.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Shopify Admin API
+  version: "2021-10"
+paths:
+  /admin:
+    post:
+      operationId: "test1"
+      requestBody:
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/Address"
+      responses:
+        200:
+          description: Status OK
+
+components:
+  schemas:
+    Address:  # 01 : string type has invalid constraint `maximum` and valid constraint `maxLength`
+      type: string
+      maximum: 5
+      maxLength: 5
+    Person:
+      type: object
+      required:
+        - id
+      properties:
+        name:
+          type: string
+          maximum: 14 # 02 : string type has invalid constraint `maximum` in record field
+        id:
+          type: integer
+          maxItems: 5  # 03 : integer type has invalid constraint `maxItems`
+          maximum: 5

--- a/openapi-cli/src/test/resources/generators/schema/swagger/constraint/invalidConstraintFieldWithDataType.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/constraint/invalidConstraintFieldWithDataType.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: Shopify Admin API
+  version: "2021-10"
+tags:
+  - name: customers
+  - name: products
+  - name: orders
+  - name: fulfillments
+  - name: order_risks
+paths:
+  /admin:
+    post:
+      operationId: "test1"
+      requestBody:
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/Address"
+      responses:
+        200:
+          description: Status OK
+
+components:
+  schemas:
+    Address:  # 01 : string type has invalid constraint `maximum`
+      type: string
+      maximum: 5
+    Person:
+      type: object
+      required:
+        - id
+      properties:
+        name:
+          type: string
+          maximum: 14 # 02 : string type has invalid constraint `maximum` in record field
+        id:
+          type: integer
+          maxItems: 5  # 03 : integer type has invalid constraint `maxItems`

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
@@ -27,6 +27,7 @@ import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeFactory;
 import io.ballerina.compiler.syntax.tree.NodeList;
+import io.ballerina.compiler.syntax.tree.NodeParser;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.RecordTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
@@ -49,9 +50,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyNodeList;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createNodeList;
@@ -67,7 +70,7 @@ import static io.ballerina.openapi.core.GeneratorConstants.CONNECTION_CONFIG;
 public class BallerinaTypesGenerator {
 
     private final List<TypeDefinitionNode> typeDefinitionNodeList;
-    private boolean hasConstraints;
+    private final Set<String> imports = new LinkedHashSet<>();
 
     /**
      * This public constructor is used to generate record and other relevant data type when the nullable flag is
@@ -81,7 +84,6 @@ public class BallerinaTypesGenerator {
                                    List<TypeDefinitionNode> typeDefinitionNodeList) {
         GeneratorMetaData.createInstance(openAPI, isNullable);
         this.typeDefinitionNodeList = typeDefinitionNodeList;
-        this.hasConstraints = false;
     }
 
     /**
@@ -118,13 +120,10 @@ public class BallerinaTypesGenerator {
             if (schemas != null) {
                 for (Map.Entry<String, Schema> schema : schemas.entrySet()) {
                     String schemaKey = schema.getKey().trim();
-                    if (!hasConstraints) {
-                        hasConstraints = GeneratorUtils.hasConstraints(schema.getValue());
-                    }
                     if (GeneratorUtils.isValidSchemaName(schemaKey)) {
                         List<Node> schemaDoc = new ArrayList<>();
-                        typeDefinitionNodeListForSchema.add(getTypeDefinitionNode
-                                (schema.getValue(), schemaKey, schemaDoc));
+                        typeDefinitionNodeListForSchema.add(getTypeDefinitionNode(schema.getValue(), schemaKey,
+                                schemaDoc));
                     }
                 }
             }
@@ -145,25 +144,25 @@ public class BallerinaTypesGenerator {
     }
 
     private NodeList<ImportDeclarationNode> generateImportNodes() {
-        List<ImportDeclarationNode> imports = new ArrayList<>();
+        Set<ImportDeclarationNode> finalImports = new LinkedHashSet<>();
+        // Imports for the http module, when record has http type inclusions.
         if (!typeDefinitionNodeList.isEmpty()) {
-            importsForTypeDefinitions(imports);
+            importsForTypeDefinitions(finalImports);
         }
-        boolean nullable = GeneratorMetaData.getInstance().isNullable();
-        if (hasConstraints && !nullable) {
-            //import for constraint
-            ImportDeclarationNode importForConstraint = GeneratorUtils.getImportDeclarationNode(
-                    GeneratorConstants.BALLERINA,
-                    GeneratorConstants.CONSTRAINT);
-            imports.add(importForConstraint);
+        //Imports for constraints
+        if (!imports.isEmpty()) {
+            for (String importValue : imports) {
+                ImportDeclarationNode importDeclarationNode = NodeParser.parseImportDeclaration(importValue);
+                finalImports.add(importDeclarationNode);
+            }
         }
-        if (imports.isEmpty()) {
+        if (finalImports.isEmpty()) {
             return createEmptyNodeList();
         }
-        return createNodeList(imports);
+        return createNodeList(finalImports);
     }
 
-    private void importsForTypeDefinitions(List<ImportDeclarationNode> imports) {
+    private void importsForTypeDefinitions(Set<ImportDeclarationNode> imports) {
         for (TypeDefinitionNode node : typeDefinitionNodeList) {
             if (!(node.typeDescriptor() instanceof RecordTypeDescriptorNode)) {
                 continue;
@@ -220,18 +219,19 @@ public class BallerinaTypesGenerator {
                 typeGenerator.generateTypeDefinitionNode(typeNameToken, schemaDocs, typeAnnotations);
 
         if (typeGenerator instanceof ArrayTypeGenerator &&
-                !((ArrayTypeGenerator) typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-            typeDefinitionNodeList.addAll(((ArrayTypeGenerator) typeGenerator).getTypeDefinitionNodeList());
+                !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
+            typeDefinitionNodeList.addAll((typeGenerator).getTypeDefinitionNodeList());
         } else if (typeGenerator instanceof RecordTypeGenerator &&
-                !((RecordTypeGenerator) typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-            removeDuplicateNode(((RecordTypeGenerator) typeGenerator).getTypeDefinitionNodeList());
+                !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
+            removeDuplicateNode((typeGenerator).getTypeDefinitionNodeList());
         } else if (typeGenerator instanceof AllOfRecordTypeGenerator &&
-                !((AllOfRecordTypeGenerator) typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-            removeDuplicateNode(((AllOfRecordTypeGenerator) typeGenerator).getTypeDefinitionNodeList());
+                !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
+            removeDuplicateNode((typeGenerator).getTypeDefinitionNodeList());
         } else if (typeGenerator instanceof UnionTypeGenerator &&
-                !((UnionTypeGenerator) typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-            removeDuplicateNode(((UnionTypeGenerator) typeGenerator).getTypeDefinitionNodeList());
+                !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
+            removeDuplicateNode((typeGenerator).getTypeDefinitionNodeList());
         }
+        imports.addAll(typeGenerator.getImports());
         return typeDefinitionNode;
     }
 

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
@@ -144,22 +144,22 @@ public class BallerinaTypesGenerator {
     }
 
     private NodeList<ImportDeclarationNode> generateImportNodes() {
-        Set<ImportDeclarationNode> finalImports = new LinkedHashSet<>();
+        Set<ImportDeclarationNode> importDeclarationNodes = new LinkedHashSet<>();
         // Imports for the http module, when record has http type inclusions.
         if (!typeDefinitionNodeList.isEmpty()) {
-            importsForTypeDefinitions(finalImports);
+            importsForTypeDefinitions(importDeclarationNodes);
         }
         //Imports for constraints
         if (!imports.isEmpty()) {
             for (String importValue : imports) {
                 ImportDeclarationNode importDeclarationNode = NodeParser.parseImportDeclaration(importValue);
-                finalImports.add(importDeclarationNode);
+                importDeclarationNodes.add(importDeclarationNode);
             }
         }
-        if (finalImports.isEmpty()) {
+        if (importDeclarationNodes.isEmpty()) {
             return createEmptyNodeList();
         }
-        return createNodeList(finalImports);
+        return createNodeList(importDeclarationNodes);
     }
 
     private void importsForTypeDefinitions(Set<ImportDeclarationNode> imports) {

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/BallerinaTypesGenerator.java
@@ -218,18 +218,17 @@ public class BallerinaTypesGenerator {
         TypeDefinitionNode typeDefinitionNode =
                 typeGenerator.generateTypeDefinitionNode(typeNameToken, schemaDocs, typeAnnotations);
 
-        if (typeGenerator instanceof ArrayTypeGenerator &&
-                !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-            typeDefinitionNodeList.addAll((typeGenerator).getTypeDefinitionNodeList());
+        if (typeGenerator instanceof ArrayTypeGenerator && !typeGenerator.getTypeDefinitionNodeList().isEmpty()) {
+            typeDefinitionNodeList.addAll(typeGenerator.getTypeDefinitionNodeList());
         } else if (typeGenerator instanceof RecordTypeGenerator &&
-                !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-            removeDuplicateNode((typeGenerator).getTypeDefinitionNodeList());
+                !typeGenerator.getTypeDefinitionNodeList().isEmpty()) {
+            removeDuplicateNode(typeGenerator.getTypeDefinitionNodeList());
         } else if (typeGenerator instanceof AllOfRecordTypeGenerator &&
-                !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-            removeDuplicateNode((typeGenerator).getTypeDefinitionNodeList());
+                !typeGenerator.getTypeDefinitionNodeList().isEmpty()) {
+            removeDuplicateNode(typeGenerator.getTypeDefinitionNodeList());
         } else if (typeGenerator instanceof UnionTypeGenerator &&
-                !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-            removeDuplicateNode((typeGenerator).getTypeDefinitionNodeList());
+                !typeGenerator.getTypeDefinitionNodeList().isEmpty()) {
+            removeDuplicateNode(typeGenerator.getTypeDefinitionNodeList());
         }
         imports.addAll(typeGenerator.getImports());
         return typeDefinitionNode;

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
@@ -61,7 +61,6 @@ import io.swagger.v3.oas.models.media.StringSchema;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import java.io.PrintStream;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -348,33 +347,27 @@ public class TypeGeneratorUtils {
 
         List<String> fields = new ArrayList<>();
         boolean isInt = numberSchema instanceof IntegerSchema;
-        if (numberSchema.getMinimum() != null &&
-                BigDecimal.ZERO.compareTo(numberSchema.getMinimum()) != 0
-                && numberSchema.getExclusiveMinimum() == null) {
+        if (numberSchema.getMinimum() != null && numberSchema.getExclusiveMinimum() == null) {
             String value = numberSchema.getMinimum().toString();
             String fieldRef = GeneratorConstants.MINIMUM + GeneratorConstants.COLON +
                     (isInt ? numberSchema.getMinimum().intValue() : value);
             fields.add(fieldRef);
         }
-        if (numberSchema.getMaximum() != null &&
-                BigDecimal.ZERO.compareTo(numberSchema.getMaximum()) != 0
-                && numberSchema.getExclusiveMaximum() == null) {
+        if (numberSchema.getMaximum() != null && numberSchema.getExclusiveMaximum() == null) {
             String value = numberSchema.getMaximum().toString();
             String fieldRef = GeneratorConstants.MAXIMUM + GeneratorConstants.COLON +
                     (isInt ? numberSchema.getMaximum().intValue() : value);
             fields.add(fieldRef);
         }
         if (numberSchema.getExclusiveMinimum() != null &&
-                numberSchema.getExclusiveMinimum() && numberSchema.getMinimum() != null &&
-                BigDecimal.ZERO.compareTo(numberSchema.getMinimum()) != 0) {
+                numberSchema.getExclusiveMinimum() && numberSchema.getMinimum() != null) {
             String value = numberSchema.getMinimum().toString();
             String fieldRef = GeneratorConstants.EXCLUSIVE_MIN + GeneratorConstants.COLON +
                     (isInt ? numberSchema.getMinimum().intValue() : value);
             fields.add(fieldRef);
         }
         if (numberSchema.getExclusiveMaximum() != null &&
-                numberSchema.getExclusiveMaximum() &&
-                numberSchema.getMaximum() != null && BigDecimal.ZERO.compareTo(numberSchema.getMaximum()) != 0) {
+                numberSchema.getExclusiveMaximum() && numberSchema.getMaximum() != null) {
             String value = numberSchema.getMaximum().toString();
             String fieldRef = GeneratorConstants.EXCLUSIVE_MAX + GeneratorConstants.COLON +
                     (isInt ? numberSchema.getMaximum().intValue() : value);

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/TypeGeneratorUtils.java
@@ -179,8 +179,8 @@ public class TypeGeneratorUtils {
         MetadataNode metadataNode;
         boolean isConstraintSupport =
                 constraintNode != null && fieldSchema.getNullable() != null && fieldSchema.getNullable() ||
-                        (fieldSchema instanceof ComposedSchema && ((fieldSchema).getOneOf() != null ||
-                                (fieldSchema).getAnyOf() != null));
+                        (fieldSchema instanceof ComposedSchema && (fieldSchema.getOneOf() != null ||
+                                fieldSchema.getAnyOf() != null));
         boolean nullable = GeneratorMetaData.getInstance().isNullable();
         if (nullable) {
             constraintNode = null;

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/AllOfRecordTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/AllOfRecordTypeGenerator.java
@@ -159,7 +159,7 @@ public class AllOfRecordTypeGenerator extends RecordTypeGenerator {
      * ex: string|int...
      * @return
      */
-    private static RecordRestDescriptorNode getRestDescriptorNodeForAllOf(List<Schema<?>> restSchemas)
+    private RecordRestDescriptorNode getRestDescriptorNodeForAllOf(List<Schema<?>> restSchemas)
             throws BallerinaOpenApiException {
         TypeDescriptorNode unionType = getUnionType(restSchemas);
         return NodeFactory.createRecordRestDescriptorNode(unionType, createToken(ELLIPSIS_TOKEN),
@@ -173,7 +173,7 @@ public class AllOfRecordTypeGenerator extends RecordTypeGenerator {
      * @return Union type
      * @throws BallerinaOpenApiException when unsupported combination of schemas found
      */
-    private static TypeDescriptorNode getUnionType(List<Schema<?>> schemas) throws BallerinaOpenApiException {
+    private TypeDescriptorNode getUnionType(List<Schema<?>> schemas) throws BallerinaOpenApiException {
 
         // TODO: this has issue with generating union type with `string?|int?...
         // this will be tracked via https://github.com/ballerina-platform/openapi-tools/issues/810
@@ -181,6 +181,7 @@ public class AllOfRecordTypeGenerator extends RecordTypeGenerator {
         for (Schema schema : schemas) {
             TypeGenerator typeGenerator = getTypeGenerator(schema, null, null);
             TypeDescriptorNode typeDescriptorNode = typeGenerator.generateTypeDescriptorNode();
+            imports.addAll(typeGenerator.getImports());
             typeDescriptorNodes.add(typeDescriptorNode);
             // error for rest field unhandled constraint support
             if (GeneratorUtils.hasConstraints(schema)) {

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/ArrayTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/ArrayTypeGenerator.java
@@ -105,6 +105,7 @@ public class ArrayTypeGenerator extends TypeGenerator {
                     createIdentifierToken(typeName),
                     new ArrayList<>(),
                     typeAnnotations);
+            imports.addAll(typeGenerator.getImports());
             typeDefinitionNodeList.add(arrayItemWithConstraint);
         } else {
             typeGenerator = TypeGeneratorUtils.getTypeGenerator(items, typeName, null);
@@ -147,7 +148,7 @@ public class ArrayTypeGenerator extends TypeGenerator {
         arrayDimensions = arrayDimensions.add(arrayDimension);
         ArrayTypeDescriptorNode arrayTypeDescriptorNode = createArrayTypeDescriptorNode(typeDescriptorNode
                 , arrayDimensions);
-
+        imports.addAll(typeGenerator.getImports());
         return getNullableType(arraySchema, arrayTypeDescriptorNode);
     }
 }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
@@ -40,6 +40,7 @@ import io.swagger.v3.oas.models.media.NumberSchema;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -249,17 +250,18 @@ public class RecordTypeGenerator extends TypeGenerator {
             if (typeGenerator instanceof RecordTypeGenerator) {
                 fieldTypeName = TypeGeneratorUtils.getNullableType(fieldSchema, fieldTypeName);
             }
-            if (typeGenerator instanceof ArrayTypeGenerator &&
-                    !((ArrayTypeGenerator) typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-                typeDefinitionNodeList.addAll(((ArrayTypeGenerator) typeGenerator).getTypeDefinitionNodeList());
+            if (typeGenerator instanceof ArrayTypeGenerator && !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
+                typeDefinitionNodeList.addAll((typeGenerator).getTypeDefinitionNodeList());
             } else if (typeGenerator instanceof UnionTypeGenerator &&
-                    !((UnionTypeGenerator) typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-                List<TypeDefinitionNode> newConstraintNode =
-                        ((UnionTypeGenerator) typeGenerator).getTypeDefinitionNodeList();
+                    !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
+                List<TypeDefinitionNode> newConstraintNode = typeGenerator.getTypeDefinitionNodeList();
                 typeDefinitionNodeList.addAll(newConstraintNode);
             }
-            TypeGeneratorUtils.updateRecordFieldList(required, recordFieldList, field, fieldSchema, schemaDocNodes,
-                    fieldName, fieldTypeName);
+            ImmutablePair<List<Node>, Set<String>> fieldListWithImports =
+                    TypeGeneratorUtils.updateRecordFieldListWithImports(required, recordFieldList, field, fieldSchema,
+                            schemaDocNodes, fieldName, fieldTypeName);
+            recordFieldList = fieldListWithImports.getLeft();
+            imports.addAll(fieldListWithImports.getRight());
         }
         return recordFieldList;
     }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
@@ -177,7 +177,7 @@ public class RecordTypeGenerator extends TypeGenerator {
     /**
      * Creates reference rest node when additional property has reference.
      */
-    public static RecordRestDescriptorNode getRestDescriptorNodeForReference(Schema<?> additionalPropSchema)
+    public RecordRestDescriptorNode getRestDescriptorNodeForReference(Schema<?> additionalPropSchema)
             throws BallerinaOpenApiException {
         ReferencedTypeGenerator referencedTypeGenerator = new ReferencedTypeGenerator(additionalPropSchema, null);
         TypeDescriptorNode refNode = referencedTypeGenerator.generateTypeDescriptorNode();
@@ -250,13 +250,14 @@ public class RecordTypeGenerator extends TypeGenerator {
             if (typeGenerator instanceof RecordTypeGenerator) {
                 fieldTypeName = TypeGeneratorUtils.getNullableType(fieldSchema, fieldTypeName);
             }
-            if (typeGenerator instanceof ArrayTypeGenerator && !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
-                typeDefinitionNodeList.addAll((typeGenerator).getTypeDefinitionNodeList());
+            if (typeGenerator instanceof ArrayTypeGenerator && !typeGenerator.getTypeDefinitionNodeList().isEmpty()) {
+                typeDefinitionNodeList.addAll(typeGenerator.getTypeDefinitionNodeList());
             } else if (typeGenerator instanceof UnionTypeGenerator &&
-                    !(typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
+                    !typeGenerator.getTypeDefinitionNodeList().isEmpty()) {
                 List<TypeDefinitionNode> newConstraintNode = typeGenerator.getTypeDefinitionNodeList();
                 typeDefinitionNodeList.addAll(newConstraintNode);
             }
+            imports.addAll(typeGenerator.getImports());
             ImmutablePair<List<Node>, Set<String>> fieldListWithImports =
                     TypeGeneratorUtils.updateRecordFieldListWithImports(required, recordFieldList, field, fieldSchema,
                             schemaDocNodes, fieldName, fieldTypeName);

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/TypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/TypeGenerator.java
@@ -90,7 +90,7 @@ public abstract class TypeGenerator {
             String annotationRef = annotation.annotReference().toString();
             if (annotationRef.startsWith(CONSTRAINT) && !nullable) {
                 ImportDeclarationNode constraintImport = GeneratorUtils.getImportDeclarationNode(BALLERINA, CONSTRAINT);
-                //Here we are unable to add ImportDeclarationNode since newly generate node has different hashcode.
+                //Here we are unable to add ImportDeclarationNode since newly generated node has different hashcode.
                 imports.add(constraintImport.toSourceCode());
             }
         }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/TypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/TypeGenerator.java
@@ -20,15 +20,19 @@ package io.ballerina.openapi.core.generators.schema.ballerinatypegenerators;
 
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
 import io.ballerina.compiler.syntax.tree.IdentifierToken;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.MarkdownDocumentationNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
+import io.ballerina.openapi.core.GeneratorUtils;
 import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
+import io.ballerina.openapi.core.generators.schema.model.GeneratorMetaData;
 import io.swagger.v3.oas.models.media.Schema;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createNodeList;
@@ -39,6 +43,8 @@ import static io.ballerina.compiler.syntax.tree.NodeFactory.createTypeDefinition
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.PUBLIC_KEYWORD;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.TYPE_KEYWORD;
+import static io.ballerina.openapi.core.GeneratorConstants.BALLERINA;
+import static io.ballerina.openapi.core.GeneratorConstants.CONSTRAINT;
 
 /**
  * Abstract class for schema types.
@@ -50,6 +56,7 @@ public abstract class TypeGenerator {
     Schema schema;
     String typeName;
     final List<TypeDefinitionNode> typeDefinitionNodeList = new ArrayList<>();
+    final LinkedHashSet<String> imports = new LinkedHashSet<>();
 
     public TypeGenerator(Schema schema, String typeName) {
         this.schema = schema;
@@ -58,6 +65,10 @@ public abstract class TypeGenerator {
 
     public List<TypeDefinitionNode> getTypeDefinitionNodeList() {
         return typeDefinitionNodeList;
+    }
+
+    public LinkedHashSet<String> getImports() {
+        return imports;
     }
 
     /**
@@ -72,6 +83,17 @@ public abstract class TypeGenerator {
     public TypeDefinitionNode generateTypeDefinitionNode(IdentifierToken typeName, List<Node> schemaDoc,
                                                          List<AnnotationNode> typeAnnotations)
             throws BallerinaOpenApiException {
+
+        //Check the annotation for constraint support
+        boolean nullable = GeneratorMetaData.getInstance().isNullable();
+        for (AnnotationNode annotation : typeAnnotations) {
+            String annotationRef = annotation.annotReference().toString();
+            if (annotationRef.startsWith(CONSTRAINT) && !nullable) {
+                ImportDeclarationNode constraintImport = GeneratorUtils.getImportDeclarationNode(BALLERINA, CONSTRAINT);
+                //Here we are unable to add ImportDeclarationNode since newly generate node has different hashcode.
+                imports.add(constraintImport.toSourceCode());
+            }
+        }
 
         MarkdownDocumentationNode documentationNode = createMarkdownDocumentationNode(createNodeList(schemaDoc));
         MetadataNode metadataNode = createMetadataNode(documentationNode, createNodeList(typeAnnotations));

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/UnionTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/UnionTypeGenerator.java
@@ -93,13 +93,13 @@ public class UnionTypeGenerator extends TypeGenerator {
         for (Schema<?> schema : schemas) {
             TypeGenerator typeGenerator = getTypeGenerator(schema, typeName, null);
             TypeDescriptorNode typeDescNode = typeGenerator.generateTypeDescriptorNode();
+            imports.addAll(typeGenerator.getImports());
             if (typeDescNode instanceof OptionalTypeDescriptorNode && GeneratorMetaData.getInstance().isNullable()) {
                 Node internalTypeDesc = ((OptionalTypeDescriptorNode) typeDescNode).typeDescriptor();
                 typeDescNode = (TypeDescriptorNode) internalTypeDesc;
             }
             typeDescriptorNodes.add(typeDescNode);
-            if (typeGenerator instanceof ArrayTypeGenerator &&
-                    !((ArrayTypeGenerator) typeGenerator).getTypeDefinitionNodeList().isEmpty()) {
+            if (typeGenerator instanceof ArrayTypeGenerator && !typeGenerator.getTypeDefinitionNodeList().isEmpty()) {
                 typeDefinitionNodeList.addAll(typeGenerator.getTypeDefinitionNodeList());
             }
         }


### PR DESCRIPTION
## Purpose
> Fix #https://github.com/ballerina-platform/openapi-tools/issues/1291
Tested below connectors  with the command `bal openapi -i <yaml> --mode client`: 
This need to generate constraint import since now it is support for the integer and numbers to have zero as value
- [powertoolsdeveloper.collections](https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/powertoolsdeveloper.collections)
- [powertoolsdeveloper.data](https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/powertoolsdeveloper.data)
- [powertoolsdeveloper.datetime](https://github.com/ballerina-platform/openapi-connectors/blob/main/openapi/powertoolsdeveloper.datetime/openapi.yml)
- [powertoolsdeveloper.files](https://github.com/ballerina-platform/openapi-connectors/blob/main/openapi/powertoolsdeveloper.files/openapi.yml)
- [powertoolsdeveloper.finance](https://github.com/ballerina-platform/openapi-connectors/blob/main/openapi/powertoolsdeveloper.finance/openapi.yml)
- [powertoolsdeveloper.math](https://github.com/ballerina-platform/openapi-connectors/blob/main/openapi/powertoolsdeveloper.math/openapi.yml)
- [powertoolsdeveloper.text](https://github.com/ballerina-platform/openapi-connectors/blob/main/openapi/powertoolsdeveloper.text/openapi.yml)
- [powertoolsdeveloper.weather](https://github.com/ballerina-platform/openapi-connectors/blob/main/openapi/powertoolsdeveloper.weather/openapi.yml)

These connectors are not included in the constraint import since their swagger includes the wrong constraint https://github.com/ballerina-platform/openapi-tools/issues/1291#issuecomment-1495841381  
- [sinch.verification](https://github.com/ballerina-platform/openapi-connectors/blob/main/openapi/sinch.verification/openapi.yaml)
- [xero.bankfeeds](https://github.com/ballerina-platform/openapi-connectors/blob/main/openapi/xero.bankfeeds/openapi.yml#L627)
- [xero.Project](https://github.com/ballerina-platform/openapi-connectors/blob/main/openapi/xero.projects/openapi.yaml#L1469)

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.