### PR TITLE
Add support for query params with ref schema in service generation

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ParameterGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ParameterGeneratorTest.java
@@ -184,18 +184,4 @@ public class ParameterGeneratorTest {
         syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("keywords.bal", syntaxTree);
     }
-
-    @Test(description = "Tests when query parameter(s) having a referenced schema")
-    public void generateParamsWithRefSchema() throws IOException, BallerinaOpenApiException {
-        Path definitionPath = RES_DIR.resolve("swagger/parameters_with_ref_schema.yaml");
-        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
-        OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
-                .withOpenAPI(openAPI)
-                .withFilters(filter)
-                .build();
-        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
-        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
-        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
-                "parameters_with_ref_schema.bal", syntaxTree);
-    }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ParameterGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ParameterGeneratorTest.java
@@ -158,8 +158,9 @@ public class ParameterGeneratorTest {
 
     @Test(description = "Generate functionDefinitionNode for paramter for content instead of schema",
             expectedExceptions = BallerinaOpenApiException.class,
-            expectedExceptionsMessageRegExp = "Query parameters with type 'content' can not be mapped to the " +
-                    "Ballerina query.*")
+            expectedExceptionsMessageRegExp = "Type 'content' is not a valid query parameter type in Ballerina. " +
+                    "The supported types are string, int, float, boolean, decimal, " +
+                    "array types of the aforementioned types and map<json>.")
     public void generateParameterHasContent() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/parameterTypehasContent.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ParameterGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ParameterGeneratorTest.java
@@ -184,4 +184,18 @@ public class ParameterGeneratorTest {
         syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("keywords.bal", syntaxTree);
     }
+
+    @Test(description = "Tests when query parameter(s) having a referenced schema")
+    public void generateParamsWithRefSchema() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/parameters_with_ref_schema.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
+                .withOpenAPI(openAPI)
+                .withFilters(filter)
+                .build();
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "parameters_with_ref_schema.bal", syntaxTree);
+    }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/QueryParameterTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/QueryParameterTests.java
@@ -290,8 +290,9 @@ public class QueryParameterTests {
 
     @Test(description = "17. Query parameter(s) having a referenced schema of unsupported type",
             expectedExceptions = BallerinaOpenApiException.class,
-            expectedExceptionsMessageRegExp = "Query parameters with type 'Room' " +
-                    "can not be mapped to the Ballerina query parameters.")
+            expectedExceptionsMessageRegExp = "Type 'Room' is not a valid query parameter type in Ballerina. " +
+            "The supported types are string, int, float, boolean, decimal, array types of the aforementioned " +
+            "types and map<json>.")
     public void generateParamsWithInvalidRefSchema() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/parameters_with_invalid_ref_schema.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
@@ -305,8 +306,9 @@ public class QueryParameterTests {
 
     @Test(description = "18. Query parameter(s) having a referenced schema of array of unsupported type",
             expectedExceptions = BallerinaOpenApiException.class,
-            expectedExceptionsMessageRegExp = "Only array types of string, int, float, boolean, and decimal are " +
-                    "allowed to be used as query parameters in Ballerina.")
+            expectedExceptionsMessageRegExp = "Type 'Room' is not a valid query parameter type in Ballerina. " +
+                    "The supported types are string, int, float, boolean, decimal, array types of the aforementioned " +
+                    "types and map<json>.")
     public void generateParamsWithInvalidArrayRefSchema() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/parameter_with_ref_array_invalid_schema.yaml");
         OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/QueryParameterTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/QueryParameterTests.java
@@ -19,6 +19,7 @@ package io.ballerina.openapi.generators.service;
 
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.openapi.cmd.CmdUtils;
+import io.ballerina.openapi.core.GeneratorUtils;
 import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
 import io.ballerina.openapi.core.generators.service.BallerinaServiceGenerator;
 import io.ballerina.openapi.core.generators.service.model.OASServiceMetadata;
@@ -259,7 +260,7 @@ public class QueryParameterTests {
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("query/query_14.bal", syntaxTree);
     }
 
-    @Test(description = "14.Optional query parameter")
+    @Test(description = "15. Optional query parameter")
     public void optionalQueryParameter() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/query/query_15.yaml");
         OpenAPI openAPI = CmdUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
@@ -270,5 +271,50 @@ public class QueryParameterTests {
         BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
         syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree("query/query_15.bal", syntaxTree);
+    }
+
+
+    @Test(description = "16. Query parameter(s) having a referenced schema")
+    public void generateParamsWithRefSchema() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/parameters_with_ref_schema.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
+                .withOpenAPI(openAPI)
+                .withFilters(filter)
+                .build();
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "parameters_with_ref_schema.bal", syntaxTree);
+    }
+
+    @Test(description = "17. Query parameter(s) having a referenced schema of unsupported type",
+            expectedExceptions = BallerinaOpenApiException.class,
+            expectedExceptionsMessageRegExp = "Query parameters with type 'Room' " +
+                    "can not be mapped to the Ballerina query parameters.")
+    public void generateParamsWithInvalidRefSchema() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/parameters_with_invalid_ref_schema.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
+                .withOpenAPI(openAPI)
+                .withFilters(filter)
+                .build();
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+    }
+
+    @Test(description = "18. Query parameter(s) having a referenced schema of array of unsupported type",
+            expectedExceptions = BallerinaOpenApiException.class,
+            expectedExceptionsMessageRegExp = "Only array types of string, int, float, boolean, and decimal are " +
+                    "allowed to be used as query parameters in Ballerina.")
+    public void generateParamsWithInvalidArrayRefSchema() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/parameter_with_ref_array_invalid_schema.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
+                .withOpenAPI(openAPI)
+                .withFilters(filter)
+                .build();
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/parameters_with_ref_schema.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/parameters_with_ref_schema.bal
@@ -5,6 +5,7 @@ listener http:Listener ep0 = new (443, config = {host: "petstore3.swagger.io"});
 service /api/v3 on ep0 {
     # List all the meetings that were scheduled
     #
+    # + organizer - Meeting organizer
     # + location - Meeting location
     # + types - Meeting Types
     # + audience - Meeting audience
@@ -12,6 +13,6 @@ service /api/v3 on ep0 {
     # + return - returns can be any of following types
     # MeetingList (HTTP Status Code:200. List of meetings returned.)
     # http:NotFound (HTTP Status Code:404 User ID not found. Error Code:1001, User not exist or not belong to this account.)
-    resource function get users/meetings(MeetingTypes[] types, Audience? audience, TimeZone? timezone, RoomNo location = "R5") returns MeetingList|http:NotFound {
+    resource function get users/meetings(Organizer organizer, MeetingTypes[] types, Audience? audience, TimeZone? timezone, RoomNo location = "R5") returns MeetingList|http:NotFound {
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/parameters_with_ref_schema.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/parameters_with_ref_schema.bal
@@ -1,0 +1,17 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (443, config = {host: "petstore3.swagger.io"});
+
+service /api/v3 on ep0 {
+    # List all the meetings that were scheduled
+    #
+    # + location - Meeting location
+    # + types - Meeting Types
+    # + audience - Meeting audience
+    # + timezone - Meeting timezone
+    # + return - returns can be any of following types
+    # MeetingList (HTTP Status Code:200. List of meetings returned.)
+    # http:NotFound (HTTP Status Code:404 User ID not found. Error Code:1001, User not exist or not belong to this account.)
+    resource function get users/meetings(MeetingTypes[] types, Audience? audience, TimeZone? timezone, RoomNo location = "R5") returns MeetingList|http:NotFound {
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/ballerina/parameters_with_ref_schema.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/parameters_with_ref_schema.bal
@@ -9,9 +9,10 @@ service /api/v3 on ep0 {
     # + location - Meeting location
     # + types - Meeting Types
     # + audience - Meeting audience
+    # + remarks - Meeting remarks
     # + return - returns can be any of following types
     # MeetingList (HTTP Status Code:200. List of meetings returned.)
     # http:NotFound (HTTP Status Code:404 User ID not found. Error Code:1001, User not exist or not belong to this account.)
-    resource function get users/meetings(Organizer organizer, MeetingTypes[] types, Audience? audience, RoomNo location = "R5") returns MeetingList|http:NotFound {
+    resource function get users/meetings(Organizer organizer, MeetingTypes[] types, Audience? audience, map<json> remarks, RoomNo location = "R5") returns MeetingList|http:NotFound {
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/ballerina/parameters_with_ref_schema.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/parameters_with_ref_schema.bal
@@ -9,10 +9,9 @@ service /api/v3 on ep0 {
     # + location - Meeting location
     # + types - Meeting Types
     # + audience - Meeting audience
-    # + timezone - Meeting timezone
     # + return - returns can be any of following types
     # MeetingList (HTTP Status Code:200. List of meetings returned.)
     # http:NotFound (HTTP Status Code:404 User ID not found. Error Code:1001, User not exist or not belong to this account.)
-    resource function get users/meetings(Organizer organizer, MeetingTypes[] types, Audience? audience, TimeZone? timezone, RoomNo location = "R5") returns MeetingList|http:NotFound {
+    resource function get users/meetings(Organizer organizer, MeetingTypes[] types, Audience? audience, RoomNo location = "R5") returns MeetingList|http:NotFound {
     }
 }

--- a/openapi-cli/src/test/resources/generators/service/swagger/parameter_with_ref_array_invalid_schema.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/parameter_with_ref_array_invalid_schema.yaml
@@ -1,0 +1,90 @@
+openapi: 3.0.3
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.11
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore3.swagger.io/api/v3
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
+paths:
+  /users/meetings:
+    get:
+      description: List all the meetings that were scheduled
+      operationId: listMeetings
+      parameters:
+        - description: "Meeting location"
+          in: query
+          name: location
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Room'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeetingList'
+          description: "HTTP Status Code:200. List of meetings returned."
+components:
+  parameters:
+    responseFormat:
+      description: The response format you would like
+      in: query
+      name: format
+      schema:
+        enum:
+          - json
+          - jsonp
+          - msgpack
+          - html
+        type: string
+  schemas:
+    Room:
+      type: object
+      properties:
+        roomNo:
+          type: string
+        seats:
+          type: integer
+    MeetingList:
+      description: List of meetings
+      title: Group List
+      type: object
+      properties:
+        meetings:
+          description: List of Meeting objects.
+          items:
+            $ref: '#/components/schemas/MeetingObject'
+          type: array
+    MeetingObject:
+      properties:
+        topic:
+          description: Meeting topic.
+          type: string
+        type:
+          description: "Meeting Type: 1 - Instant meeting. 2 - Scheduled meeting. 3 - Recurring meeting with no fixed time. 8 - Recurring meeting with fixed time."
+          type: integer
+      type: object

--- a/openapi-cli/src/test/resources/generators/service/swagger/parameters_with_invalid_ref_schema.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/parameters_with_invalid_ref_schema.yaml
@@ -1,0 +1,88 @@
+openapi: 3.0.3
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.11
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore3.swagger.io/api/v3
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
+paths:
+  /users/meetings:
+    get:
+      description: List all the meetings that were scheduled
+      operationId: listMeetings
+      parameters:
+        - description: "Meeting location"
+          in: query
+          name: location
+          schema:
+            $ref: '#/components/schemas/Room'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeetingList'
+          description: "HTTP Status Code:200. List of meetings returned."
+components:
+  parameters:
+    responseFormat:
+      description: The response format you would like
+      in: query
+      name: format
+      schema:
+        enum:
+          - json
+          - jsonp
+          - msgpack
+          - html
+        type: string
+  schemas:
+    Room:
+      type: object
+      properties:
+        roomNo:
+          type: string
+        seats:
+          type: integer
+    MeetingList:
+      description: List of meetings
+      title: Group List
+      type: object
+      properties:
+        meetings:
+          description: List of Meeting objects.
+          items:
+            $ref: '#/components/schemas/MeetingObject'
+          type: array
+    MeetingObject:
+      properties:
+        topic:
+          description: Meeting topic.
+          type: string
+        type:
+          description: "Meeting Type: 1 - Instant meeting. 2 - Scheduled meeting. 3 - Recurring meeting with no fixed time. 8 - Recurring meeting with fixed time."
+          type: integer
+      type: object

--- a/openapi-cli/src/test/resources/generators/service/swagger/parameters_with_ref_schema.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/parameters_with_ref_schema.yaml
@@ -67,6 +67,14 @@ paths:
           name: audience
           schema:
             $ref: '#/components/schemas/Audience'
+        - description: "Meeting remarks"
+          in: query
+          name: remarks
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Remarks'
 #        - description: "Meeting timezone"
 #          in: query
 #          name: timezone
@@ -103,6 +111,9 @@ components:
       enum:
         - "students"
         - "professionals"
+    Remarks:
+      type: object
+      additionalProperties: true
     # not supported currently by the http module
 #    TimeZone:
 #      type: string

--- a/openapi-cli/src/test/resources/generators/service/swagger/parameters_with_ref_schema.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/parameters_with_ref_schema.yaml
@@ -43,6 +43,12 @@ paths:
       description: List all the meetings that were scheduled
       operationId: listMeetings
       parameters:
+        - description: "Meeting organizer"
+          in: query
+          name: organizer
+          required: true
+          schema:
+            $ref: '#/components/schemas/Organizer'
         - description: "Meeting location"
           in: query
           name: location
@@ -91,6 +97,8 @@ components:
           - html
         type: string
   schemas:
+    Organizer:
+      type: string
     Audience:
       enum:
         - "students"

--- a/openapi-cli/src/test/resources/generators/service/swagger/parameters_with_ref_schema.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/parameters_with_ref_schema.yaml
@@ -1,0 +1,134 @@
+openapi: 3.0.3
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
+    Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+    You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+    That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+
+    _If you're looking for the Swagger 2.0/OAS 2.0 version of Petstore, then click [here](https://editor.swagger.io/?url=https://petstore.swagger.io/v2/swagger.yaml). Alternatively, you can load via the `Edit > Load Petstore OAS 2.0` menu option!_
+    
+    Some useful links:
+    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.11
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore3.swagger.io/api/v3
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
+paths:
+  /users/meetings:
+    get:
+      description: List all the meetings that were scheduled
+      operationId: listMeetings
+      parameters:
+        - description: "Meeting location"
+          in: query
+          name: location
+          schema:
+            $ref: '#/components/schemas/RoomNo'
+        - description: "Meeting Types"
+          in: query
+          required: true
+          name: types
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/MeetingTypes'
+        - description: "Meeting audience"
+          in: query
+          name: audience
+          schema:
+            $ref: '#/components/schemas/Audience'
+        - description: "Meeting timezone"
+          in: query
+          name: timezone
+          schema:
+            $ref: '#/components/schemas/TimeZone'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeetingList'
+          description: "HTTP Status Code:200. List of meetings returned."
+        "404":
+          description: "HTTP Status Code:404 User ID not found. Error Code:1001, User not exist or not belong to this account."
+      tags:
+        - Meetings
+components:
+  parameters:
+    responseFormat:
+      description: The response format you would like
+      in: query
+      name: format
+      schema:
+        enum:
+          - json
+          - jsonp
+          - msgpack
+          - html
+        type: string
+  schemas:
+    Audience:
+      enum:
+        - "students"
+        - "professionals"
+    #    # not supported currently by the http module
+    TimeZone:
+      type: string
+      nullable: true
+    RoomNo:
+      default: "R5"
+      enum:
+        - R1
+        - R3
+        - R5
+      type: string
+    MeetingTypes:
+      type: string
+      default: live
+      enum:
+        - "scheduled"
+        - "live"
+        - "upcoming"
+    MeetingList:
+      description: List of meetings
+      title: Group List
+      type: object
+      properties:
+        meetings:
+          description: List of Meeting objects.
+          items:
+            $ref: '#/components/schemas/MeetingObject'
+          type: array
+    MeetingObject:
+      properties:
+        topic:
+          description: Meeting topic.
+          type: string
+        type:
+          description: "Meeting Type: 1 - Instant meeting. 2 - Scheduled meeting. 3 - Recurring meeting with no fixed time. 8 - Recurring meeting with fixed time."
+          type: integer
+      type: object

--- a/openapi-cli/src/test/resources/generators/service/swagger/parameters_with_ref_schema.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/parameters_with_ref_schema.yaml
@@ -67,11 +67,11 @@ paths:
           name: audience
           schema:
             $ref: '#/components/schemas/Audience'
-        - description: "Meeting timezone"
-          in: query
-          name: timezone
-          schema:
-            $ref: '#/components/schemas/TimeZone'
+#        - description: "Meeting timezone"
+#          in: query
+#          name: timezone
+#          schema:
+#            $ref: '#/components/schemas/TimeZone'
       responses:
         "200":
           content:
@@ -103,10 +103,10 @@ components:
       enum:
         - "students"
         - "professionals"
-    #    # not supported currently by the http module
-    TimeZone:
-      type: string
-      nullable: true
+    # not supported currently by the http module
+#    TimeZone:
+#      type: string
+#      nullable: true
     RoomNo:
       default: "R5"
       enum:

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/BallerinaServiceGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/BallerinaServiceGenerator.java
@@ -275,7 +275,7 @@ public class BallerinaServiceGenerator {
         IdentifierToken functionName = createIdentifierToken(operation.getKey().name()
                 .toLowerCase(Locale.ENGLISH), GeneratorUtils.SINGLE_WS_MINUTIAE, GeneratorUtils.SINGLE_WS_MINUTIAE);
         NodeList<Node> relativeResourcePath = createNodeList(pathNodes);
-        ParametersGenerator parametersGenerator = new ParametersGenerator(false);
+        ParametersGenerator parametersGenerator = new ParametersGenerator(false, openAPI);
         parametersGenerator.generateResourcesInputs(operation, resourceFunctionDocs);
         List<Node> params = new ArrayList<>(parametersGenerator.getRequiredParams());
 

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ParametersGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ParametersGenerator.java
@@ -400,22 +400,23 @@ public class ParametersGenerator {
 
     private Node handleReferencedQueryParameter(Parameter parameter, String refTypeName, Schema<?> refSchema,
                                                 NodeList<AnnotationNode> annotations, IdentifierToken parameterName) {
-        BuiltinSimpleNameReferenceNode rTypeName = createBuiltinSimpleNameReferenceNode(null,
+        BuiltinSimpleNameReferenceNode refTypeNameNode = createBuiltinSimpleNameReferenceNode(null,
                 createIdentifierToken(refTypeName));
         if (refSchema.getDefault() != null) {
             String defaultValue = refSchema.getType().equals(GeneratorConstants.STRING) ?
                     String.format("\"%s\"", refSchema.getDefault().toString()) : refSchema.getDefault().toString();
-            return createDefaultableParameterNode(annotations, rTypeName, parameterName,
+            return createDefaultableParameterNode(annotations, refTypeNameNode, parameterName,
                     createToken(SyntaxKind.EQUAL_TOKEN),
                     createSimpleNameReferenceNode(createIdentifierToken(defaultValue)));
         } else if (parameter.getRequired() && (refSchema.getNullable() == null || (!refSchema.getNullable()))) {
-            return createRequiredParameterNode(annotations, rTypeName, parameterName);
+            return createRequiredParameterNode(annotations, refTypeNameNode, parameterName);
         } else {
-            OptionalTypeDescriptorNode optionalNode = createOptionalTypeDescriptorNode(rTypeName,
+            OptionalTypeDescriptorNode optionalNode = createOptionalTypeDescriptorNode(refTypeNameNode,
                     createToken(SyntaxKind.QUESTION_MARK_TOKEN));
             return createRequiredParameterNode(annotations, optionalNode, parameterName);
         }
     }
+
     private Node handleRequiredQueryParameter(Schema<?> schema, NodeList<AnnotationNode> annotations,
                                               IdentifierToken parameterName) throws BallerinaOpenApiException {
 
@@ -507,8 +508,8 @@ public class ParametersGenerator {
             if (queryParamSupportedTypes.contains(refSchema.getType())) {
                 arrayName = type;
             } else {
-                ServiceDiagnosticMessages messages = ServiceDiagnosticMessages.OAS_SERVICE_108;
-                throw new BallerinaOpenApiException(messages.getDescription());
+                ServiceDiagnosticMessages messages = ServiceDiagnosticMessages.OAS_SERVICE_102;
+                throw new BallerinaOpenApiException(String.format(messages.getDescription(), type));
             }
         } else {
             arrayName = GeneratorUtils.convertOpenAPITypeToBallerina(items.getType().toLowerCase(

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ParametersGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ParametersGenerator.java
@@ -137,7 +137,8 @@ public class ParametersGenerator {
                     }
                 } else if (parameter.getIn().trim().equals(GeneratorConstants.QUERY)) {
                     if (parameter.getRequired() != null && parameter.getRequired() &&
-                            (parameter.getSchema().getNullable() != null && parameter.getSchema().getNullable())) {
+                            (parameter.getSchema() != null && parameter.getSchema().getNullable() != null &&
+                                    parameter.getSchema().getNullable())) {
                         isNullableRequired = true;
                     }
                     // type  BasicType boolean|int|float|decimal|string ;
@@ -328,8 +329,17 @@ public class ParametersGenerator {
                                                               Map.Entry<String, MediaType> mediaTypeEntry)
             throws BallerinaOpenApiException {
 
+        Schema<?> parameterSchema;
+        if (mediaTypeEntry.getValue().getSchema() != null &&
+                mediaTypeEntry.getValue().getSchema().get$ref() != null) {
+            String type = getValidName(extractReferenceType(mediaTypeEntry.getValue().getSchema().get$ref()), true);
+            parameterSchema = (Schema<?>) openAPI.getComponents().getSchemas().get(type.trim());
+        } else {
+            parameterSchema = mediaTypeEntry.getValue().getSchema();
+        }
+
         if (mediaTypeEntry.getKey().equals(GeneratorConstants.APPLICATION_JSON) &&
-                mediaTypeEntry.getValue().getSchema() instanceof MapSchema) {
+                parameterSchema instanceof MapSchema) {
             if (parameter.getRequired()) {
                 BuiltinSimpleNameReferenceNode rTypeName = createBuiltinSimpleNameReferenceNode(null,
                         createIdentifierToken(GeneratorConstants.MAP_JSON));

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceDiagnosticMessages.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceDiagnosticMessages.java
@@ -47,7 +47,9 @@ public enum ServiceDiagnosticMessages {
             "Header '%s' with no header type can not be mapped to the Ballerina headers.",
             DiagnosticSeverity.ERROR),
     OAS_SERVICE_107("OAS_SERVICE_107", "HTTP status code '%s' is not supported in Ballerina.",
-            DiagnosticSeverity.ERROR);
+            DiagnosticSeverity.ERROR),
+    OAS_SERVICE_108("OAS_SERVICE_108", "Only array types of string, int, float, boolean, " +
+            "and decimal are allowed to be used in query parameters in Ballerina.", DiagnosticSeverity.ERROR);
 
     private final String code;
     private final String description;

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceDiagnosticMessages.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceDiagnosticMessages.java
@@ -33,7 +33,9 @@ public enum ServiceDiagnosticMessages {
             "Query parameters with no array item type can not be mapped to Ballerina resource" +
                     " query parameters.", DiagnosticSeverity.ERROR),
     OAS_SERVICE_102("OAS_SERVICE_102",
-            "Query parameters with type '%s' can not be mapped to the Ballerina query parameters.",
+            "Type '%s' is not a valid query parameter type in Ballerina. " +
+                    "The supported types are string, int, float, boolean, decimal, array types of the aforementioned " +
+                    "types and map<json>.",
             DiagnosticSeverity.ERROR),
     OAS_SERVICE_103("OAS_SERVICE_103", "Header '%s' with array item type: '%s' is not " +
             "supported in Ballerina.", DiagnosticSeverity.ERROR),
@@ -47,9 +49,7 @@ public enum ServiceDiagnosticMessages {
             "Header '%s' with no header type can not be mapped to the Ballerina headers.",
             DiagnosticSeverity.ERROR),
     OAS_SERVICE_107("OAS_SERVICE_107", "HTTP status code '%s' is not supported in Ballerina.",
-            DiagnosticSeverity.ERROR),
-    OAS_SERVICE_108("OAS_SERVICE_108", "Only array types of string, int, float, boolean, " +
-            "and decimal are allowed to be used as query parameters in Ballerina.", DiagnosticSeverity.ERROR);
+            DiagnosticSeverity.ERROR);
 
     private final String code;
     private final String description;

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceDiagnosticMessages.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceDiagnosticMessages.java
@@ -49,7 +49,7 @@ public enum ServiceDiagnosticMessages {
     OAS_SERVICE_107("OAS_SERVICE_107", "HTTP status code '%s' is not supported in Ballerina.",
             DiagnosticSeverity.ERROR),
     OAS_SERVICE_108("OAS_SERVICE_108", "Only array types of string, int, float, boolean, " +
-            "and decimal are allowed to be used in query parameters in Ballerina.", DiagnosticSeverity.ERROR);
+            "and decimal are allowed to be used as query parameters in Ballerina.", DiagnosticSeverity.ERROR);
 
     private final String code;
     private final String description;


### PR DESCRIPTION
## Purpose
> $subject
Resolves https://github.com/ballerina-platform/openapi-tools/issues/1331

## Goals

Example:

```yaml
paths:
  /users/meetings:
    get:
      description: List all the meetings that were scheduled
      operationId: listMeetings
      parameters:
        - description: "Meeting location"
          in: query
          name: location
          schema:
            $ref: '#/components/schemas/RoomNo'
      responses:
        "200":
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/MeetingList'
          description: "HTTP Status Code:200. List of meetings returned."
components:
  schemas:
    RoomNo:
      enum:
        - R1
        - R3
        - R5
      type: string
      nullable: true
```

**Proposed generation**

```bal
public type RoomNo string;

     resource function get users/meetings(RoomNo location) {
     }

```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11