### PR TITLE
[1.8.x] Fix type mismatching when the resource path end with path segment including parameter and extensions 

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ParameterGeneratorTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/service/ParameterGeneratorTest.java
@@ -262,5 +262,18 @@ public class ParameterGeneratorTest {
         CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
                 "parameter_with_ref_v31.bal", syntaxTree);
     }
-}
 
+    @Test(description = "Tests for path segments has parameters with extension")
+    public void testsForPathSegmentHasExtensionType() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/multiPathParamWithExtensionType.yaml");
+        OpenAPI openAPI = GeneratorUtils.getOpenAPIFromOpenAPIV3Parser(definitionPath);
+        OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
+                .withOpenAPI(openAPI)
+                .withFilters(filter)
+                .build();
+        BallerinaServiceGenerator ballerinaServiceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
+        syntaxTree = ballerinaServiceGenerator.generateSyntaxTree();
+        CommonTestFunctions.compareGeneratedSyntaxTreewithExpectedSyntaxTree(
+                "multiPathParamWithExtensionType.bal", syntaxTree);
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/ballerina/multiPathParamWithExtensionType.bal
+++ b/openapi-cli/src/test/resources/generators/service/ballerina/multiPathParamWithExtensionType.bal
@@ -1,0 +1,29 @@
+import ballerina/http;
+
+listener http:Listener ep0 = new (80, config = {host: "petstore.openapi.io"});
+
+service /v1 on ep0 {
+    # Info for a specific pet
+    #
+    # + spreadsheetId - The id of the pet to retrieve
+    # + sheetidCopyto - The id of the pet to retrieve
+    # + return - returns can be any of following types
+    # http:Ok (Expected response to a valid request)
+    # http:Response (unexpected error)
+    resource function get v4/spreadsheets/[int spreadsheetId]/sheets/[string sheetidCopyto]() returns http:Ok|http:Response|error {
+        if !sheetidCopyto.endsWith(":copyTo") {
+            return error("bad URL");
+        }
+        string sheetId = sheetidCopyto.substring(0, sheetidCopyto.length() - 6);
+    }
+    # Get the details of the specified field
+    #
+    # + idJson - Field ID
+    # + return - Successful response
+    resource function get 'field/[string idJson]() returns http:Ok|error {
+        if !idJson.endsWith(".json") {
+            return error("bad URL");
+        }
+        string id = idJson.substring(0, idJson.length() - 4);
+    }
+}

--- a/openapi-cli/src/test/resources/generators/service/swagger/multiPathParamWithExtensionType.yaml
+++ b/openapi-cli/src/test/resources/generators/service/swagger/multiPathParamWithExtensionType.yaml
@@ -1,0 +1,92 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OpenApi Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.{host}.io/v1
+    description: The production API server
+    variables:
+      host:
+        default: openapi
+        description: this value is assigned by the service provider
+
+tags:
+  - name: pets
+    description: Pets Tag
+  - name: list
+    description: List Tag
+
+paths:
+  /v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: spreadsheetId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: integer
+        - name: sheetId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Expected response to a valid request
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /field/{id}.json:
+    get:
+      tags:
+        - Field
+      operationId: getFieldById
+      description: Get the details of the specified field
+      parameters:
+        - description: Field ID
+          in: path
+          name: id
+          schema:
+            type: number
+            format: double
+          required: true
+      responses:
+        '200':
+          description: Successful response
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -292,7 +292,7 @@ public class GeneratorUtils {
                 // TypeDescriptor
                 BuiltinSimpleNameReferenceNode builtSNRNode = createBuiltinSimpleNameReferenceNode(
                         null,
-                        parameter.getSchema() == null ?
+                        parameter.getSchema() == null || hasSpecialCharacter ?
                                 createIdentifierToken(STRING) :
                                 createIdentifierToken(paramType));
                 IdentifierToken paramName = createIdentifierToken(


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/4856
Parent issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/4850
## Automation tests
 - Unit tests - Added
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
