### PR TITLE
[1.8.x] fix for mapping error status code for return `nil` type in Ballerina to OpenAPI spec generation

### DIFF
--- a/module-ballerina-openapi/Ballerina.toml
+++ b/module-ballerina-openapi/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org= "ballerina"
 name= "openapi"
-version= "1.8.0"
+version= "@toml.version@"
 
 [[platform.java17.dependency]]
-path = "../openapi-validator/build/libs/openapi-validator-1.8.0-SNAPSHOT.jar"
+path = "../openapi-validator/build/libs/openapi-validator-@project.version@.jar"
 groupId = "ballerina"
 artifactId = "openapi"
-version = "1.8.0-SNAPSHOT"
+version = "@project.version@"

--- a/module-ballerina-openapi/Ballerina.toml
+++ b/module-ballerina-openapi/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org= "ballerina"
 name= "openapi"
-version= "@toml.version@"
+version= "1.8.0"
 
 [[platform.java17.dependency]]
-path = "../openapi-validator/build/libs/openapi-validator-@project.version@.jar"
+path = "../openapi-validator/build/libs/openapi-validator-1.8.0-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "openapi"
-version = "@project.version@"
+version = "1.8.0-SNAPSHOT"

--- a/module-ballerina-openapi/CompilerPlugin.toml
+++ b/module-ballerina-openapi/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "openapi-tools"
 class = "io.ballerina.openapi.validator.OpenAPIValidatorPlugin"
 
 [[dependency]]
-path = "../openapi-validator/build/libs/openapi-validator-1.8.0-SNAPSHOT.jar"
+path = "../openapi-validator/build/libs/openapi-validator-@project.version@.jar"
 groupId = "ballerina"
 artifactId = "openapi"
-version = "1.8.0-SNAPSHOT"
+version = "@project.version@"

--- a/module-ballerina-openapi/CompilerPlugin.toml
+++ b/module-ballerina-openapi/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "openapi-tools"
 class = "io.ballerina.openapi.validator.OpenAPIValidatorPlugin"
 
 [[dependency]]
-path = "../openapi-validator/build/libs/openapi-validator-@project.version@.jar"
+path = "../openapi-validator/build/libs/openapi-validator-1.8.0-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "openapi"
-version = "@project.version@"
+version = "1.8.0-SNAPSHOT"

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/Constants.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/Constants.java
@@ -238,5 +238,8 @@ public class Constants {
     public static final String YML_EXTENSION = ".yml";
     public static final String PLUS = "+";
     public static final String UNDERSCORE = "_";
-
+    public static final String HTTP_202 = "202";
+    public static final String HTTP_400 = "400";
+    public static final String ACCEPTED = "Accepted";
+    public static final String BAD_REQUEST = "BadRequest";
 }

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
@@ -199,6 +199,11 @@ public class OpenAPIResponseMapper {
             ApiResponse apiResponse = new ApiResponse();
             apiResponse.description("Accepted");
             apiResponses.put("202", apiResponse);
+            if (operation.getRequestBody() != null || operation.getParameters() != null) {
+                ApiResponse badRequestResponse = new ApiResponse();
+                badRequestResponse.description("BadRequest");
+                apiResponses.put("400", badRequestResponse);
+            }
         }
         operation.setResponses(apiResponses);
     }

--- a/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
+++ b/openapi-bal-service/src/main/java/io/ballerina/openapi/converter/service/OpenAPIResponseMapper.java
@@ -93,7 +93,9 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUALIFIED_NAME_REFERE
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.RECORD_FIELD;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SIMPLE_NAME_REFERENCE;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.TYPE_REFERENCE;
+import static io.ballerina.openapi.converter.Constants.ACCEPTED;
 import static io.ballerina.openapi.converter.Constants.APPLICATION_PREFIX;
+import static io.ballerina.openapi.converter.Constants.BAD_REQUEST;
 import static io.ballerina.openapi.converter.Constants.BODY;
 import static io.ballerina.openapi.converter.Constants.BYTE;
 import static io.ballerina.openapi.converter.Constants.BYTE_ARRAY;
@@ -106,7 +108,9 @@ import static io.ballerina.openapi.converter.Constants.HTTP_200;
 import static io.ballerina.openapi.converter.Constants.HTTP_200_DESCRIPTION;
 import static io.ballerina.openapi.converter.Constants.HTTP_201;
 import static io.ballerina.openapi.converter.Constants.HTTP_201_DESCRIPTION;
+import static io.ballerina.openapi.converter.Constants.HTTP_202;
 import static io.ballerina.openapi.converter.Constants.HTTP_204;
+import static io.ballerina.openapi.converter.Constants.HTTP_400;
 import static io.ballerina.openapi.converter.Constants.HTTP_500;
 import static io.ballerina.openapi.converter.Constants.HTTP_500_DESCRIPTION;
 import static io.ballerina.openapi.converter.Constants.HTTP_CODES;
@@ -198,12 +202,12 @@ public class OpenAPIResponseMapper {
         } else {
             // When the return type is not mention in the resource function.
             ApiResponse apiResponse = new ApiResponse();
-            apiResponse.description("Accepted");
-            apiResponses.put("202", apiResponse);
+            apiResponse.description(ACCEPTED);
+            apiResponses.put(HTTP_202, apiResponse);
             if (operation.getRequestBody() != null || operation.getParameters() != null) {
                 ApiResponse badRequestResponse = new ApiResponse();
-                badRequestResponse.description("BadRequest");
-                apiResponses.put("400", badRequestResponse);
+                badRequestResponse.description(BAD_REQUEST);
+                apiResponses.put(HTTP_400, badRequestResponse);
             }
         }
         operation.setResponses(apiResponses);
@@ -441,13 +445,13 @@ public class OpenAPIResponseMapper {
         String description = httpMethod.equals(POST) ? HTTP_201_DESCRIPTION : HTTP_200_DESCRIPTION;
         if (typeNode.parent().kind() == SyntaxKind.OPTIONAL_TYPE_DESC) {
             ApiResponse acceptedRequestResponse = new ApiResponse();
-            acceptedRequestResponse.description("Accepted");
-            apiResponses.put("202", acceptedRequestResponse);
+            acceptedRequestResponse.description(ACCEPTED);
+            apiResponses.put(HTTP_202, acceptedRequestResponse);
             Operation operation = operationAdaptor.getOperation();
             if (operation.getRequestBody() != null || operation.getParameters() != null) {
                 ApiResponse badRequestResponse = new ApiResponse();
-                badRequestResponse.description("BadRequest");
-                apiResponses.put("400", badRequestResponse);
+                badRequestResponse.description(BAD_REQUEST);
+                apiResponses.put(HTTP_400, badRequestResponse);
             }
         }
         String mediaTypeString;

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/DataTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/DataTypeTests.java
@@ -50,14 +50,12 @@ public class DataTypeTests {
     @Test(description = "When the record field has type definitions with nullable")
     public void testForAllTypeDefinitionWithNullableValue() throws IOException {
         Path ballerinaFilePath = RES_DIR.resolve("data_type/nullable_type_def.bal");
-        //Compare generated yaml file with expected yaml content
         TestUtils.compareWithGeneratedFile(ballerinaFilePath, "data_type/nullable_type_def.yaml");
     }
 
     @Test(description = "test for tuple type scenarios")
     public void testForTupleType() throws IOException {
         Path ballerinaFilePath = RES_DIR.resolve("data_type/tuple_types.bal");
-        //Compare generated yaml file with expected yaml content
         TestUtils.compareWithGeneratedFile(ballerinaFilePath, "data_type/tuple_type.yaml");
     }
 

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/NegativeResponseTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/NegativeResponseTests.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.openapi.generators.openapi;
+
+import io.ballerina.openapi.cmd.OASContractGenerator;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * This test class is covering the negative unit tests for return type scenarios.
+ */
+public class NegativeResponseTests {
+    private static final Path RES_DIR = Paths.get("src/test/resources/ballerina-to-openapi").toAbsolutePath();
+    private Path tempDir;
+
+    @BeforeMethod
+    public void setup() throws IOException {
+        this.tempDir = Files.createTempDirectory("bal-to-openapi-test-out-" + System.nanoTime());
+    }
+
+    @Test(description = "When the resource has nil type return")
+    public void testNilReturnType() {
+        Path ballerinaFilePath = RES_DIR.resolve("response/negative/nil_return_type.bal");
+        OASContractGenerator openApiConverterUtils = new OASContractGenerator();
+        openApiConverterUtils.generateOAS3DefinitionsAllService(ballerinaFilePath, this.tempDir, null
+                , false);
+        //TODO: Uncomment after merging this PR https://github.com/ballerina-platform/openapi-tools/pull/1370.
+//        Assert.assertFalse(openApiConverterUtils.getErrors().isEmpty());
+        Assert.assertFalse(Files.exists(tempDir.resolve("payloadV_openapi.yaml")));
+    }
+
+
+    @AfterMethod
+    public void cleanUp() {
+        TestUtils.deleteDirectory(this.tempDir);
+    }
+
+    @AfterTest
+    public void clean() {
+        System.setErr(null);
+        System.setOut(null);
+    }
+}

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/ResponseTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/ResponseTests.java
@@ -373,6 +373,16 @@ public class ResponseTests {
         Assert.assertTrue(generatedYaml.contains(expectedYamlContent));
     }
 
+    @Test(description = "When the service has config without mediaType attribute")
+    public void testNilReturnType() throws IOException {
+        Path ballerinaFilePath = RES_DIR.resolve("response/nil_return_type.bal");
+        OASContractGenerator openApiConverterUtils = new OASContractGenerator();
+        openApiConverterUtils.generateOAS3DefinitionsAllService(ballerinaFilePath, this.tempDir, null
+                , false);
+        Assert.assertTrue(openApiConverterUtils.getErrors().isEmpty());
+        compareWithGeneratedFile(ballerinaFilePath, "response/nil_return_type.yaml");
+    }
+
     @AfterMethod
     public void cleanUp() {
         TestUtils.deleteDirectory(this.tempDir);

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/ResponseTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/ResponseTests.java
@@ -373,7 +373,7 @@ public class ResponseTests {
         Assert.assertTrue(generatedYaml.contains(expectedYamlContent));
     }
 
-    @Test(description = "When the service has config without mediaType attribute")
+    @Test(description = "When the resource has nil type return")
     public void testNilReturnType() throws IOException {
         Path ballerinaFilePath = RES_DIR.resolve("response/nil_return_type.bal");
         OASContractGenerator openApiConverterUtils = new OASContractGenerator();
@@ -381,6 +381,16 @@ public class ResponseTests {
                 , false);
         Assert.assertTrue(openApiConverterUtils.getErrors().isEmpty());
         compareWithGeneratedFile(ballerinaFilePath, "response/nil_return_type.yaml");
+    }
+
+    @Test(description = "When the resource has nil union type return")
+    public void testNilUnionReturnType() throws IOException {
+        Path ballerinaFilePath = RES_DIR.resolve("response/nil_union_return_type.bal");
+        OASContractGenerator openApiConverterUtils = new OASContractGenerator();
+        openApiConverterUtils.generateOAS3DefinitionsAllService(ballerinaFilePath, this.tempDir, null
+                , false);
+        Assert.assertTrue(openApiConverterUtils.getErrors().isEmpty());
+        compareWithGeneratedFile(ballerinaFilePath, "response/nil_union_return_type.yaml");
     }
 
     @AfterMethod

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/advance/openapi/multiple_service_01.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/advance/openapi/multiple_service_01.yaml
@@ -20,4 +20,6 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/advance/openapi/multiple_service_02.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/advance/openapi/multiple_service_02.yaml
@@ -20,4 +20,6 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/advance/openapi/multiple_service_03.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/advance/openapi/multiple_service_03.yaml
@@ -20,4 +20,6 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/apidoc/path_param.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/apidoc/path_param.yaml
@@ -24,4 +24,6 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/apidoc/query_param.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/apidoc/query_param.yaml
@@ -36,4 +36,6 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/apidoc/record.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/apidoc/record.yaml
@@ -23,6 +23,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     ReserveRoom:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/apidoc/requestBody.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/apidoc/requestBody.yaml
@@ -23,6 +23,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     ReserveRoom:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/apidoc/typeInclusion.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/apidoc/typeInclusion.yaml
@@ -21,6 +21,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Link:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/enum.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/enum.yaml
@@ -23,6 +23,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
   /getOrder:
     post:
       operationId: postGetorder
@@ -34,6 +36,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Link:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/enum_array_type.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/enum_array_type.yaml
@@ -23,6 +23,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Link:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/enum_with_value.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/enum_with_value.yaml
@@ -23,6 +23,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Link:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/nullable_type_def.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/nullable_type_def.yaml
@@ -23,6 +23,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Salary:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/tuple_type.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/tuple_type.yaml
@@ -21,6 +21,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     User:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/type_def.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/data_type/type_def.yaml
@@ -23,6 +23,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
   /reservation/{id}:
     get:
       operationId: getReservationId
@@ -35,6 +37,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     PriceMap:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/escape_identifier.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/escape_identifier.yaml
@@ -52,6 +52,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Pet-Task:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/escape_identifier_02.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/escape_identifier_02.yaml
@@ -97,6 +97,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
     put:
       operationId: putพิมพ์ชื่อ
       parameters:
@@ -108,6 +110,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     ErrorPayload:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/json/nestedRecord.json
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/json/nestedRecord.json
@@ -31,6 +31,9 @@
         "responses" : {
           "202" : {
             "description" : "Accepted"
+          },
+          "400" : {
+            "description" : "BadRequest"
           }
         }
       }

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/path_scenario03.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/path_scenario03.yaml
@@ -1,4 +1,14 @@
-
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
 paths:
   /:
     get:
@@ -24,4 +34,6 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/path_scenario04.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/path_scenario04.yaml
@@ -23,6 +23,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
     post:
       operationId: post
       responses:
@@ -46,4 +48,6 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/readonly.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/readonly.yaml
@@ -40,6 +40,10 @@ paths:
           schema:
             type: string
       responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
         "200":
           description: Ok
           content:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/record/typeInclusion.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/record/typeInclusion.yaml
@@ -21,6 +21,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Link:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/json_payload.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/json_payload.yaml
@@ -1,3 +1,14 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
 paths:
   /hi:
     post:
@@ -9,5 +20,6 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components: {}
-

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/mime_with_record_payload.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/mime_with_record_payload.yaml
@@ -1,3 +1,14 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
 paths:
   /hi:
     post:
@@ -10,6 +21,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Pet:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/multiple_payload.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/multiple_payload.yaml
@@ -1,3 +1,14 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
 paths:
   /hi:
     post:
@@ -11,4 +22,6 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/nested_2record.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/nested_2record.yaml
@@ -1,3 +1,14 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
 paths:
   /hi:
     post:
@@ -10,6 +21,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Tag:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/nested_array.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/nested_array.yaml
@@ -1,3 +1,14 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
 paths:
   /hi:
     post:
@@ -10,6 +21,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Pet:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/nested_record.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/nested_record.yaml
@@ -1,3 +1,14 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
 paths:
   /hi:
     post:
@@ -10,6 +21,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Dog:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/record_field_array.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/record_field_array.yaml
@@ -1,3 +1,14 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
 paths:
   /hi:
     post:
@@ -10,6 +21,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Dog:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/record_payload.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/record_payload.yaml
@@ -1,3 +1,14 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
 paths:
   /hi:
     post:
@@ -10,6 +21,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     Pet:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/union_type.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/request_body/union_type.yaml
@@ -21,6 +21,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
   /path1:
     post:
       operationId: postPath1
@@ -40,6 +42,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
   /path3:
     post:
       operationId: postPath3
@@ -55,6 +59,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
   /path4:
     post:
       operationId: postPath4
@@ -71,6 +77,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
   /path5:
     post:
       operationId: postPath5
@@ -85,6 +93,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
   /path6:
     post:
       operationId: postPath6
@@ -100,6 +110,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
   /path7:
     post:
       operationId: postPath7
@@ -117,6 +129,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
   /path8:
     post:
       operationId: postPath8
@@ -134,6 +148,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
   /path9:
     post:
       operationId: postPath9
@@ -152,6 +168,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
 components:
   schemas:
     ABC:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/cache_config_06.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/cache_config_06.yaml
@@ -58,6 +58,8 @@ paths:
             text/plain:
               schema:
                 type: string
+        "202":
+          description: Accepted
         "500":
           description: Internal server error
           content:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/nil_return_type.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/nil_return_type.yaml
@@ -1,0 +1,330 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
+paths:
+  /path1:
+    get:
+      operationId: getPath1
+      responses:
+        "202":
+          description: Accepted
+    put:
+      operationId: putPath1
+      responses:
+        "202":
+          description: Accepted
+    post:
+      operationId: postPath1
+      responses:
+        "202":
+          description: Accepted
+    delete:
+      operationId: deletePath1
+      responses:
+        "202":
+          description: Accepted
+    head:
+      operationId: headPath1
+      responses:
+        "202":
+          description: Accepted
+    patch:
+      operationId: patchPath1
+      responses:
+        "202":
+          description: Accepted
+  /path_with_query:
+    get:
+      operationId: getPathWithQuery
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    put:
+      operationId: putPathWithQuery
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    post:
+      operationId: postPathWithQuery
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    delete:
+      operationId: deletePathWithQuery
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    head:
+      operationId: headPathWithQuery
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    patch:
+      operationId: patchPathWithQuery
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+  /path_with_path/{id}:
+    get:
+      operationId: getPathWithPathId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    put:
+      operationId: putPathWithPathId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    post:
+      operationId: postPathWithPathId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    delete:
+      operationId: deletePathWithPathId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    head:
+      operationId: headPathWithPathId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    patch:
+      operationId: patchPathWithPathId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+  /path_with_headers:
+    get:
+      operationId: getPathWithHeaders
+      parameters:
+        - name: header
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    put:
+      operationId: putPathWithHeaders
+      parameters:
+        - name: header
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    post:
+      operationId: postPathWithHeaders
+      parameters:
+        - name: header
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    delete:
+      operationId: deletePathWithHeaders
+      parameters:
+        - name: header
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    head:
+      operationId: headPathWithHeaders
+      parameters:
+        - name: header
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    patch:
+      operationId: patchPathWithHeaders
+      parameters:
+        - name: header
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+  /path_with_request_body:
+    put:
+      operationId: putPathWithRequestBody
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    post:
+      operationId: postPathWithRequestBody
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    delete:
+      operationId: deletePathWithRequestBody
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+    patch:
+      operationId: patchPathWithRequestBody
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+components: {}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/nil_union_return_type.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/nil_union_return_type.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /path_get_error:
     get:
-      summary: for `get` method with nil return type and no error status code
+      summary: for `get` method with nil return type and error
       operationId: getPathGetError
       responses:
         "202":
@@ -25,7 +25,7 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
   /path_get:
     get:
-      summary: for `get` method with nil return type and no error status code
+      summary: for `get` method with nil return type and success status code
       operationId: getPathGet
       responses:
         "202":
@@ -38,7 +38,8 @@ paths:
                 type: string
   /path_get_query_param:
     get:
-      summary: for `get` method with nil return type and no error status code
+      summary: for `get` method with nil return type and success status code with
+        query param
       operationId: getPathGetQueryParam
       parameters:
         - name: id
@@ -59,7 +60,7 @@ paths:
                 type: string
   /path_post:
     post:
-      summary: for `post` method with 201 payload with optional error status code
+      summary: for `post` method with 201 payload with error status code and nil type
       operationId: postPathPost
       responses:
         "201":
@@ -74,7 +75,7 @@ paths:
           description: NotFound
   /path:
     get:
-      summary: for union return type with error status code
+      summary: for union return type with error status code and nil type
       operationId: getPath
       responses:
         "200":
@@ -88,8 +89,8 @@ paths:
         "404":
           description: NotFound
     post:
-      summary: "with same error status code (202): by default for ? and explicitly\
-        \ mentioned as return type"
+      summary: "resource has 3 status codes that explicitly returns (202, 404, 400)\
+        \ while ? type returns implicitly 400, 202"
       operationId: postPath
       parameters:
         - name: id
@@ -110,6 +111,8 @@ paths:
                 type: string
   /path_with_query:
     get:
+      summary: "resource has 4 status codes that explicitly returns (200, 404) while\
+        \ ? type returns implicitly 400, 202"
       operationId: getPathWithQuery
       parameters:
         - name: id
@@ -132,6 +135,8 @@ paths:
           description: NotFound
   /path_with_path/{id}:
     post:
+      summary: "resource has 3 status codes that explicitly returns (404) while ?\
+        \ type returns implicitly 400, 202"
       operationId: postPathWithPathId
       parameters:
         - name: id
@@ -148,6 +153,8 @@ paths:
           description: NotFound
   /path_with_headers:
     post:
+      summary: "method has 3 status codes that explicitly returns (404) while ? type\
+        \ returns implicitly 400, 202"
       operationId: postPathWithHeaders
       parameters:
         - name: header

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/nil_union_return_type.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/nil_union_return_type.yaml
@@ -1,0 +1,216 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
+paths:
+  /path_get_error:
+    get:
+      summary: for `get` method with nil return type and no error status code
+      operationId: getPathGetError
+      responses:
+        "202":
+          description: Accepted
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+  /path_get:
+    get:
+      summary: for `get` method with nil return type and no error status code
+      operationId: getPathGet
+      responses:
+        "202":
+          description: Accepted
+        "200":
+          description: Ok
+          content:
+            text/plain:
+              schema:
+                type: string
+  /path_get_query_param:
+    get:
+      summary: for `get` method with nil return type and no error status code
+      operationId: getPathGetQueryParam
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+        "200":
+          description: Ok
+          content:
+            text/plain:
+              schema:
+                type: string
+  /path_post:
+    post:
+      summary: for `post` method with 201 payload with optional error status code
+      operationId: postPathPost
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Links'
+        "202":
+          description: Accepted
+        "404":
+          description: NotFound
+  /path:
+    get:
+      summary: for union return type with error status code
+      operationId: getPath
+      responses:
+        "200":
+          description: Ok
+          content:
+            text/plain:
+              schema:
+                type: string
+        "202":
+          description: Accepted
+        "404":
+          description: NotFound
+    post:
+      summary: "with same error status code (202): by default for ? and explicitly\
+        \ mentioned as return type"
+      operationId: postPath
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "404":
+          description: NotFound
+        "400":
+          description: BadRequest
+          content:
+            text/plain:
+              schema:
+                type: string
+  /path_with_query:
+    get:
+      operationId: getPathWithQuery
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            text/plain:
+              schema:
+                type: string
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+        "404":
+          description: NotFound
+  /path_with_path/{id}:
+    post:
+      operationId: postPathWithPathId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+        "404":
+          description: NotFound
+  /path_with_headers:
+    post:
+      operationId: postPathWithHeaders
+      parameters:
+        - name: header
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+        "404":
+          description: NotFound
+  /path_with_request_body:
+    post:
+      operationId: postPathWithRequestBody
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
+        "404":
+          description: NotFound
+components:
+  schemas:
+    ErrorPayload:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: Reason phrase
+        path:
+          type: string
+          description: Request path
+        method:
+          type: string
+          description: Method type of the request
+        message:
+          type: string
+          description: Error message
+        timestamp:
+          type: string
+          description: Timestamp of the error
+        status:
+          type: integer
+          description: Relevant HTTP status code
+          format: int32
+    Links:
+      required:
+        - id
+        - links
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        links:
+          type: array
+          items:
+            type: string

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/rs_scenario09.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/rs_scenario09.yaml
@@ -28,6 +28,8 @@ paths:
       responses:
         "202":
           description: Accepted
+        "400":
+          description: BadRequest
     put:
       operationId: putHi
       responses:
@@ -59,6 +61,10 @@ paths:
             type: integer
             format: int64
       responses:
+        "202":
+          description: Accepted
+        "400":
+          description: BadRequest
         "500":
           description: Internal server error
           content:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/rs_scenario20.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/response/rs_scenario20.yaml
@@ -20,6 +20,8 @@ paths:
             '*/*':
               schema:
                 description: Any type of entity body
+        "202":
+          description: Accepted
         "500":
           description: Internal server error
           content:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/status_code/not_acceptable.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/status_code/not_acceptable.yaml
@@ -16,6 +16,8 @@ paths:
       responses:
         "406":
           description: NotAcceptable
+        "202":
+          description: Accepted
         "500":
           description: Internal server error
           content:

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/response/negative/nil_return_type.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/response/negative/nil_return_type.bal
@@ -1,0 +1,11 @@
+import ballerina/http;
+
+service /payloadV on new http:Listener(9090) {
+
+     resource function get path_with_request_body(@http:Payload string payload) {
+     };
+
+     resource function head path_with_request_body(@http:Payload string payload) {
+     };
+
+}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/response/nil_return_type.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/response/nil_return_type.bal
@@ -9,8 +9,6 @@ service /payloadV on new http:Listener(9090) {
     };
     resource function get path_with_headers(@http:Header string header) {
     };
-    // resource function get path_with_request_body(@http:Payload string payload) {
-    // };
 
     resource function post path1() {
     };
@@ -64,8 +62,6 @@ service /payloadV on new http:Listener(9090) {
     };
     resource function head path_with_headers(@http:Header string header) {
     };
-    // resource function head path_with_request_body(@http:Payload string payload) {
-    // };
 
     resource function option path1() {
     };

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/response/nil_return_type.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/response/nil_return_type.bal
@@ -1,0 +1,80 @@
+import ballerina/http;
+
+service /payloadV on new http:Listener(9090) {
+    resource function get path1() {
+    };
+    resource function get path_with_query(string id)  {
+    };
+    resource function get path_with_path/[string id]() {
+    };
+    resource function get path_with_headers(@http:Header string header) {
+    };
+    // resource function get path_with_request_body(@http:Payload string payload) {
+    // };
+
+    resource function post path1() {
+    };
+    resource function post path_with_query(string id)  {
+    };
+    resource function post path_with_path/[string id]() {
+    };
+    resource function post path_with_headers(@http:Header string header) {
+    };
+    resource function post path_with_request_body(@http:Payload string payload) {
+    };
+
+    resource function put path1() {
+    };
+    resource function put path_with_query(string id)  {
+    };
+    resource function put path_with_path/[string id]() {
+    };
+    resource function put path_with_headers(@http:Header string header) {
+    };
+    resource function put path_with_request_body(@http:Payload string payload) {
+    };
+
+    resource function patch path1() {
+    };
+    resource function patch path_with_query(string id)  {
+    };
+    resource function patch path_with_path/[string id]() {
+    };
+    resource function patch path_with_headers(@http:Header string header) {
+    };
+    resource function patch path_with_request_body(@http:Payload string payload) {
+    };
+
+    resource function delete path1() {
+    };
+    resource function delete path_with_query(string id)  {
+    };
+    resource function delete path_with_path/[string id]() {
+    };
+    resource function delete path_with_headers(@http:Header string header) {
+    };
+    resource function delete path_with_request_body(@http:Payload string payload) {
+    };
+
+    resource function head path1() {
+    };
+    resource function head path_with_query(string id)  {
+    };
+    resource function head path_with_path/[string id]() {
+    };
+    resource function head path_with_headers(@http:Header string header) {
+    };
+    // resource function head path_with_request_body(@http:Payload string payload) {
+    // };
+
+    resource function option path1() {
+    };
+    resource function option path_with_query(string id)  {
+    };
+    resource function option path_with_path/[string id]() {
+    };
+    resource function option path_with_headers(@http:Header string header) {
+    };
+    resource function option path_with_request_body(@http:Payload string payload) {
+    };
+}

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/response/nil_union_return_type.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/response/nil_union_return_type.bal
@@ -12,36 +12,39 @@ type Links record {|
 
 
 service /payloadV on new http:Listener(9090) {
-    # for `get` method with nil return type and no error status code
+    # for `get` method with nil return type and error
     resource function get path_get_error() returns error? {
     };
 
-    # for `get` method with nil return type and no error status code
+    # for `get` method with nil return type and success status code
     resource function get path_get() returns string? {
     };
 
-    # for `get` method with nil return type and no error status code
+    # for `get` method with nil return type and success status code with query param
     resource function get path_get_query_param(string id) returns string? {
     };
 
-    # for `post` method with 201 payload with optional error status code
+    # for `post` method with 201 payload with error status code and nil type
     resource function post path_post() returns Links|http:NotFound? {
     };
 
-    # for union return type with error status code
+    # for union return type with error status code and nil type
     resource function get path() returns string|http:NotFound? {
     };
 
-    # with same error status code (202): by default for ? and explicitly mentioned as return type
+    # resource has 3 status codes that explicitly returns (202, 404, 400) while ? type returns implicitly 400, 202
     resource function post path(string id) returns http:Accepted|http:NotFound|BadRequestRecord? {
     };
 
+    # resource has 4 status codes that explicitly returns (200, 404) while ? type returns implicitly 400, 202
     resource function get path_with_query(string id) returns string|http:NotFound? {
     };
 
+    # resource has 3 status codes that explicitly returns (404) while ? type returns implicitly 400, 202
     resource function post path_with_path/[string id]() returns http:NotFound? {
     };
 
+    # method has 3 status codes that explicitly returns (404) while ? type returns implicitly 400, 202
     resource function post path_with_headers(@http:Header string header) returns http:NotFound? {
     };
 

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/response/nil_union_return_type.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/response/nil_union_return_type.bal
@@ -1,0 +1,50 @@
+import ballerina/http;
+
+type Links record {|
+    int id;
+    string[] links;
+|};
+
+ public type BadRequestRecord record {|
+    *http:BadRequest;
+    string body;
+ |};
+
+
+service /payloadV on new http:Listener(9090) {
+    # for `get` method with nil return type and no error status code
+    resource function get path_get_error() returns error? {
+    };
+
+    # for `get` method with nil return type and no error status code
+    resource function get path_get() returns string? {
+    };
+
+    # for `get` method with nil return type and no error status code
+    resource function get path_get_query_param(string id) returns string? {
+    };
+
+    # for `post` method with 201 payload with optional error status code
+    resource function post path_post() returns Links|http:NotFound? {
+    };
+
+    # for union return type with error status code
+    resource function get path() returns string|http:NotFound? {
+    };
+
+    # with same error status code (202): by default for ? and explicitly mentioned as return type
+    resource function post path(string id) returns http:Accepted|http:NotFound|BadRequestRecord? {
+    };
+
+    resource function get path_with_query(string id) returns string|http:NotFound? {
+    };
+
+    resource function post path_with_path/[string id]() returns http:NotFound? {
+    };
+
+    resource function post path_with_headers(@http:Header string header) returns http:NotFound? {
+    };
+
+    resource function post path_with_request_body(@http:Payload string payload) returns http:NotFound? {
+    };
+}

--- a/openapi-cli/src/test/resources/testng.xml
+++ b/openapi-cli/src/test/resources/testng.xml
@@ -104,6 +104,7 @@ under the License.
             <class name="io.ballerina.openapi.generators.testcases.BallerinaTestGeneratorTests"/>
             <class name="io.ballerina.openapi.generators.client.OneOfResponsesTests"/>
             <class name="io.ballerina.openapi.generators.openapi.DataTypeTests"/>
+            <class name="io.ballerina.openapi.generators.openapi.NegativeResponseTests"/>
             <!--            <class name="io.ballerina.openapi.generators.schema.SwaggerParserTests"/>-->
         </classes>
     </test>


### PR DESCRIPTION
## Purpose
> Fix https://github.com/ballerina-platform/ballerina-standard-library/issues/4924

## Automation tests
 - Unit tests - Added
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.