### PR TITLE
[master] Fix for handling of inline objects in content type for reusable request bodies

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/BallerinaDiagnosticTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/BallerinaDiagnosticTests.java
@@ -110,6 +110,7 @@ public class BallerinaDiagnosticTests {
                 {"complex_oneOf_schema.yaml"},
                 {"request_body_ref.yaml"},
                 {"vendor_specific_mime_types.yaml"},
+                {"requestBody_reference_has_inline_object_content_type.yaml"},
                 {"ballerinax_connector_tests/ably.yaml"},
                 {"ballerinax_connector_tests/azure.iot.yaml"},
                 {"ballerinax_connector_tests/beezup.yaml"},

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
@@ -183,7 +183,7 @@ public class FunctionSignatureNodeTests {
         Assert.assertFalse(parameters.isEmpty());
         RequiredParameterNode param01 = (RequiredParameterNode) parameters.get(0);
         Assert.assertEquals(param01.paramName().orElseThrow().text(), "payload");
-        Assert.assertEquals(param01.typeName().toString(), "CreatedPet");
+        Assert.assertEquals(param01.typeName().toString(), "CreatedPet_requestBody");
     }
 
     @Test(description = "Test parameter generation for request body with unsupported (application/pdf) media type")

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
@@ -183,7 +183,7 @@ public class FunctionSignatureNodeTests {
         Assert.assertFalse(parameters.isEmpty());
         RequiredParameterNode param01 = (RequiredParameterNode) parameters.get(0);
         Assert.assertEquals(param01.paramName().orElseThrow().text(), "payload");
-        Assert.assertEquals(param01.typeName().toString(), "CreatedPet_requestBody");
+        Assert.assertEquals(param01.typeName().toString(), "CreatedPet_RequestBody");
     }
 
     @Test(description = "Test parameter generation for request body with unsupported (application/pdf) media type")

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_with_ref.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_with_ref.bal
@@ -38,7 +38,7 @@ public isolated client class Client {
     #
     # + payload - Return from creating a pet
     # + return - Successful operation
-    remote isolated function createPet(CreatedPet_requestBody payload) returns http:Response|error {
+    remote isolated function createPet(CreatedPet_RequestBody payload) returns http:Response|error {
         string resourcePath = string `/pets`;
         http:Request request = new;
         json jsonBody = payload.toJson();

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_with_ref.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_with_ref.bal
@@ -38,7 +38,7 @@ public isolated client class Client {
     #
     # + payload - Return from creating a pet
     # + return - Successful operation
-    remote isolated function createPet(CreatedPet payload) returns http:Response|error {
+    remote isolated function createPet(CreatedPet_requestBody payload) returns http:Response|error {
         string resourcePath = string `/pets`;
         http:Request request = new;
         json jsonBody = payload.toJson();

--- a/openapi-cli/src/test/resources/generators/diagnostic_files/requestBody_reference_has_inline_object_content_type.yaml
+++ b/openapi-cli/src/test/resources/generators/diagnostic_files/requestBody_reference_has_inline_object_content_type.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.0
+info:
+  title: LaunchDarkly REST API
+  version: 4.0.0
+paths:
+  /projects:
+    post:
+      operationId: operation01
+      requestBody:
+        $ref: '#/components/requestBodies/deleteFeatureFlagApproval'
+      responses:
+        '200':
+          description: Feature flag approval request response
+  /projects02:
+    post:
+      operationId: operation02
+      requestBody:
+        $ref: '#/components/requestBodies/deleteFeatureFlag'
+      responses:
+        '200':
+          description: Feature flag approval request response
+
+servers:
+  - url: https://app.launchdarkly.com/api/v2
+components:
+  requestBodies:
+    deleteFeatureFlagApproval:
+      content:
+        application/json:
+          schema: #When schema type is an object
+            type: object
+            properties:
+              comment:
+                description: comment will be included in audit log item for change.
+                type: string
+              description:
+                description: A name that describes the changes you would like to apply to a feature flag configuration
+                type: string
+              notifyMemberIds:
+                description: Id of members to notify.
+                example:
+                  - memberId
+                  - memberId2
+                items:
+                  type: string
+                type: array
+            required:
+              - description
+              - instructions
+              - notifyMemberIds
+      description: Create a new feature flag approval request
+    deleteFeatureFlag:
+      content:
+        application/json:
+          schema: #When schema has properties without schema type object
+            properties:
+              comment:
+                type: string
+              date:
+                type: string
+
+      description: Create a new feature flag approval request
+  schemas:
+    deleteFeatureFlagApprovalRequestFeatureflagapprovalrequestconfigbody:
+      type: object
+      properties:
+        name:
+          type: string

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema_with_request_body_ref.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema_with_request_body_ref.bal
@@ -1,4 +1,4 @@
-public type CreatedPet_requestBody record {
+public type CreatedPet_RequestBody record {
     string petId?;
     string createdDate?;
 };

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/schema_with_request_body_ref.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/schema_with_request_body_ref.bal
@@ -1,4 +1,4 @@
-public type CreatedPet record {
+public type CreatedPet_requestBody record {
     string petId?;
     string createdDate?;
 };

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
@@ -581,7 +581,7 @@ public class FunctionSignatureGenerator {
 
     private String getRequestBodyParameterForObjectSchema (String recordName, Schema objectSchema)
             throws BallerinaOpenApiException {
-        recordName = getValidName(recordName + "_requestBody", true);
+        recordName = getValidName(recordName + "_RequestBody", true);
         if (objectSchema.getProperties() == null || objectSchema.getProperties().isEmpty()) {
             return EMPTY_RECORD;
         }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionSignatureGenerator.java
@@ -526,9 +526,8 @@ public class FunctionSignatureGenerator {
                         //TODO: handle nested array - this is impossible to handle
                         ArraySchema arraySchema = (ArraySchema) schema;
                         paramType = getRequestBodyParameterForArraySchema(operationId, mediaTypeEntry, arraySchema);
-                    } else if (schema instanceof ObjectSchema) {
-                        ObjectSchema objectSchema = (ObjectSchema) schema;
-                        paramType = getRequestBodyParameterForObjectSchema(referencedRequestBodyName, objectSchema);
+                    } else if (schema instanceof ObjectSchema || schema.getProperties() != null) {
+                        paramType = getRequestBodyParameterForObjectSchema(referencedRequestBodyName, schema);
                     } else { // composed and object schemas are handled by the flatten
                         paramType = getBallerinaMediaType(mediaTypeEntryKey, true);
                     }
@@ -580,8 +579,9 @@ public class FunctionSignatureGenerator {
         }
     }
 
-    private String getRequestBodyParameterForObjectSchema (String recordName, ObjectSchema objectSchema)
+    private String getRequestBodyParameterForObjectSchema (String recordName, Schema objectSchema)
             throws BallerinaOpenApiException {
+        recordName = getValidName(recordName + "_requestBody", true);
         if (objectSchema.getProperties() == null || objectSchema.getProperties().isEmpty()) {
             return EMPTY_RECORD;
         }


### PR DESCRIPTION
## Purpose
Fixes for two issues:

01. Fixes https://github.com/ballerina-platform/openapi-tools/issues/1484
02. This includes the fix for  **microsoft.dynamics365businesscentral** issue
Issue: **microsoft.dynamics365businesscentral** connector was assigning generate json value when it has the requestBody scenario similar to the above issue.
Reason: Given connector's inline object defined without the schema type object.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests - Added
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
