### PR TITLE
[1.5.x] Handle unsupported data type formats 

### DIFF
--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/api2pdf.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/api2pdf.bal
@@ -163,11 +163,11 @@ public isolated client class Client {
     # + height - Height of the barcode generated image
     # + width - Width of the barcode generated image
     # + return - An image of the generated barcode or QR code
-    remote isolated function zebraGET(string format, string value, boolean? showlabel = (), int? height = (), int? width = ()) returns string|error {
+    remote isolated function zebraGET(string format, string value, boolean? showlabel = (), int? height = (), int? width = ()) returns byte[]|error {
         string resourcePath = string `/zebra`;
         map<anydata> queryParam = {"format": format, "value": value, "showlabel": showlabel, "height": height, "width": width, "apikey": self.apiKeyConfig.apikey};
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
-        string response = check self.clientEp-> get(resourcePath);
+        byte[] response = check self.clientEp-> get(resourcePath);
         return response;
     }
 }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -265,7 +265,7 @@ public class GeneratorUtils {
                 if (parameter.getSchema().get$ref() != null) {
                     paramType = getValidName(extractReferenceType(parameter.getSchema().get$ref()), true);
                 } else {
-                    paramType = convertOpenAPITypeToBallerina(parameter.getSchema().getType());
+                    paramType = convertOpenAPITypeToBallerina(parameter.getSchema());
                 }
 
                 // TypeDescriptor
@@ -305,25 +305,44 @@ public class GeneratorUtils {
     }
 
     /**
-     * Method for convert openApi type to ballerina type.
+     * Method for convert openApi type of format to ballerina type.
      *
-     * @param type OpenApi parameter types
+     * @param schema OpenApi schema
      * @return ballerina type
      */
-    public static String convertOpenAPITypeToBallerina(String type) throws BallerinaOpenApiException {
-        if (GeneratorConstants.TYPE_MAP.containsKey(type)) {
-            return GeneratorConstants.TYPE_MAP.get(type);
-        } else {
-            throw new BallerinaOpenApiException("Unsupported OAS data type `" + type + "`");
-        }
-    }
-
     public static String convertOpenAPITypeToBallerina(Schema<?> schema) throws BallerinaOpenApiException {
         String type = schema.getType().toLowerCase(Locale.ENGLISH).trim();
         if ((INTEGER.equals(type) || NUMBER.equals(type) || STRING.equals(type)) && schema.getFormat() != null) {
-            return convertOpenAPITypeFormatToBallerina(convertOpenAPITypeToBallerina(type), schema);
+            return convertOpenAPITypeFormatToBallerina(type, schema);
+        } else {
+            if (GeneratorConstants.TYPE_MAP.containsKey(type)) {
+                return GeneratorConstants.TYPE_MAP.get(type);
+            } else {
+                throw new BallerinaOpenApiException("Unsupported OAS data type `" + type + "`");
+            }
         }
-        return convertOpenAPITypeToBallerina(type);
+    }
+
+    /**
+     * This utility is used to select the Ballerina data type for a given OpenAPI type format.
+     *
+     * @param dataType name of the data type. ex: number, integer, string
+     * @param schema uses to generate the type descriptor name ex: int32, int64
+     * @return data type for invalid numeric data formats
+     */
+    private static String convertOpenAPITypeFormatToBallerina(final String dataType, final Schema<?> schema)
+            throws BallerinaOpenApiException {
+        if (GeneratorConstants.TYPE_MAP.containsKey(schema.getFormat())) {
+            return GeneratorConstants.TYPE_MAP.get(schema.getFormat());
+        } else {
+            OUT_STREAM.printf("WARNING: unsupported format `%s` will be skipped when generating the counterpart " +
+                    "Ballerina type for openAPI schema type: `%s`%n", schema.getFormat(), schema.getType());
+            if (GeneratorConstants.TYPE_MAP.containsKey(dataType)) {
+                return GeneratorConstants.TYPE_MAP.get(dataType);
+            } else {
+                throw new BallerinaOpenApiException("Unsupported OAS data type `" + dataType + "`");
+            }
+        }
     }
 
     /**
@@ -998,24 +1017,5 @@ public class GeneratorUtils {
         } catch (ProjectException e) {
             throw new ProjectException(e.getMessage());
         }
-    }
-
-    /**
-     * This utility is used to select the Ballerina data type for a given OpenAPI type format.
-     *
-     * @param dataType name of the data type. ex: number, integer, string
-     * @param schema uses to generate the type descriptor name ex: int32, int64
-     * @return data type for invalid numeric data formats
-     */
-    public static String convertOpenAPITypeFormatToBallerina(final String dataType, final Schema<?> schema) {
-        try {
-            if (schema.getFormat() != null) {
-                return GeneratorUtils.convertOpenAPITypeToBallerina(schema.getFormat().trim());
-            }
-        } catch (BallerinaOpenApiException e) {
-            OUT_STREAM.printf("WARNING: unsupported format `%s` will be skipped when generating the counterpart " +
-                    "Ballerina type for openAPI schema type: `%s`", schema.getFormat(), schema.getType());
-        }
-        return dataType;
     }
 }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
@@ -169,7 +169,7 @@ public class FunctionReturnTypeGenerator {
             // TODO: Nested array when response has
             type = generateReturnTypeForArraySchema(media, arraySchema, isSignature);
         } else if (schema.getType() != null) {
-            type = convertOpenAPITypeToBallerina(schema.getType());
+            type = convertOpenAPITypeToBallerina(schema);
         } else if (media.getKey().trim().equals("application/xml")) {
             type = generateCustomTypeDefine("xml", "XML", isSignature);
         } else {
@@ -218,13 +218,13 @@ public class FunctionReturnTypeGenerator {
             if (arraySchema.getItems() instanceof ArraySchema) {
                 Schema nestedSchema = arraySchema.getItems();
                 ArraySchema nestedArraySchema = (ArraySchema) nestedSchema;
-                String inlineArrayType = convertOpenAPITypeToBallerina(nestedArraySchema.getItems().getType());
+                String inlineArrayType = convertOpenAPITypeToBallerina(nestedArraySchema.getItems());
                 typeName = inlineArrayType + "NestedArr";
                 type = inlineArrayType + "[][]";
             } else {
-                typeName = convertOpenAPITypeToBallerina(Objects.requireNonNull(arraySchema.getItems()).getType()) +
+                typeName = convertOpenAPITypeToBallerina(Objects.requireNonNull(arraySchema.getItems())) +
                         "Arr";
-                type = convertOpenAPITypeToBallerina(arraySchema.getItems().getType()) + "[]";
+                type = convertOpenAPITypeToBallerina(arraySchema.getItems()) + "[]";
             }
             type = generateCustomTypeDefine(type, getValidName(typeName, true), isSignature);
         }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/PrimitiveTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/PrimitiveTypeGenerator.java
@@ -57,13 +57,9 @@ public class PrimitiveTypeGenerator extends TypeGenerator {
      */
     @Override
     public TypeDescriptorNode generateTypeDescriptorNode() throws BallerinaOpenApiException {
-        String typeDescriptorName = GeneratorUtils.convertOpenAPITypeToBallerina(schema.getType().trim());
+        String typeDescriptorName = GeneratorUtils.convertOpenAPITypeToBallerina(schema);
         // TODO: Need to the format of other primitive types too
-        if (schema.getType().equals(GeneratorConstants.NUMBER)) {
-            if (schema.getFormat() != null) {
-                typeDescriptorName = GeneratorUtils.convertOpenAPITypeToBallerina(schema.getFormat().trim());
-            }
-        } else if (schema.getType().equals(GeneratorConstants.STRING) && schema.getFormat() != null &&
+        if (schema.getType().equals(GeneratorConstants.STRING) && schema.getFormat() != null &&
                 schema.getFormat().equals(GeneratorConstants.BINARY)) {
             typeDescriptorName = "record {byte[] fileContent; string fileName;}";
         }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/RecordTypeGenerator.java
@@ -199,9 +199,8 @@ public class RecordTypeGenerator extends TypeGenerator {
         RecordRestDescriptorNode recordRestDescNode = null;
         if (additionalPropSchema instanceof NumberSchema && additionalPropSchema.getFormat() != null) {
             // this is special for `NumberSchema` because it has format with its expected type.
-            String type = additionalPropSchema.getFormat();
             SimpleNameReferenceNode numberNode = NodeFactory.createSimpleNameReferenceNode(
-                    createIdentifierToken(GeneratorUtils.convertOpenAPITypeToBallerina(type)));
+                    createIdentifierToken(GeneratorUtils.convertOpenAPITypeToBallerina(additionalPropSchema)));
             recordRestDescNode = NodeFactory.createRecordRestDescriptorNode(
                     TypeGeneratorUtils.getNullableType(additionalPropSchema, numberNode),
                     createToken(ELLIPSIS_TOKEN),

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ParametersGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ParametersGenerator.java
@@ -212,7 +212,7 @@ public class ParametersGenerator {
                 headerTypeName = createArrayTypeDescriptorNode(headerArrayItemTypeName, nodeList);
             } else {
                 headerTypeName = createBuiltinSimpleNameReferenceNode(null, createIdentifierToken(
-                        GeneratorUtils.convertOpenAPITypeToBallerina(schema.getType().trim()),
+                        GeneratorUtils.convertOpenAPITypeToBallerina(schema),
                         GeneratorUtils.SINGLE_WS_MINUTIAE, GeneratorUtils.SINGLE_WS_MINUTIAE));
             }
             // Create annotation for header
@@ -499,8 +499,7 @@ public class ParametersGenerator {
                 throw new BallerinaOpenApiException(String.format(messages.getDescription(), type));
             }
         } else {
-            arrayName = GeneratorUtils.convertOpenAPITypeToBallerina(items.getType().toLowerCase(
-                    Locale.ENGLISH).trim());
+            arrayName = GeneratorUtils.convertOpenAPITypeToBallerina(items);
         }
         Token arrayNameToken = createIdentifierToken(arrayName, GeneratorUtils.SINGLE_WS_MINUTIAE,
                 GeneratorUtils.SINGLE_WS_MINUTIAE);
@@ -530,7 +529,7 @@ public class ParametersGenerator {
                     GeneratorUtils.SINGLE_WS_MINUTIAE,
                     GeneratorUtils.SINGLE_WS_MINUTIAE);
         } else {
-            name = createIdentifierToken(GeneratorUtils.convertOpenAPITypeToBallerina(schema.getType()),
+            name = createIdentifierToken(GeneratorUtils.convertOpenAPITypeToBallerina(schema),
                     GeneratorUtils.SINGLE_WS_MINUTIAE,
                     GeneratorUtils.SINGLE_WS_MINUTIAE);
         }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceGenerationUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/service/ServiceGenerationUtils.java
@@ -194,7 +194,7 @@ public class ServiceGenerationUtils {
         } else if (schemaType != null && (schemaType.equals(INTEGER) || schemaType.equals(NUMBER) ||
                 schemaType.equals(BOOLEAN) || schemaType.equals(STRING))) {
             member = createBuiltinSimpleNameReferenceNode(null, createIdentifierToken(
-                    GeneratorUtils.convertOpenAPITypeToBallerina(schema.getItems().getType())));
+                    GeneratorUtils.convertOpenAPITypeToBallerina(schema.getItems())));
         } else {
             return Optional.empty();
         }

--- a/openapi-integration-tests/src/test/java/io/ballerina/openapi/TestUtil.java
+++ b/openapi-integration-tests/src/test/java/io/ballerina/openapi/TestUtil.java
@@ -95,6 +95,16 @@ public class TestUtil {
     }
 
     /**
+     * Execute ballerina openapi command to test warnings in the output stream
+     */
+    public static InputStream executeOpenAPIToTestWarnings(String distributionName, Path sourceDirectory,
+                                                           List<String> args) throws IOException {
+        args.add(0, "openapi");
+        Process process = getProcessBuilderResults(distributionName, sourceDirectory, args);
+        return process.getErrorStream();
+    }
+
+    /**
      * Ballerina run command.
      */
     public static Process executeRun(String distributionName, Path sourceDirectory,

--- a/openapi-integration-tests/src/test/java/io/ballerina/openapi/TestUtil.java
+++ b/openapi-integration-tests/src/test/java/io/ballerina/openapi/TestUtil.java
@@ -95,7 +95,7 @@ public class TestUtil {
     }
 
     /**
-     * Execute ballerina openapi command to test warnings in the output stream
+     * Execute ballerina openapi command to test warnings in the output stream.
      */
     public static InputStream executeOpenAPIToTestWarnings(String distributionName, Path sourceDirectory,
                                                            List<String> args) throws IOException {


### PR DESCRIPTION
## Purpose
> $subject
Resolves https://github.com/ballerina-platform/openapi-tools/issues/1412

## Goals
> Print a warning meesage when unsupported data format is given in the OpenAPI file

## Approach 

Fix was sent to address the unsupported data type format scenarios by priniting a warning message in the CLI without terminating the generation purpose. The format would not be considered in generation and the type will be used to identify the corresponsing ballerina type.

Ex:
```yaml
components:
  schemas:
    Pet:
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        price:
          type: number
          format: currency
        name:
          type: string
        tag:
          type: string
        type:
          type: string
        updatedDate:
          type: string
          format: date
      additionalProperties: false
```
**In 2201.5.1 :**

Generation terminated with the error message 

```Error occurred when generating service for OpenAPI contract at petstore.yaml. Unsupported OAS data type currency.```

**Fix :**

Successfully generated with the warning

WARNING: unsupported format `currency` will be skipped when generating the counterpart Ballerina type for openAPI schema type: `number`

```bal
public type Pet record {|
    int id;
    decimal price?;
    string name;
    string tag?;
    string 'type?;
    string updatedDate?;
|};
```

the price field is generated in type decimal which is the default Ballerina type for the OpenAPI type number. The format is ignored here. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11