### PR TITLE
[1.8.x]Fix for changing the OAS `byte` format from mapping `byte[]` to `string` in the Ballerina type

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/TypeFormatTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/TypeFormatTests.java
@@ -37,7 +37,7 @@ public class TypeFormatTests {
     private static final Path RES_DIR = Paths.get("src/test/resources/generators/schema").toAbsolutePath();
 
     @Test
-    public void stringFormats() throws IOException, BallerinaOpenApiException {
+    public void testStringFormats() throws IOException, BallerinaOpenApiException {
         Path definitionPath = RES_DIR.resolve("swagger/format/string_formats.yaml");
         OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(definitionPath, true);
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/TypeFormatTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/schema/TypeFormatTests.java
@@ -1,0 +1,48 @@
+/*
+ *Copyright (c) 2023,WSO2 LLC. (https://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.openapi.generators.schema;
+
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.openapi.core.GeneratorUtils;
+import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
+import io.ballerina.openapi.core.generators.schema.BallerinaTypesGenerator;
+import io.ballerina.openapi.generators.common.TestUtils;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * This includes primitive data types format types tests.
+ */
+public class TypeFormatTests {
+    private static final Path RES_DIR = Paths.get("src/test/resources/generators/schema").toAbsolutePath();
+
+    @Test
+    public void stringFormats() throws IOException, BallerinaOpenApiException {
+        Path definitionPath = RES_DIR.resolve("swagger/format/string_formats.yaml");
+        OpenAPI openAPI = GeneratorUtils.normalizeOpenAPI(definitionPath, true);
+        BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(openAPI);
+        SyntaxTree syntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
+        TestUtils.compareGeneratedSyntaxTreewithExpectedSyntaxTree("schema/ballerina/format/string_formats.bal",
+                syntaxTree);
+    }
+}

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/format_type.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/constraint/format_type.bal
@@ -2,7 +2,8 @@ import ballerina/constraint;
 
 public type StringObject record {
     string name?;
-    byte[] byteContent?;
+    @constraint:String {pattern: re `^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$`}
+    string byteContent?;
     record {byte[] fileContent; string fileName;} binaryContent?;
     @constraint:String {pattern: re `^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$`}
     string uuidContent?;

--- a/openapi-cli/src/test/resources/generators/schema/ballerina/format/string_formats.bal
+++ b/openapi-cli/src/test/resources/generators/schema/ballerina/format/string_formats.bal
@@ -1,0 +1,19 @@
+# formats those are defined by the OpenAPI Specification
+public type OASStringFormats record {
+    string name?;
+    string byteContent?;
+    record {byte[] fileContent; string fileName;} binaryContent?;
+    string dateContent?;
+    string passwordContent?;
+    string datetimeContent?;
+};
+
+# formats those are not defined by the OpenAPI Specification
+public type NONOASStringFormats record {
+    string uuidContent?;
+    string uriContent?;
+    string emailContent?;
+    string hostnameContent?;
+    string ipv4Content?;
+    string ipv6Content?;
+};

--- a/openapi-cli/src/test/resources/generators/schema/swagger/format/string_formats.yaml
+++ b/openapi-cli/src/test/resources/generators/schema/swagger/format/string_formats.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.0
+info:
+  title: Format REST API
+  version: 4.0.0
+paths:
+  /projects:
+    get:
+      operationId: op1
+      responses:
+        '200':
+          description: Feature flag approval request response
+          content:
+            "application/json":
+              schema:
+                $ref: '#/components/schemas/OASStringFormats'
+servers:
+  - url: https://app.launchdarkly.com/api/v2
+components:
+  schemas:
+    OASStringFormats:
+      type: object
+      description: formats those are defined by the OpenAPI Specification
+      properties:
+        name:
+          type: string
+        byteContent:
+          type: string
+          format: byte
+        binaryContent:
+          type: string
+          format: binary
+        dateContent:
+          type: string
+          format: date
+        passwordContent:
+          type: string
+          format: password
+        datetimeContent:
+          type: string
+          format: date-time
+    NONOASStringFormats:
+      description:  formats those are not defined by the OpenAPI Specification
+      type: object
+      properties:
+        uuidContent:
+          type: string
+          format: uuid
+        uriContent:
+          type: string
+          format: uri
+        emailContent:
+          type: string
+          format: email
+        hostnameContent:
+          type: string
+          format: hostname
+        ipv4Content:
+          type: string
+          format: ipv4
+        ipv6Content:
+          type: string
+          format: ipv6

--- a/openapi-cli/src/test/resources/testng.xml
+++ b/openapi-cli/src/test/resources/testng.xml
@@ -101,6 +101,7 @@ under the License.
             <class name="io.ballerina.openapi.generators.schema.IntegerDataTypeTests"/>
             <class name="io.ballerina.openapi.generators.schema.EnumGenerationTests"/>
             <class name="io.ballerina.openapi.generators.schema.NegativeConstraintTests"/>
+            <class name="io.ballerina.openapi.generators.schema.TypeFormatTests"/>
             <class name="io.ballerina.openapi.generators.testcases.BallerinaTestGeneratorTests"/>
             <class name="io.ballerina.openapi.generators.client.OneOfResponsesTests"/>
             <class name="io.ballerina.openapi.generators.openapi.DataTypeTests"/>

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorConstants.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorConstants.java
@@ -326,7 +326,7 @@ public class GeneratorConstants {
         typeMap.put("double", "decimal");
         typeMap.put("float", "float");
         typeMap.put("binary", "byte[]");
-        typeMap.put("byte", "byte[]");
+        typeMap.put("byte", "string");
         typeMap.put("int32", "int:Signed32");
         typeMap.put("int64", "int");
         OPENAPI_TYPE_TO_BAL_TYPE_MAP = Collections.unmodifiableMap(typeMap);


### PR DESCRIPTION
## Purpose
> Fix https://github.com/ballerina-platform/ballerina-standard-library/issues/5072

[As per the OAS specification `byte` format ](https://swagger.io/docs/specification/data-models/data-types/#string:~:text=byte%20%E2%80%93%20base64%2Dencoded%20characters%2C%20for%20example%2C%20U3dhZ2dlciByb2Nrcw%3D%3D)of the string type 
>byte – base64-encoded characters, for example, U3dhZ2dlciByb2Nrcw==

should map to the Ballerina string 


## Automation tests
 - Unit tests - Added
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.