### PR TITLE
[master] Fix bug when return type is byte[] in OpenAPI spec generation

### DIFF
--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/Constants.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/Constants.java
@@ -46,6 +46,7 @@ public class Constants {
     public static final String TYPEREFERENCE = "typeReference";
     public static final String HTTP_HEADER = "http:Header";
     public static final String BYTE_ARRAY = "byte[]";
+    public static final String BYTE = "byte";
     public static final String OCTET_STREAM = "octet-stream";
     public static final String XML = "xml";
     public static final String JSON = "json";

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
@@ -606,10 +606,10 @@ public class OpenAPIResponseMapper {
         String statusCode = httpMethod.equals(POST) ? HTTP_201 : HTTP_200;
         String description = httpMethod.equals(POST) ? HTTP_201_DESCRIPTION : HTTP_200_DESCRIPTION;
 
-        Map<String, Schema> schemas02 = components.getSchemas();
+        Map<String, Schema> schemas = components.getSchemas();
         if (array.memberTypeDesc().kind() == SIMPLE_NAME_REFERENCE) {
             handleReferenceResponse(operationAdaptor, (SimpleNameReferenceNode) array.memberTypeDesc(),
-                    schemas02, apiResponses, customMediaPrefix, headers);
+                    schemas, apiResponses, customMediaPrefix, headers);
         } else if (array.memberTypeDesc().kind() == QUALIFIED_NAME_REFERENCE) {
             Optional<ApiResponses> optionalAPIResponses =
                     handleQualifiedNameType(new ApiResponses(), customMediaPrefix, headers, apiResponse,
@@ -621,11 +621,11 @@ public class OpenAPIResponseMapper {
             }
         } else {
             ArraySchema arraySchema = new ArraySchema();
-            String type02 = array.memberTypeDesc().kind().toString().trim().split("_")[0].
+            String type = array.memberTypeDesc().kind().toString().trim().split("_")[0].
                     toLowerCase(Locale.ENGLISH);
-            type02 = type02.equals(BYTE) ? BYTE_ARRAY : type02;
-            Schema<?> openApiSchema = ConverterCommonUtils.getOpenApiSchema(type02);
-            Optional<String> mimeType = convertBallerinaMIMEToOASMIMETypes(type02, customMediaPrefix);
+            type = type.equals(BYTE) ? BYTE_ARRAY : type;
+            Schema<?> openApiSchema = ConverterCommonUtils.getOpenApiSchema(type);
+            Optional<String> mimeType = convertBallerinaMIMEToOASMIMETypes(type, customMediaPrefix);
             if (mimeType.isEmpty()) {
                 return Optional.empty();
             }

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
@@ -94,6 +94,8 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.SIMPLE_NAME_REFERENCE
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.TYPE_REFERENCE;
 import static io.ballerina.openapi.converter.Constants.APPLICATION_PREFIX;
 import static io.ballerina.openapi.converter.Constants.BODY;
+import static io.ballerina.openapi.converter.Constants.BYTE;
+import static io.ballerina.openapi.converter.Constants.BYTE_ARRAY;
 import static io.ballerina.openapi.converter.Constants.CACHE_CONTROL;
 import static io.ballerina.openapi.converter.Constants.ETAG;
 import static io.ballerina.openapi.converter.Constants.FALSE;
@@ -621,6 +623,7 @@ public class OpenAPIResponseMapper {
             ArraySchema arraySchema = new ArraySchema();
             String type02 = array.memberTypeDesc().kind().toString().trim().split("_")[0].
                     toLowerCase(Locale.ENGLISH);
+            type02 = type02.equals(BYTE) ? BYTE_ARRAY : type02;
             Schema<?> openApiSchema = ConverterCommonUtils.getOpenApiSchema(type02);
             Optional<String> mimeType = convertBallerinaMIMEToOASMIMETypes(type02, customMediaPrefix);
             if (mimeType.isEmpty()) {

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
@@ -629,8 +629,12 @@ public class OpenAPIResponseMapper {
             if (mimeType.isEmpty()) {
                 return Optional.empty();
             }
-            arraySchema.setItems(openApiSchema);
-            mediaType.setSchema(arraySchema);
+            if (type.equals(BYTE_ARRAY)) {
+                mediaType.setSchema(openApiSchema);
+            } else {
+                arraySchema.setItems(openApiSchema);
+                mediaType.setSchema(arraySchema);
+            }
             apiResponse.description(description);
             apiResponse.content(new Content().addMediaType(mimeType.get(), mediaType));
             apiResponses.put(statusCode, apiResponse);

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/utils/ConverterCommonUtils.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/utils/ConverterCommonUtils.java
@@ -124,7 +124,7 @@ public class ConverterCommonUtils {
             case Constants.BYTE_ARRAY:
             case Constants.OCTET_STREAM:
                 schema = new StringSchema();
-                schema.setFormat("uuid");
+                schema.setFormat("byte");
                 break;
             case Constants.NUMBER:
             case Constants.DECIMAL:
@@ -179,7 +179,7 @@ public class ConverterCommonUtils {
                 break;
             case BYTE_TYPE_DESC:
                 schema = new StringSchema();
-                schema.setFormat("uuid");
+                schema.setFormat("byte");
                 break;
             case DECIMAL_TYPE_DESC:
                 schema = new NumberSchema();

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/ResponseTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/ResponseTests.java
@@ -256,6 +256,16 @@ public class ResponseTests {
         compareWithGeneratedFile(ballerinaFilePath, "response/decimal.yaml");
     }
 
+    @Test(description = "When the response has byte[] return type")
+    public void testResponseWithByteArray() throws IOException {
+        Path ballerinaFilePath = RES_DIR.resolve("response/byte.bal");
+        OASContractGenerator openApiConverterUtils = new OASContractGenerator();
+        openApiConverterUtils.generateOAS3DefinitionsAllService(ballerinaFilePath, this.tempDir, null
+                , false);
+        Assert.assertTrue(openApiConverterUtils.getErrors().isEmpty());
+        compareWithGeneratedFile(ballerinaFilePath, "response/byte.yaml");
+    }
+
     @Test
     public void testWithMultipleReturnPayloadSameStatusCode() throws IOException {
         Path ballerinaFilePath = RES_DIR.resolve("response/same_status_code.bal");

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/rb_scenario09.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/rb_scenario09.yaml
@@ -7,7 +7,7 @@ paths:
           application/octet-stream:
             schema:
               type: string
-              format: uuid
+              format: byte
       responses:
         "200":
           description: Ok

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/byte.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/byte.yaml
@@ -25,10 +25,8 @@ paths:
           content:
             application/octet-stream:
               schema:
-                type: array
-                items:
-                  type: string
-                  format: uuid
+                type: string
+                format: byte
         "500":
           description: Internal server error
           content:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/byte.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/byte.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
+paths:
+  /challenges/{challenged}:
+    get:
+      operationId: getChallengesChallenged
+      parameters:
+        - name: challenged
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/octet-stream:
+              schema:
+                type: array
+                items:
+                  type: string
+                  format: uuid
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+components:
+  schemas:
+    ErrorPayload:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: Reason phrase
+        path:
+          type: string
+          description: Request path
+        method:
+          type: string
+          description: Method type of the request
+        message:
+          type: string
+          description: Error message
+        timestamp:
+          type: string
+          description: Timestamp of the error
+        status:
+          type: integer
+          description: Relevant HTTP status code
+          format: int32

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/response/byte.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/response/byte.bal
@@ -1,0 +1,15 @@
+import ballerina/http;
+
+public type ReturnValueXML xml;
+
+public type ReturnValueCustomRec record {|
+    *http:BadGateway;
+    ReturnValueXML body;
+|};
+
+service /payloadV on new http:Listener(9090) {
+
+    resource function get challenges/[string challenged]() returns byte[]|error {
+        return error("");
+    }
+}


### PR DESCRIPTION
## Purpose
> $subject
Resolves https://github.com/ballerina-platform/openapi-tools/issues/1314

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11