### PR TITLE
[master] Revamp format handling when invalid formats given

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/ComparedGeneratedFileTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/ComparedGeneratedFileTests.java
@@ -110,7 +110,8 @@ public class ComparedGeneratedFileTests {
                 {"nillable_union_response.yaml", "nillable_union_response.bal"},
                 {"duplicated_response.yaml", "duplicated_response.bal"},
                 {"multiline_param_comment.yaml", "multiline_param_comment.bal"},
-                {"description_with_special_characters.yaml", "description_with_special_characters.bal"}
+                {"description_with_special_characters.yaml", "description_with_special_characters.bal"},
+                {"incorrect_format.yaml", "incorrect_format.bal"}
         };
     }
 

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
@@ -81,7 +81,7 @@ public class FunctionSignatureNodeTests {
         Assert.assertEquals(param03.typeName().toString(), "string");
 
         Assert.assertEquals(param04.paramName().orElseThrow().text(), "pages");
-        Assert.assertEquals(param04.typeName().toString(), "int[]");
+        Assert.assertEquals(param04.typeName().toString(), "decimal[]");
 
         ReturnTypeDescriptorNode returnTypeNode = signature.returnTypeDesc().orElseThrow();
         Assert.assertEquals(returnTypeNode.type().toString(), "Product[]|error");

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/PrimitiveDataTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/PrimitiveDataTypeTests.java
@@ -100,6 +100,17 @@ public class PrimitiveDataTypeTests {
                 syntaxTree);
     }
 
+    @Test(description = "Test for primitive types with formats")
+    public void generateSchemaForPrimitiveTypesWithUnsupportedFormats() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/invalid_formats.yaml");
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(definitionPath, true);
+        BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
+        syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
+        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree("schema/ballerina/" +
+                        "invalid_formats.bal",
+                syntaxTree);
+    }
+
     @AfterTest
     public void clean() {
         System.setErr(null);

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/PrimitiveDataTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/PrimitiveDataTypeTests.java
@@ -106,9 +106,8 @@ public class PrimitiveDataTypeTests {
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(definitionPath, true);
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
         syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
-        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree("schema/ballerina/" +
-                        "invalid_formats.bal",
-                syntaxTree);
+        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "schema/ballerina/invalid_formats.bal", syntaxTree);
     }
 
     @AfterTest

--- a/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/incorrect_format.bal
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/ballerina/incorrect_format.bal
@@ -1,0 +1,57 @@
+import ballerina/http;
+
+# This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
+# Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+# You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+# That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+#
+# Some useful links:
+# - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+# - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    #
+    # + config - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error if connector initialization failed
+    public isolated function init(ConnectionConfig config =  {}, string serviceUrl = "https://petstore3.swagger.io/api/v3") returns error? {
+        http:ClientConfiguration httpClientConfig = {httpVersion: config.httpVersion, timeout: config.timeout, forwarded: config.forwarded, poolConfig: config.poolConfig, compression: config.compression, circuitBreaker: config.circuitBreaker, retryConfig: config.retryConfig, validation: config.validation};
+        do {
+            if config.http1Settings is ClientHttp1Settings {
+                ClientHttp1Settings settings = check config.http1Settings.ensureType(ClientHttp1Settings);
+                httpClientConfig.http1Settings = {...settings};
+            }
+            if config.http2Settings is http:ClientHttp2Settings {
+                httpClientConfig.http2Settings = check config.http2Settings.ensureType(http:ClientHttp2Settings);
+            }
+            if config.cache is http:CacheConfig {
+                httpClientConfig.cache = check config.cache.ensureType(http:CacheConfig);
+            }
+            if config.responseLimits is http:ResponseLimitConfigs {
+                httpClientConfig.responseLimits = check config.responseLimits.ensureType(http:ResponseLimitConfigs);
+            }
+            if config.secureSocket is http:ClientSecureSocket {
+                httpClientConfig.secureSocket = check config.secureSocket.ensureType(http:ClientSecureSocket);
+            }
+            if config.proxy is http:ProxyConfig {
+                httpClientConfig.proxy = check config.proxy.ensureType(http:ProxyConfig);
+            }
+        }
+        http:Client httpEp = check new (serviceUrl, httpClientConfig);
+        self.clientEp = httpEp;
+        return;
+    }
+    # Finds Pets by status
+    #
+    # + status - Status values that need to be considered for filter
+    # + 'limit - The number of client accounts to return on each page of results. The default value is `50`. Entering a `limit` value less than the minimum (`10`) or greater than the maximum (`50`) is ignored and the system uses the default values. Depending on the `limit` you specify, the system determines the `offset` parameter to use (number of records to skip) and includes it in the link used to get the next page of results.
+    # + return - successful operation
+    remote isolated function findPetsByStatus("available"|"pending"|"sold" status = "available", string 'limit = "50") returns Pet[]|error {
+        string resourcePath = string `/pet/findByStatus`;
+        map<anydata> queryParam = {"status": status, "limit": 'limit};
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Pet[] response = check self.clientEp->get(resourcePath);
+        return response;
+    }
+}

--- a/openapi-cli/src/test/resources/generators/client/file_provider/swagger/incorrect_format.yaml
+++ b/openapi-cli/src/test/resources/generators/client/file_provider/swagger/incorrect_format.yaml
@@ -1,0 +1,129 @@
+openapi: 3.0.3
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
+    Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+    You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+    That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+
+    Some useful links:
+    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.11
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore3.swagger.io/api/v3
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
+paths:
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: false
+          explode: true
+          schema:
+            type: string
+            default: available
+            enum:
+              - available
+              - pending
+              - sold
+        - name: limit
+          in: query
+          description: The number of client accounts to return on each page of results.
+            The default value is `50`. Entering a `limit` value less than the minimum
+            (`10`) or greater than the maximum (`50`) is ignored and the system uses
+            the default values. Depending on the `limit` you specify, the system determines
+            the `offset` parameter to use (number of records to skip) and includes it
+            in the link used to get the next page of results.
+          schema:
+            maximum: 50
+            minimum: 10
+            type: string
+            format: int32
+            default: "50"
+          example: "50"
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: tag
+    Pet:
+      required:
+        - name
+        - photoUrls
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            type: string
+            xml:
+              name: photoUrl
+        tags:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/invalid_formats.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/invalid_formats.bal
@@ -1,0 +1,8 @@
+public type Pet record {
+    int id?;
+    string name;
+    # pet status in the store
+    string status?;
+    string addedDate?;
+    string points = "50";
+};

--- a/openapi-cli/src/test/resources/generators/schema/swagger/invalid_formats.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/invalid_formats.yaml
@@ -1,0 +1,86 @@
+openapi: 3.0.3
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.11
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore3.swagger.io/api/v3
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
+paths:
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: false
+          explode: true
+          schema:
+            type: string
+            default: available
+            enum:
+              - available
+              - pending
+              - sold
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      required:
+        - name
+        - photoUrls
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          example: doggie
+        status:
+          type: string
+          description: pet status in the store
+        addedDate:
+          type: string
+          format: date-time
+        points:
+          maximum: 50
+          minimum: 10
+          type: string
+          format: int32
+          default: "50"

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorConstants.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorConstants.java
@@ -303,18 +303,17 @@ public class GeneratorConstants {
     public static final String SQUARE_BRACKETS = "[]";
 
     public static final Map<String, List<String>> OPENAPI_TYPE_TO_FORMAT_MAP;
+    public static final Map<String, String> OPENAPI_TYPE_TO_BAL_TYPE_MAP;
 
     static {
+        // Add values to `OPENAPI_TYPE_TO_FORMAT_MAP`
         Map<String, List<String>> typeToFormatMap = new HashMap<>();
         typeToFormatMap.put("integer", List.of("int32", "int64"));
         typeToFormatMap.put("number", List.of("float", "double"));
         typeToFormatMap.put("string", List.of("date", "date-time", "password", "byte", "binary"));
         OPENAPI_TYPE_TO_FORMAT_MAP = Collections.unmodifiableMap(typeToFormatMap);
-    }
 
-    public static final Map<String, String> OPENAPI_TYPE_TO_BAL_TYPE_MAP;
-
-    static {
+        // Add values to `OPENAPI_TYPE_TO_BAL_TYPE_MAP`
         Map<String, String> typeMap = new HashMap<>();
         typeMap.put("integer", "int");
         typeMap.put("string", "string");

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorConstants.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorConstants.java
@@ -20,6 +20,7 @@ package io.ballerina.openapi.core;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -301,7 +302,17 @@ public class GeneratorConstants {
     public static final String NILLABLE = "?";
     public static final String SQUARE_BRACKETS = "[]";
 
-    public static final Map<String, String> TYPE_MAP;
+    public static final Map<String, List<String>> OPENAPI_TYPE_TO_FORMAT_MAP;
+
+    static {
+        Map<String, List<String>> typeToFormatMap = new HashMap<>();
+        typeToFormatMap.put("integer", List.of("int32", "int64"));
+        typeToFormatMap.put("number", List.of("float", "double"));
+        typeToFormatMap.put("string", List.of("date", "date-time", "password", "byte", "binary"));
+        OPENAPI_TYPE_TO_FORMAT_MAP = Collections.unmodifiableMap(typeToFormatMap);
+    }
+
+    public static final Map<String, String> OPENAPI_TYPE_TO_BAL_TYPE_MAP;
 
     static {
         Map<String, String> typeMap = new HashMap<>();
@@ -318,7 +329,7 @@ public class GeneratorConstants {
         typeMap.put("byte", "byte[]");
         typeMap.put("int32", "int:Signed32");
         typeMap.put("int64", "int");
-        TYPE_MAP = Collections.unmodifiableMap(typeMap);
+        OPENAPI_TYPE_TO_BAL_TYPE_MAP = Collections.unmodifiableMap(typeMap);
     }
 
     public static final String DEFAULT_HTTP_VERSION = "2.0";

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -164,6 +164,7 @@ import static io.ballerina.openapi.core.GeneratorConstants.SQUARE_BRACKETS;
 import static io.ballerina.openapi.core.GeneratorConstants.STRING;
 import static io.ballerina.openapi.core.GeneratorConstants.STYLE;
 import static io.ballerina.openapi.core.GeneratorConstants.TYPE_FILE_NAME;
+import static io.ballerina.openapi.core.GeneratorConstants.OPENAPI_TYPE_TO_FORMAT_MAP;
 import static io.ballerina.openapi.core.GeneratorConstants.TYPE_NAME;
 import static io.ballerina.openapi.core.GeneratorConstants.UNSUPPORTED_OPENAPI_VERSION_PARSER_MESSAGE;
 import static io.ballerina.openapi.core.GeneratorConstants.YAML_EXTENSION;
@@ -331,8 +332,8 @@ public class GeneratorUtils {
         } else if ((INTEGER.equals(type) || NUMBER.equals(type) || STRING.equals(type)) && schema.getFormat() != null) {
             return convertOpenAPITypeFormatToBallerina(type, schema);
         } else {
-            if (GeneratorConstants.TYPE_MAP.containsKey(type)) {
-                return GeneratorConstants.TYPE_MAP.get(type);
+            if (GeneratorConstants.OPENAPI_TYPE_TO_BAL_TYPE_MAP.containsKey(type)) {
+                return GeneratorConstants.OPENAPI_TYPE_TO_BAL_TYPE_MAP.get(type);
             } else {
                 throw new BallerinaOpenApiException("Unsupported OAS data type `" + type + "`");
             }
@@ -348,13 +349,22 @@ public class GeneratorUtils {
      */
     private static String convertOpenAPITypeFormatToBallerina(final String dataType, final Schema<?> schema)
             throws BallerinaOpenApiException {
-        if (GeneratorConstants.TYPE_MAP.containsKey(schema.getFormat())) {
-            return GeneratorConstants.TYPE_MAP.get(schema.getFormat());
+        if (OPENAPI_TYPE_TO_FORMAT_MAP.containsKey(dataType) &&
+                OPENAPI_TYPE_TO_FORMAT_MAP.get(dataType).contains(schema.getFormat())) {
+            if (GeneratorConstants.OPENAPI_TYPE_TO_BAL_TYPE_MAP.containsKey(schema.getFormat())) {
+                return GeneratorConstants.OPENAPI_TYPE_TO_BAL_TYPE_MAP.get(schema.getFormat());
+            } else {
+                OUT_STREAM.printf("WARNING: unsupported format `%s` will be skipped when generating the counterpart " +
+                        "Ballerina type for openAPI schema type: `%s`%n", schema.getFormat(), schema.getType());
+                if (GeneratorConstants.OPENAPI_TYPE_TO_BAL_TYPE_MAP.containsKey(dataType)) {
+                    return GeneratorConstants.OPENAPI_TYPE_TO_BAL_TYPE_MAP.get(dataType);
+                } else {
+                    throw new BallerinaOpenApiException("Unsupported OAS data type `" + dataType + "`");
+                }
+            }
         } else {
-            OUT_STREAM.printf("WARNING: unsupported format `%s` will be skipped when generating the counterpart " +
-                    "Ballerina type for openAPI schema type: `%s`%n", schema.getFormat(), schema.getType());
-            if (GeneratorConstants.TYPE_MAP.containsKey(dataType)) {
-                return GeneratorConstants.TYPE_MAP.get(dataType);
+            if (GeneratorConstants.OPENAPI_TYPE_TO_BAL_TYPE_MAP.containsKey(dataType)) {
+                return GeneratorConstants.OPENAPI_TYPE_TO_BAL_TYPE_MAP.get(dataType);
             } else {
                 throw new BallerinaOpenApiException("Unsupported OAS data type `" + dataType + "`");
             }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/EnumGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/schema/ballerinatypegenerators/EnumGenerator.java
@@ -83,8 +83,8 @@ public class EnumGenerator extends TypeGenerator {
                 return NodeParser.parseTypeDescriptor(enumString);
             } else {
                 String typeDescriptorName;
-                if (GeneratorConstants.TYPE_MAP.containsKey(schema.getType().trim())) {
-                    typeDescriptorName = GeneratorConstants.TYPE_MAP.get(schema.getType().trim());
+                if (GeneratorConstants.OPENAPI_TYPE_TO_BAL_TYPE_MAP.containsKey(schema.getType().trim())) {
+                    typeDescriptorName = GeneratorConstants.OPENAPI_TYPE_TO_BAL_TYPE_MAP.get(schema.getType().trim());
                 } else {
                     throw new BallerinaOpenApiException("Unsupported OAS data type `" + schema.getType().trim() + "`");
                 }

--- a/openapi-integration-tests/src/test/java/io/ballerina/openapi/cmd/ServiceGenerationTests.java
+++ b/openapi-integration-tests/src/test/java/io/ballerina/openapi/cmd/ServiceGenerationTests.java
@@ -70,9 +70,7 @@ public class ServiceGenerationTests extends OpenAPITest {
         buildArgs.add(tmpDir.toString());
         InputStream successful = TestUtil.executeOpenAPIToTestWarnings(
                 DISTRIBUTION_FILE_NAME, TEST_RESOURCE, buildArgs);
-        String msg = "WARNING: unsupported format `currency` will be skipped when generating the counterpart " +
-                "Ballerina type for openAPI schema type: `number`\n" +
-                "WARNING: unsupported format `date` will be skipped when generating the counterpart " +
+        String msg = "WARNING: unsupported format `date` will be skipped when generating the counterpart " +
                 "Ballerina type for openAPI schema type: `string`";
         try (BufferedReader br = new BufferedReader(new InputStreamReader(successful))) {
             Stream<String> logLines = br.lines();


### PR DESCRIPTION
## Purpose
> $subject
Resolves https://github.com/ballerina-platform/openapi-tools/issues/1483

## Goal
*   Check the format of a schema against the schema type before generating the ballerina type
*   Return unsupported warning only for the formats that are defined in the OpenAPI spec not for the undefined formats

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 17