### PR TITLE
[master] Fix the outdated tests in type generation of compund objects

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/AllOfResponsesTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/AllOfResponsesTests.java
@@ -46,7 +46,7 @@ public class AllOfResponsesTests {
         FunctionReturnTypeGenerator functionReturnType = new FunctionReturnTypeGenerator(response,
                 ballerinaSchemaGenerator, new ArrayList<>());
         Assert.assertEquals(functionReturnType.getReturnType(response.getPaths().get("/products").getGet(),
-                true), "CompoundTestsProductsResponse|error");
+                true), "Inline_response_200|error");
     }
     @Test(description = "Tests for returnType")
     public void getReturnTypeForAllOf() throws IOException, BallerinaOpenApiException {
@@ -55,7 +55,7 @@ public class AllOfResponsesTests {
         FunctionReturnTypeGenerator functionReturnType = new FunctionReturnTypeGenerator(response,
                 ballerinaSchemaGenerator, new ArrayList<>());
         Assert.assertEquals(functionReturnType.getReturnType(response.getPaths().get("/users/{userId}/meetings")
-                        .getPost(), true), "CompoundCreateMeetingResponse|error");
+                        .getPost(), true), "Inline_response_201|error");
     }
     @Test(description = "Tests for the object response without property")
     public void getReturnTypeForObjectSchema() throws IOException, BallerinaOpenApiException {
@@ -80,7 +80,7 @@ public class AllOfResponsesTests {
 
         String returnType = functionReturnType.getReturnType(response.getPaths().get("/products").getGet(),
                 true);
-        Assert.assertEquals(returnType, "TestsProductsResponse|error");
+        Assert.assertEquals(returnType, "Inline_response_200|error");
     }
 
     @Test(description = "Tests for the object response without property and without additional properties")
@@ -106,7 +106,7 @@ public class AllOfResponsesTests {
 
         String returnType = functionReturnType.getReturnType(response.getPaths().get("/products").getGet(),
                 true);
-        Assert.assertEquals(returnType, "TestsProductsResponse|error");
+        Assert.assertEquals(returnType, "Inline_response_200|error");
     }
     // 1. nested allof
     // 2. allof with reference

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureReturnTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureReturnTypeTests.java
@@ -74,7 +74,7 @@ public class FunctionSignatureReturnTypeTests {
                 new BallerinaTypesGenerator(array), new ArrayList<>());
         String returnType = functionReturnType.getReturnType(array.getPaths().get("/products").getGet(),
                 true);
-        Assert.assertEquals(returnType, "TestsProductsResponse|error");
+        Assert.assertEquals(returnType, "Inline_response_200|error");
     }
 
     @Test(description = "Tests for the object response without property and without additional properties")
@@ -96,7 +96,7 @@ public class FunctionSignatureReturnTypeTests {
                 new BallerinaTypesGenerator(array), new ArrayList<>());
         String returnType = functionReturnType.getReturnType(array.getPaths().get("/products").getGet(),
                 true);
-        Assert.assertEquals(returnType, "TestsProductsResponse|error");
+        Assert.assertEquals(returnType, "Inline_response_200|error");
     }
 
     @Test(description = "Tests for the response with no schema")

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/OneOfResponsesTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/OneOfResponsesTests.java
@@ -46,7 +46,7 @@ public class OneOfResponsesTests {
         FunctionReturnTypeGenerator functionReturnType = new FunctionReturnTypeGenerator(response,
                 ballerinaSchemaGenerator,  new ArrayList<>());
         Assert.assertEquals(functionReturnType.getReturnType(response.getPaths().get("/pet").getGet(),
-                true), "ChannelDetails[]|string[]|error");
+                true), "Inline_response_2XX|error");
     }
 
     @Test(description = "Tests for returnType when response has array oneOf when it has function body")
@@ -56,6 +56,6 @@ public class OneOfResponsesTests {
         FunctionReturnTypeGenerator functionReturnType = new FunctionReturnTypeGenerator(response,
                 ballerinaSchemaGenerator, new ArrayList<>());
         Assert.assertEquals(functionReturnType.getReturnType(response.getPaths().get("/pet").getGet(),
-                false), "OneOfOperationId01Response|error");
+                false), "Inline_response_2XX|error");
     }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/common/TestUtils.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/common/TestUtils.java
@@ -21,6 +21,7 @@ package io.ballerina.openapi.generators.common;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
+import io.ballerina.openapi.cmd.CmdUtils;
 import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
 import io.ballerina.openapi.core.generators.client.BallerinaClientGenerator;
 import io.ballerina.openapi.core.generators.schema.BallerinaTypesGenerator;
@@ -33,8 +34,6 @@ import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.directory.ProjectLoader;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.parser.OpenAPIV3Parser;
-import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.ballerinalang.formatter.core.Formatter;
 import org.ballerinalang.formatter.core.FormatterException;
 import org.testng.Assert;
@@ -148,9 +147,7 @@ public class TestUtils {
     }
 
     public static OpenAPI getOpenAPI(Path definitionPath) throws IOException, BallerinaOpenApiException {
-        String openAPIFileContent = Files.readString(definitionPath);
-        SwaggerParseResult parseResult = new OpenAPIV3Parser().readContents(openAPIFileContent);
-        return parseResult.getOpenAPI();
+        return CmdUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
     }
 
     public static String getStringFromGivenBalFile(Path expectedServiceFile, String s) throws IOException {


### PR DESCRIPTION
## Purpose
> $subject
We are not utilizing the swagger.v3 OpenAPI parser's flatten to structure to simplify the nested and complex data structure in to seperate component schemas. The tests updated here were not using the flattened OpenAPI for generation, which generated types that are not generating when using the tool. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11
