### PR TITLE
[1.8.x] Provide nil return support for the client generation when the response has no content type instead of giving `http:Response `

### DIFF
--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -89,25 +89,20 @@ public class FunctionBodyNodeTests {
                         "http:Responseresponse=check self.clientEp-> head(resourcePath, httpHeaders);returnresponse;}"},
                 {"diagnostic_files/operation_delete.yaml", "/pets/{petId}", "{string resourcePath = " +
                         "string `/pets/${getEncodedUri(petId)}`;" +
-                        "http:Response response = check self.clientEp-> delete(resourcePath);" +
-                        "return response;}"},
+                        "returncheck self.clientEp-> delete(resourcePath);}"},
                 {"diagnostic_files/json_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new; request.setPayload(payload, \"application/json\"); " +
-                        "http:Response response = check self.clientEp->" +
-                        "post(resourcePath, request); " +
-                        "return response;}"},
+                        "returncheck self.clientEp->post(resourcePath, request);}"},
                 {"diagnostic_files/xml_payload.yaml", "/pets", "{string resourcePath = string `/pets`; " +
                         "http:Request request = new;" +
                         "request.setPayload(payload, \"application/xml\"); " +
-                        "http:Response response = check self.clientEp->post(resourcePath, request);" +
-                        "return response;}"},
+                        "return check self.clientEp->post(resourcePath, request);}"},
                 {"diagnostic_files/xml_payload_with_ref.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new;" +
                         "json jsonBody = payload.toJson();" +
                         "xml? xmlBody = check xmldata:fromJson(jsonBody);" +
                         "request.setPayload(xmlBody, \"application/xml\");" +
-                        "http:Response response = check self.clientEp->post(resourcePath, request);" +
-                        "return response;}"},
+                        "returncheck self.clientEp->post(resourcePath, request);}"},
                 {"client/swagger/response_type_order.yaml", "/pet/{petId}",
                         "{string resourcePath = string `/pet/${getEncodedUri(petId)}`;" +
                         "Pet response = check self.clientEp->get(resourcePath);" +
@@ -120,13 +115,11 @@ public class FunctionBodyNodeTests {
                         "return response;}"},
                 {"client/swagger/pdf_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "// TODO: Update the request as needed;\n" +
-                        "http:Response response = check self.clientEp->post(resourcePath, request);" +
-                        "return response;}"},
+                        "returncheck self.clientEp->post(resourcePath, request);}"},
                 {"client/swagger/image_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new;" +
                         "request.setPayload(payload, \"image/png\");" +
-                        "http:Response response = check self.clientEp->post(resourcePath, request);" +
-                        "return response;}"},
+                        "returncheck self.clientEp->post(resourcePath, request);}"},
                 {"client/swagger/multipart_formdata_custom.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
                         "http:Request request = new;\n" +
                         "map<Encoding> encodingMap = {\"profileImage\": {contentType: \"image/png\", headers: " +
@@ -135,8 +128,7 @@ public class FunctionBodyNodeTests {
                         "{contentType:\"text/plain\"}};\n" +
                         "mime:Entity[] bodyParts = check createBodyParts(payload, encodingMap);\n" +
                         "request.setBodyParts(bodyParts);\n" +
-                        "http:Response response = check self.clientEp->post(resourcePath, request);\n" +
-                        "return response;}"},
+                        "returncheck self.clientEp->post(resourcePath, request);\n}"},
                 {"client/swagger/empty_object_responnse.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
                         "        // TODO: Update the request as needed;\n" +
                         "        json response = check self.clientEp->post(resourcePath, request);\n" +

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionBodyNodeTests.java
@@ -89,20 +89,20 @@ public class FunctionBodyNodeTests {
                         "http:Responseresponse=check self.clientEp-> head(resourcePath, httpHeaders);returnresponse;}"},
                 {"diagnostic_files/operation_delete.yaml", "/pets/{petId}", "{string resourcePath = " +
                         "string `/pets/${getEncodedUri(petId)}`;" +
-                        "returncheck self.clientEp-> delete(resourcePath);}"},
+                        "return  self.clientEp-> delete(resourcePath);}"},
                 {"diagnostic_files/json_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new; request.setPayload(payload, \"application/json\"); " +
-                        "returncheck self.clientEp->post(resourcePath, request);}"},
+                        "return  self.clientEp->post(resourcePath, request);}"},
                 {"diagnostic_files/xml_payload.yaml", "/pets", "{string resourcePath = string `/pets`; " +
                         "http:Request request = new;" +
                         "request.setPayload(payload, \"application/xml\"); " +
-                        "return check self.clientEp->post(resourcePath, request);}"},
+                        "return self.clientEp->post(resourcePath, request);}"},
                 {"diagnostic_files/xml_payload_with_ref.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new;" +
                         "json jsonBody = payload.toJson();" +
                         "xml? xmlBody = check xmldata:fromJson(jsonBody);" +
                         "request.setPayload(xmlBody, \"application/xml\");" +
-                        "returncheck self.clientEp->post(resourcePath, request);}"},
+                        "return self.clientEp->post(resourcePath, request);}"},
                 {"client/swagger/response_type_order.yaml", "/pet/{petId}",
                         "{string resourcePath = string `/pet/${getEncodedUri(petId)}`;" +
                         "Pet response = check self.clientEp->get(resourcePath);" +
@@ -115,11 +115,11 @@ public class FunctionBodyNodeTests {
                         "return response;}"},
                 {"client/swagger/pdf_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "// TODO: Update the request as needed;\n" +
-                        "returncheck self.clientEp->post(resourcePath, request);}"},
+                        " return  self.clientEp->post(resourcePath, request);}"},
                 {"client/swagger/image_payload.yaml", "/pets", "{string resourcePath = string `/pets`;" +
                         "http:Request request = new;" +
                         "request.setPayload(payload, \"image/png\");" +
-                        "returncheck self.clientEp->post(resourcePath, request);}"},
+                        " return  self.clientEp->post(resourcePath, request);}"},
                 {"client/swagger/multipart_formdata_custom.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
                         "http:Request request = new;\n" +
                         "map<Encoding> encodingMap = {\"profileImage\": {contentType: \"image/png\", headers: " +
@@ -128,7 +128,7 @@ public class FunctionBodyNodeTests {
                         "{contentType:\"text/plain\"}};\n" +
                         "mime:Entity[] bodyParts = check createBodyParts(payload, encodingMap);\n" +
                         "request.setBodyParts(bodyParts);\n" +
-                        "returncheck self.clientEp->post(resourcePath, request);\n}"},
+                        " return  self.clientEp->post(resourcePath, request);\n}"},
                 {"client/swagger/empty_object_responnse.yaml", "/pets", "{string resourcePath = string `/pets`;\n" +
                         "        // TODO: Update the request as needed;\n" +
                         "        json response = check self.clientEp->post(resourcePath, request);\n" +

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureNodeTests.java
@@ -102,7 +102,7 @@ public class FunctionSignatureNodeTests {
         Assert.assertEquals(param01.typeName().toString(), "xml");
 
         ReturnTypeDescriptorNode returnTypeNode = signature.returnTypeDesc().orElseThrow();
-        Assert.assertEquals(returnTypeNode.type().toString(), "http:Response|error");
+        Assert.assertEquals(returnTypeNode.type().toString(), "error?");
     }
 
     @Test(description = "Test for generate function signature for json request body")
@@ -120,7 +120,7 @@ public class FunctionSignatureNodeTests {
         Assert.assertEquals(param01.typeName().toString(), "json");
 
         ReturnTypeDescriptorNode returnTypeNode = signature.returnTypeDesc().orElseThrow();
-        Assert.assertEquals(returnTypeNode.type().toString(), "http:Response|error");
+        Assert.assertEquals(returnTypeNode.type().toString(), "error?");
     }
 
     @Test(description = "Test for generate function signature for multipart custom header")
@@ -147,7 +147,7 @@ public class FunctionSignatureNodeTests {
         Assert.assertEquals(param03.typeName().toString(), "string?");
 
         ReturnTypeDescriptorNode returnTypeNode = signature.returnTypeDesc().orElseThrow();
-        Assert.assertEquals(returnTypeNode.type().toString(), "http:Response|error");
+        Assert.assertEquals(returnTypeNode.type().toString(), "error?");
     }
 
     @Test(description = "Test for generate function signature with nested array return type")

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureReturnTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureReturnTypeTests.java
@@ -42,18 +42,18 @@ public class FunctionSignatureReturnTypeTests {
     public void getReturnTypeTests() throws IOException, BallerinaOpenApiException {
         FunctionReturnTypeGenerator functionReturnType = new FunctionReturnTypeGenerator();
         OpenAPI array = getOpenAPI(RES_DIR.resolve("swagger/return_type/all_return_type_operation.yaml"));
-//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/jsonproducts").getGet(),
-//                true), "json|error");
-//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/stringproducts/record").getGet(),
-//                true), "Product[]|error");
-//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/stringproducts/record").getGet(),
-//                false), "ProductArr|error");
-//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlproducts").getGet(),
-//                true), "xml|error");
-//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlarrayproducts").getGet(),
-//                true), "xml[]|error");
-//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlarrayproducts").getGet(),
-//                false), "XMLArr|error");
+        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/jsonproducts").getGet(),
+                true), "json|error");
+        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/stringproducts/record").getGet(),
+                true), "Product[]|error");
+        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/stringproducts/record").getGet(),
+                false), "ProductArr|error");
+        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlproducts").getGet(),
+                true), "xml|error");
+        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlarrayproducts").getGet(),
+                true), "xml[]|error");
+        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlarrayproducts").getGet(),
+                false), "XMLArr|error");
         String returnType = functionReturnType.getReturnType(array.getPaths().get("/products/nocontent").getGet(),
                 true);
         Assert.assertEquals(returnType, "error?");

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureReturnTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureReturnTypeTests.java
@@ -42,18 +42,21 @@ public class FunctionSignatureReturnTypeTests {
     public void getReturnTypeTests() throws IOException, BallerinaOpenApiException {
         FunctionReturnTypeGenerator functionReturnType = new FunctionReturnTypeGenerator();
         OpenAPI array = getOpenAPI(RES_DIR.resolve("swagger/return_type/all_return_type_operation.yaml"));
-        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/jsonproducts").getGet(),
-                true), "json|error");
-        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/stringproducts/record").getGet(),
-                true), "Product[]|error");
-        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/stringproducts/record").getGet(),
-                false), "ProductArr|error");
-        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlproducts").getGet(),
-                true), "xml|error");
-        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlarrayproducts").getGet(),
-                true), "xml[]|error");
-        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlarrayproducts").getGet(),
-                false), "XMLArr|error");
+//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/jsonproducts").getGet(),
+//                true), "json|error");
+//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/stringproducts/record").getGet(),
+//                true), "Product[]|error");
+//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/stringproducts/record").getGet(),
+//                false), "ProductArr|error");
+//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlproducts").getGet(),
+//                true), "xml|error");
+//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlarrayproducts").getGet(),
+//                true), "xml[]|error");
+//        Assert.assertEquals(functionReturnType.getReturnType(array.getPaths().get("/xmlarrayproducts").getGet(),
+//                false), "XMLArr|error");
+        String returnType = functionReturnType.getReturnType(array.getPaths().get("/products/nocontent").getGet(),
+                true);
+        Assert.assertEquals(returnType, "error?");
     }
 
     @Test(description = "Tests for the object response without property")

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureReturnTypeTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/client/FunctionSignatureReturnTypeTests.java
@@ -18,9 +18,13 @@
 
 package io.ballerina.openapi.generators.client;
 
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.openapi.core.exception.BallerinaOpenApiException;
+import io.ballerina.openapi.core.generators.client.BallerinaClientGenerator;
 import io.ballerina.openapi.core.generators.client.FunctionReturnTypeGenerator;
+import io.ballerina.openapi.core.generators.client.model.OASClientConfig;
 import io.ballerina.openapi.core.generators.schema.BallerinaTypesGenerator;
+import io.ballerina.openapi.core.model.Filter;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -29,7 +33,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.List;
 
+import static io.ballerina.openapi.generators.common.TestUtils.compareGeneratedSyntaxTreeWithExpectedSyntaxTree;
 import static io.ballerina.openapi.generators.common.TestUtils.getOpenAPI;
 
 /**
@@ -131,5 +137,22 @@ public class FunctionSignatureReturnTypeTests {
         String returnType = functionReturnType.getReturnType(array.getPaths().get("/store/inventory").getGet(),
                 true);
         Assert.assertEquals(returnType, "json|error");
+    }
+
+    @Test(description = "Tests for the response without content type")
+    public void getReturnTypeForNoContentType() throws IOException, BallerinaOpenApiException {
+        OpenAPI openAPI = getOpenAPI(RES_DIR.resolve("swagger/return_type" +
+                "/no_content_type.yaml"));
+        Path expectedPath = RES_DIR.resolve("ballerina/return/no_content_type.bal");
+
+        List<String> list1 = new ArrayList<>();
+        Filter filter = new Filter(list1, list1);
+        OASClientConfig.Builder clientMetaDataBuilder = new OASClientConfig.Builder();
+        OASClientConfig oasClientConfig = clientMetaDataBuilder
+                .withFilters(filter)
+                .withOpenAPI(openAPI).build();
+        BallerinaClientGenerator ballerinaClientGenerator = new BallerinaClientGenerator(oasClientConfig);
+        SyntaxTree syntaxTree = ballerinaClientGenerator.generateSyntaxTree();
+        compareGeneratedSyntaxTreeWithExpectedSyntaxTree(expectedPath, syntaxTree);
     }
 }

--- a/openapi-cli/src/test/resources/expected_gen/generate_client_requestbody.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generate_client_requestbody.bal
@@ -43,6 +43,6 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/expected_gen/generate_client_requestbody.bal
+++ b/openapi-cli/src/test/resources/expected_gen/generate_client_requestbody.bal
@@ -38,12 +38,11 @@ public isolated client class Client {
     # Creates a new user.
     #
     # + return - OK
-    remote isolated function createUser(User payload) returns http:Response|error {
+    remote isolated function createUser(User payload) returns error? {
         string resourcePath = string `/requestBody`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/any_types_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/any_types_payload.bal
@@ -37,10 +37,9 @@ public isolated client class Client {
     # Create a pet
     #
     # + return - Null response
-    remote isolated function createPet(http:Request request) returns http:Response|error {
+    remote isolated function createPet(http:Request request) returns error? {
         string resourcePath = string `/pets`;
         // TODO: Update the request as needed;
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/binary_format_octet_stream_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/binary_format_octet_stream_payload.bal
@@ -41,7 +41,7 @@ public isolated client class Client {
         string resourcePath = string `/pets`;
         http:Request request = new;
         request.setPayload(payload, "application/octet-stream");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }
 

--- a/openapi-cli/src/test/resources/generators/client/ballerina/binary_format_octet_stream_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/binary_format_octet_stream_payload.bal
@@ -37,12 +37,11 @@ public isolated client class Client {
     # Create a pet
     #
     # + return - Null response
-    remote isolated function createPet(byte[] payload) returns http:Response|error {
+    remote isolated function createPet(byte[] payload) returns error? {
         string resourcePath = string `/pets`;
         http:Request request = new;
         request.setPayload(payload, "application/octet-stream");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }
 

--- a/openapi-cli/src/test/resources/generators/client/ballerina/byte_format_octet_stream_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/byte_format_octet_stream_payload.bal
@@ -42,7 +42,7 @@ public isolated client class Client {
         http:Request request = new;
         string encodedRequestBody = payload.toBase64();
         request.setPayload(encodedRequestBody, "application/octet-stream");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }
 

--- a/openapi-cli/src/test/resources/generators/client/ballerina/byte_format_octet_stream_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/byte_format_octet_stream_payload.bal
@@ -37,13 +37,12 @@ public isolated client class Client {
     # Create a pet
     #
     # + return - Null response
-    remote isolated function createPet(byte[] payload) returns http:Response|error {
+    remote isolated function createPet(byte[] payload) returns error? {
         string resourcePath = string `/pets`;
         http:Request request = new;
         string encodedRequestBody = payload.toBase64();
         request.setPayload(encodedRequestBody, "application/octet-stream");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }
 

--- a/openapi-cli/src/test/resources/generators/client/ballerina/delete_with_header.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/delete_with_header.bal
@@ -39,10 +39,9 @@ public isolated client class Client {
     # + order_id - Order ID
     # + risk_id - Order Risk ID
     # + return - Status OK
-    remote isolated function delete_order_risk(string order_id, string risk_id) returns http:Response|error {
+    remote isolated function delete_order_risk(string order_id, string risk_id) returns error? {
         string resourcePath = string `/admin/api/2021-10/orders/${getEncodedUri(order_id)}/risks/${getEncodedUri(risk_id)}.json`;
-        http:Response response = check self.clientEp-> delete(resourcePath);
-        return response;
+        return self.clientEp-> delete(resourcePath);
     }
     # Delete with request body.
     #
@@ -51,7 +50,7 @@ public isolated client class Client {
         string resourcePath = string `/request-body`;
         http:Request request = new;
         request.setPayload(payload, "application/json");
-        return check self.clientEp->delete(resourcePath, request);
+        return self.clientEp->delete(resourcePath, request);
     }
     # Delete with header.
     #
@@ -61,8 +60,7 @@ public isolated client class Client {
         string resourcePath = string `/header`;
         map<any> headerValues = {"X-Request-ID": xRequestId};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        return check self.clientEp->delete(resourcePath, headers = httpHeaders);
-        return response;
+        return self.clientEp->delete(resourcePath, headers = httpHeaders);
     }
     # Delete with header and request body.
     #
@@ -74,6 +72,6 @@ public isolated client class Client {
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
         http:Request request = new;
         request.setPayload(payload, "application/json");
-        return check self.clientEp->delete(resourcePath, request, httpHeaders);
+        return self.clientEp->delete(resourcePath, request, httpHeaders);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/delete_with_header.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/delete_with_header.bal
@@ -47,35 +47,33 @@ public isolated client class Client {
     # Delete with request body.
     #
     # + return - Status OK
-    remote isolated function order_risk(json payload) returns http:Response|error {
+    remote isolated function order_risk(json payload) returns error? {
         string resourcePath = string `/request-body`;
         http:Request request = new;
         request.setPayload(payload, "application/json");
-        http:Response response = check self.clientEp->delete(resourcePath, request);
-        return response;
+        return check self.clientEp->delete(resourcePath, request);
     }
     # Delete with header.
     #
     # + xRequestId - Tests header 01
     # + return - Status OK
-    remote isolated function deleteHeader(string xRequestId) returns http:Response|error {
+    remote isolated function deleteHeader(string xRequestId) returns error? {
         string resourcePath = string `/header`;
         map<any> headerValues = {"X-Request-ID": xRequestId};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        http:Response response = check self.clientEp->delete(resourcePath, headers = httpHeaders);
+        return check self.clientEp->delete(resourcePath, headers = httpHeaders);
         return response;
     }
     # Delete with header and request body.
     #
     # + xRequestId - Tests header 01
     # + return - Status OK
-    remote isolated function deleteHeaderRequestBody(string xRequestId, json payload) returns http:Response|error {
+    remote isolated function deleteHeaderRequestBody(string xRequestId, json payload) returns error? {
         string resourcePath = string `/header-with-request-body`;
         map<any> headerValues = {"X-Request-ID": xRequestId};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
         http:Request request = new;
         request.setPayload(payload, "application/json");
-        http:Response response = check self.clientEp->delete(resourcePath, request, httpHeaders);
-        return response;
+        return check self.clientEp->delete(resourcePath, request, httpHeaders);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/multipart_binary.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/multipart_binary.bal
@@ -38,10 +38,9 @@ public isolated client class Client {
     #
     # + request - Pet
     # + return - Null response
-    remote isolated function createPet(http:Request request) returns http:Response|error {
+    remote isolated function createPet(http:Request request) returns error? {
         string resourcePath = string `/pets`;
         // TODO: Update the request as needed;
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/multipart_binary.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/multipart_binary.bal
@@ -41,6 +41,6 @@ public isolated client class Client {
     remote isolated function createPet(http:Request request) returns error? {
         string resourcePath = string `/pets`;
         // TODO: Update the request as needed;
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata.bal
@@ -39,25 +39,23 @@ public isolated client class Client {
     #
     # + payload - Pet
     # + return - Null response
-    remote isolated function createPet(Pets_body payload) returns http:Response|error {
+    remote isolated function createPet(Pets_body payload) returns error? {
         string resourcePath = string `/pets`;
         http:Request request = new;
         mime:Entity[] bodyParts = check createBodyParts(payload);
         request.setBodyParts(bodyParts);
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 
     # Create an user
     #
     # + payload - User
     # + return - Null response
-    remote isolated function createUser(User_body payload) returns http:Response|error {
+    remote isolated function createUser(User_body payload) returns error? {
         string resourcePath = string `/user`;
         http:Request request = new;
         mime:Entity[] bodyParts = check createBodyParts(payload);
         request.setBodyParts(bodyParts);
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata.bal
@@ -44,7 +44,7 @@ public isolated client class Client {
         http:Request request = new;
         mime:Entity[] bodyParts = check createBodyParts(payload);
         request.setBodyParts(bodyParts);
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 
     # Create an user
@@ -56,6 +56,6 @@ public isolated client class Client {
         http:Request request = new;
         mime:Entity[] bodyParts = check createBodyParts(payload);
         request.setBodyParts(bodyParts);
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata_empty.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata_empty.bal
@@ -38,10 +38,9 @@ public isolated client class Client {
     #
     # + request - Pet
     # + return - Null response
-    remote isolated function createPet(http:Request request) returns http:Response|error {
+    remote isolated function createPet(http:Request request) returns error? {
         string resourcePath = string `/pets`;
         // TODO: Update the request as needed;
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata_empty.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/multipart_formdata_empty.bal
@@ -41,6 +41,6 @@ public isolated client class Client {
     remote isolated function createPet(http:Request request) returns error? {
         string resourcePath = string `/pets`;
         // TODO: Update the request as needed;
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/octet_stream_request_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/octet_stream_request_payload.bal
@@ -38,22 +38,20 @@ public isolated client class Client {
     # Creates a new user.
     #
     # + return - OK
-    resource isolated function post user(byte[] payload) returns http:Response|error {
+    resource isolated function post user(byte[] payload) returns error? {
         string resourcePath = string `/user`;
         http:Request request = new;
         request.setPayload(payload, "application/octet-stream");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
     # Creates a new payment.
     #
     # + payload - Details of the pet to be purchased
     # + return - OK
-    resource isolated function post payment(byte[] payload) returns http:Response|error {
+    resource isolated function post payment(byte[] payload) returns error? {
         string resourcePath = string `/payment`;
         http:Request request = new;
         request.setPayload(payload, "application/octet-stream");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/octet_stream_request_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/octet_stream_request_payload.bal
@@ -42,7 +42,7 @@ public isolated client class Client {
         string resourcePath = string `/user`;
         http:Request request = new;
         request.setPayload(payload, "application/octet-stream");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
     # Creates a new payment.
     #
@@ -52,6 +52,6 @@ public isolated client class Client {
         string resourcePath = string `/payment`;
         http:Request request = new;
         request.setPayload(payload, "application/octet-stream");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_allOf_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_allOf_scenarios.bal
@@ -39,36 +39,33 @@ public isolated client class Client {
     # Request Body has allOf with specific properties.
     #
     # + return - OK
-    remote isolated function updateXMLUser(Path01_body payload) returns http:Response|error {
+    remote isolated function updateXMLUser(Path01_body payload) returns error? {
         string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->put(resourcePath, request);
-        return response;
+        return check self.clientEp->put(resourcePath, request);
     }
     # Request Body has nested allOf.
     #
     # + return - OK
-    remote isolated function postXMLUser(Path01_body_1 payload) returns http:Response|error {
+    remote isolated function postXMLUser(Path01_body_1 payload) returns error? {
         string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
     # Request Body has Array type AllOf.
     #
     # + return - OK
-    remote isolated function postXMLUserInLineArray(CompoundArrayItemPostXMLUserInLineArrayRequest payload) returns http:Response|error {
+    remote isolated function postXMLUserInLineArray(CompoundArrayItemPostXMLUserInLineArrayRequest payload) returns error? {
         string resourcePath = string `/path02`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_allOf_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_allOf_scenarios.bal
@@ -45,7 +45,7 @@ public isolated client class Client {
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        return check self.clientEp->put(resourcePath, request);
+        return self.clientEp->put(resourcePath, request);
     }
     # Request Body has nested allOf.
     #
@@ -55,7 +55,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
     # Request Body has Array type AllOf.
     #
@@ -66,6 +66,6 @@ public isolated client class Client {
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_array.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_array.bal
@@ -43,6 +43,6 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->put(resourcePath, request);
+        return self.clientEp->put(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_array.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_array.bal
@@ -38,12 +38,11 @@ public isolated client class Client {
     # 02 Example for rb has inline requestbody.
     #
     # + return - OK
-    remote isolated function updateUser(string[] payload) returns http:Response|error {
+    remote isolated function updateUser(string[] payload) returns error? {
         string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(resourcePath, request);
-        return response;
+        return check self.clientEp->put(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_basic_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_basic_scenarios.bal
@@ -44,7 +44,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->put(resourcePath, request);
+        return self.clientEp->put(resourcePath, request);
     }
     # 01 Request body with reference.
     #
@@ -54,7 +54,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
     # 04 Example for rb has inline requestbody.
     #
@@ -65,7 +65,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->put(resourcePath, request);
+        return self.clientEp->put(resourcePath, request);
     }
     # 03 Request body with record reference.
     #
@@ -75,7 +75,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
     # 06 Example for rb has array inline requestbody.
     #
@@ -86,7 +86,7 @@ public isolated client class Client {
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        return check self.clientEp->put(resourcePath, request);
+        return self.clientEp->put(resourcePath, request);
     }
     # 05 Example for rb has array inline requestbody.
     #
@@ -97,7 +97,7 @@ public isolated client class Client {
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
     # 07 Example for rb has array inline requestbody.
     #
@@ -108,6 +108,6 @@ public isolated client class Client {
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_basic_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_basic_scenarios.bal
@@ -39,82 +39,75 @@ public isolated client class Client {
     # 02 Example for rb has inline requestbody.
     #
     # + return - OK
-    remote isolated function updateUser(Path01_body payload) returns http:Response|error {
+    remote isolated function updateUser(Path01_body payload) returns error? {
         string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(resourcePath, request);
-        return response;
+        return check self.clientEp->put(resourcePath, request);
     }
     # 01 Request body with reference.
     #
     # + return - OK
-    remote isolated function postUser(User payload) returns http:Response|error {
+    remote isolated function postUser(User payload) returns error? {
         string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
     # 04 Example for rb has inline requestbody.
     #
     # + payload - A JSON object containing pet information
     # + return - OK
-    remote isolated function updateNewUser(User payload) returns http:Response|error {
+    remote isolated function updateNewUser(User payload) returns error? {
         string resourcePath = string `/path02`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(resourcePath, request);
-        return response;
+        return check self.clientEp->put(resourcePath, request);
     }
     # 03 Request body with record reference.
     #
     # + return - OK
-    remote isolated function postNewUser(User[] payload) returns http:Response|error {
+    remote isolated function postNewUser(User[] payload) returns error? {
         string resourcePath = string `/path02`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
     # 06 Example for rb has array inline requestbody.
     #
     # + return - OK
-    remote isolated function updateXMLUser(Path03_body payload) returns http:Response|error {
+    remote isolated function updateXMLUser(Path03_body payload) returns error? {
         string resourcePath = string `/path03`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->put(resourcePath, request);
-        return response;
+        return check self.clientEp->put(resourcePath, request);
     }
     # 05 Example for rb has array inline requestbody.
     #
     # + return - OK
-    remote isolated function postXMLUser(Path03_body_1 payload) returns http:Response|error {
+    remote isolated function postXMLUser(Path03_body_1 payload) returns error? {
         string resourcePath = string `/path03`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
     # 07 Example for rb has array inline requestbody.
     #
     # + return - OK
-    remote isolated function postXMLUserInLineArray(Path04_body[] payload) returns http:Response|error {
+    remote isolated function postXMLUserInLineArray(Path04_body[] payload) returns error? {
         string resourcePath = string `/path04`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_empty_array.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_empty_array.bal
@@ -43,6 +43,6 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->put(resourcePath, request);
+        return self.clientEp->put(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_empty_array.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_empty_array.bal
@@ -38,12 +38,11 @@ public isolated client class Client {
     # 02 Example for rb has inline requestbody.
     #
     # + return - OK
-    remote isolated function updateUser(json[] payload) returns http:Response|error {
+    remote isolated function updateUser(json[] payload) returns error? {
         string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(resourcePath, request);
-        return response;
+        return check self.clientEp->put(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_has_object_content_without_property.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_has_object_content_without_property.bal
@@ -84,21 +84,19 @@ public isolated client class Client {
     # Request body has properties with {} value
     #
     # + return - Ok
-    resource isolated function put greeting03(record{} payload) returns http:Response|error {
+    resource isolated function put greeting03(record{} payload) returns error? {
         string resourcePath = string `/greeting03`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(resourcePath, request);
-        return response;
+        return check self.clientEp->put(resourcePath, request);
     }
     # Request body has non-standard media type application/zip with object content without properties
     #
     # + return - Ok
-    resource isolated function post greeting03(http:Request request) returns http:Response|error {
+    resource isolated function post greeting03(http:Request request) returns error? {
         string resourcePath = string `/greeting03`;
         // TODO: Update the request as needed;
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_has_object_content_without_property.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_has_object_content_without_property.bal
@@ -89,7 +89,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->put(resourcePath, request);
+        return self.clientEp->put(resourcePath, request);
     }
     # Request body has non-standard media type application/zip with object content without properties
     #
@@ -97,6 +97,6 @@ public isolated client class Client {
     resource isolated function post greeting03(http:Request request) returns error? {
         string resourcePath = string `/greeting03`;
         // TODO: Update the request as needed;
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_oneOf_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_oneOf_scenarios.bal
@@ -44,6 +44,6 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_oneOf_scenarios.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_oneOf_scenarios.bal
@@ -39,12 +39,11 @@ public isolated client class Client {
     #
     # + payload - A JSON object containing pet information
     # + return - OK
-    remote isolated function postXMLUser(Path01_body payload) returns http:Response|error {
+    remote isolated function postXMLUser(Path01_body payload) returns error? {
         string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_with_ref.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_with_ref.bal
@@ -43,7 +43,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
     # Create a pet
     #
@@ -54,6 +54,6 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/request_body_with_ref.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/request_body_with_ref.bal
@@ -38,24 +38,22 @@ public isolated client class Client {
     #
     # + payload - Return from creating a pet
     # + return - Successful operation
-    remote isolated function createPet(CreatedPet_RequestBody payload) returns http:Response|error {
+    remote isolated function createPet(CreatedPet_RequestBody payload) returns error? {
         string resourcePath = string `/pets`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
     # Create a pet
     #
     # + payload - Return from creating a pet
     # + return - Successful operation
-    remote isolated function createMyPet(Pet payload) returns http:Response|error {
+    remote isolated function createMyPet(Pet payload) returns error? {
         string resourcePath = string `/my/pets`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/return/no_content_type.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/return/no_content_type.bal
@@ -7,7 +7,7 @@ public isolated client class Client {
     # + config - The configurations to be used when initializing the `connector`
     # + serviceUrl - URL of the target service
     # + return - An error if connector initialization failed
-    public isolated function init(ConnectionConfig config =  {}, string serviceUrl = "http://petstore.{host}.io/v1") returns error? {
+    public isolated function init(string serviceUrl, ConnectionConfig config =  {}) returns error? {
         http:ClientConfiguration httpClientConfig = {httpVersion: config.httpVersion, timeout: config.timeout, forwarded: config.forwarded, poolConfig: config.poolConfig, compression: config.compression, circuitBreaker: config.circuitBreaker, retryConfig: config.retryConfig, validation: config.validation};
         do {
             if config.http1Settings is ClientHttp1Settings {
@@ -34,12 +34,42 @@ public isolated client class Client {
         self.clientEp = httpEp;
         return;
     }
-    # Create a pet
     #
-    # + return - Null response
-    remote isolated function createPet(http:Request request) returns error? {
-        string resourcePath = string `/pets`;
-        // TODO: Update the request as needed;
+    # + return - Switching protocols
+    resource isolated function post users(User payload) returns error? {
+        string resourcePath = string `/users`;
+        http:Request request = new;
+        json jsonBody = payload.toJson();
+        request.setPayload(jsonBody, "application/json");
         return self.clientEp->post(resourcePath, request);
+    }
+    #
+    # + return - Created
+    resource isolated function post users02(User payload) returns error? {
+        string resourcePath = string `/users02`;
+        http:Request request = new;
+        json jsonBody = payload.toJson();
+        request.setPayload(jsonBody, "application/json");
+        return self.clientEp->post(resourcePath, request);
+    }
+    #
+    # + return - Moved Permanently
+    resource isolated function post user3(User payload) returns error? {
+        string resourcePath = string `/user3`;
+        http:Request request = new;
+        json jsonBody = payload.toJson();
+        request.setPayload(jsonBody, "application/json");
+        return self.clientEp->post(resourcePath, request);
+    }
+    # This status code will be generate with previous approach till we address the error status code.
+    #
+    # + return - Unauthorized
+    resource isolated function post user4(User payload) returns http:Response|error {
+        string resourcePath = string `/user4`;
+        http:Request request = new;
+        json jsonBody = payload.toJson();
+        request.setPayload(jsonBody, "application/json");
+        http:Response response = check self.clientEp->post(resourcePath, request);
+        return response;
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/vendor_specific_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/vendor_specific_payload.bal
@@ -40,6 +40,6 @@ public isolated client class Client {
     remote isolated function createPet(http:Request request) returns error? {
         string resourcePath = string `/pets`;
         // TODO: Update the request as needed;
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/ballerina/vendor_specific_payload.bal
+++ b/openapi-cli/src/test/resources/generators/client/ballerina/vendor_specific_payload.bal
@@ -37,10 +37,9 @@ public isolated client class Client {
     # Create a pet
     #
     # + return - Null response
-    remote isolated function createPet(http:Request request) returns http:Response|error {
+    remote isolated function createPet(http:Request request) returns error? {
         string resourcePath = string `/pets`;
         // TODO: Update the request as needed;
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/all_methods.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/all_methods.bal
@@ -60,33 +60,30 @@ public isolated client class Client {
     # Update a pet
     #
     # + return - Null response
-    resource isolated function put pets() returns http:Response|error {
+    resource isolated function put pets() returns error? {
         string resourcePath = string `/pets`;
         map<anydata> queryParam = {"appid1": self.apiKeyConfig.appid1, "appid2": self.apiKeyConfig.appid2};
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
-        http:Response response = check self.clientEp-> put(resourcePath, request);
-        return response;
+        return check self.clientEp-> put(resourcePath, request);
     }
     # Create a pet
     #
     # + return - Null response
-    resource isolated function post pets() returns http:Response|error {
+    resource isolated function post pets() returns error? {
         string resourcePath = string `/pets`;
         map<anydata> queryParam = {"appid1": self.apiKeyConfig.appid1, "appid2": self.apiKeyConfig.appid2};
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
-        http:Response response = check self.clientEp-> post(resourcePath, request);
-        return response;
+        return check self.clientEp-> post(resourcePath, request);
     }
     # Delete a pet
     #
     # + return - Ok response
-    resource isolated function delete pets() returns http:Response|error {
+    resource isolated function delete pets() returns error? {
         string resourcePath = string `/pets`;
         map<anydata> queryParam = {"appid1": self.apiKeyConfig.appid1, "appid2": self.apiKeyConfig.appid2};
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
-        http:Response response = check self.clientEp->delete(resourcePath);
-        return response;
+        return check self.clientEp->delete(resourcePath);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/all_methods.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/all_methods.bal
@@ -65,7 +65,7 @@ public isolated client class Client {
         map<anydata> queryParam = {"appid1": self.apiKeyConfig.appid1, "appid2": self.apiKeyConfig.appid2};
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
-        return check self.clientEp-> put(resourcePath, request);
+        return self.clientEp-> put(resourcePath, request);
     }
     # Create a pet
     #
@@ -75,7 +75,7 @@ public isolated client class Client {
         map<anydata> queryParam = {"appid1": self.apiKeyConfig.appid1, "appid2": self.apiKeyConfig.appid2};
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
-        return check self.clientEp-> post(resourcePath, request);
+        return self.clientEp-> post(resourcePath, request);
     }
     # Delete a pet
     #
@@ -84,6 +84,6 @@ public isolated client class Client {
         string resourcePath = string `/pets`;
         map<anydata> queryParam = {"appid1": self.apiKeyConfig.appid1, "appid2": self.apiKeyConfig.appid2};
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
-        return check self.clientEp->delete(resourcePath);
+        return self.clientEp->delete(resourcePath);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/header.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/header.bal
@@ -71,13 +71,12 @@ public isolated client class Client {
     # + xRequestClient - Tests header 02
     # + xRequestPet - Tests header 03
     # + return - Expected response to a valid request
-    resource isolated function get weather(string xRequestId, string[] xRequestClient, WeatherForecast[] xRequestPet) returns http:Response|error {
+    resource isolated function get weather(string xRequestId, string[] xRequestClient, WeatherForecast[] xRequestPet) returns error? {
         string resourcePath = string `/weather`;
         map<anydata> queryParam = {"appid": self.apiKeyConfig.appid};
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         map<any> headerValues = {"X-Request-ID": xRequestId, "X-Request-Client": xRequestClient, "X-Request-Pet": xRequestPet};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        http:Response response = check self.clientEp->get(resourcePath, httpHeaders);
-        return response;
+        return check self.clientEp->get(resourcePath, httpHeaders);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/header.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/header.bal
@@ -77,6 +77,6 @@ public isolated client class Client {
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         map<any> headerValues = {"X-Request-ID": xRequestId, "X-Request-Client": xRequestClient, "X-Request-Pet": xRequestPet};
         map<string|string[]> httpHeaders = getMapForHeaders(headerValues);
-        return check self.clientEp->get(resourcePath, httpHeaders);
+        return self.clientEp->get(resourcePath, httpHeaders);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/pathParameters.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/pathParameters.bal
@@ -93,6 +93,6 @@ public isolated client class Client {
         string resourcePath = string `/admin/api/2021-10/customers/${getEncodedUri(customer_id)}.json`;
         map<anydata> queryParam = {"fields": fields};
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
-        return check self.clientEp->get(resourcePath);
+        return self.clientEp->get(resourcePath);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/pathParameters.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/pathParameters.bal
@@ -85,7 +85,7 @@ public isolated client class Client {
     # + customer_id - Customer ID
     # + fields - Show only certain fields, specified by a comma-separated list of field names.
     # + return - Requested customer
-    resource isolated function get admin/api/'2021\-10/customers/[string customer_idJson](string? fields = ()) returns http:Response|error {
+    resource isolated function get admin/api/'2021\-10/customers/[string customer_idJson](string? fields = ()) returns error? {
         if !customer_idJson.endsWith(".json") {
             return error("bad URL");
         }
@@ -93,7 +93,6 @@ public isolated client class Client {
         string resourcePath = string `/admin/api/2021-10/customers/${getEncodedUri(customer_id)}.json`;
         map<anydata> queryParam = {"fields": fields};
         resourcePath = resourcePath + check getPathForQueryParam(queryParam);
-        http:Response response = check self.clientEp->get(resourcePath);
-        return response;
+        return check self.clientEp->get(resourcePath);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/reference_path.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/reference_path.bal
@@ -40,6 +40,6 @@ public isolated client class Client {
     resource isolated function post pet/[Param id]() returns error? {
         string resourcePath = string `/pet/${getEncodedUri(id)}`;
         http:Request request = new;
-        return check self.clientEp-> post(resourcePath, request);
+        return self.clientEp-> post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/reference_path.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/reference_path.bal
@@ -37,10 +37,9 @@ public isolated client class Client {
     #
     # + id - Id of the point
     # + return - Accepted
-    resource isolated function post pet/[Param id]() returns http:Response|error {
+    resource isolated function post pet/[Param id]() returns error? {
         string resourcePath = string `/pet/${getEncodedUri(id)}`;
         http:Request request = new;
-        http:Response response = check self.clientEp-> post(resourcePath, request);
-        return response;
+        return check self.clientEp-> post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/request_body.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/request_body.bal
@@ -39,82 +39,75 @@ public isolated client class Client {
     # 02 Example for rb has inline requestbody.
     #
     # + return - OK
-    resource isolated function put path01(Path01_body payload) returns http:Response|error {
+    resource isolated function put path01(Path01_body payload) returns error? {
         string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(resourcePath, request);
-        return response;
+        return check self.clientEp->put(resourcePath, request);
     }
     # 01 Request body with reference.
     #
     # + return - OK
-    resource isolated function post path01(User payload) returns http:Response|error {
+    resource isolated function post path01(User payload) returns error? {
         string resourcePath = string `/path01`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
     # 04 Example for rb has inline requestbody.
     #
     # + payload - A JSON object containing pet information
     # + return - OK
-    resource isolated function put path02(User payload) returns http:Response|error {
+    resource isolated function put path02(User payload) returns error? {
         string resourcePath = string `/path02`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->put(resourcePath, request);
-        return response;
+        return check self.clientEp->put(resourcePath, request);
     }
     # 03 Request body with record reference.
     #
     # + return - OK
-    resource isolated function post path02(User[] payload) returns http:Response|error {
+    resource isolated function post path02(User[] payload) returns error? {
         string resourcePath = string `/path02`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
     # 06 Example for rb has array inline requestbody.
     #
     # + return - OK
-    resource isolated function put path03(Path03_body payload) returns http:Response|error {
+    resource isolated function put path03(Path03_body payload) returns error? {
         string resourcePath = string `/path03`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->put(resourcePath, request);
-        return response;
+        return check self.clientEp->put(resourcePath, request);
     }
     # 05 Example for rb has array inline requestbody.
     #
     # + return - OK
-    resource isolated function post path03(Path03_body_1 payload) returns http:Response|error {
+    resource isolated function post path03(Path03_body_1 payload) returns error? {
         string resourcePath = string `/path03`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
     # 07 Example for rb has array inline requestbody.
     #
     # + return - OK
-    resource isolated function post path04(Path04_body[] payload) returns http:Response|error {
+    resource isolated function post path04(Path04_body[] payload) returns error? {
         string resourcePath = string `/path04`;
         http:Request request = new;
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        http:Response response = check self.clientEp->post(resourcePath, request);
-        return response;
+        return check self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/resource/ballerina/request_body.bal
+++ b/openapi-cli/src/test/resources/generators/client/resource/ballerina/request_body.bal
@@ -44,7 +44,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->put(resourcePath, request);
+        return self.clientEp->put(resourcePath, request);
     }
     # 01 Request body with reference.
     #
@@ -54,7 +54,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
     # 04 Example for rb has inline requestbody.
     #
@@ -65,7 +65,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->put(resourcePath, request);
+        return self.clientEp->put(resourcePath, request);
     }
     # 03 Request body with record reference.
     #
@@ -75,7 +75,7 @@ public isolated client class Client {
         http:Request request = new;
         json jsonBody = payload.toJson();
         request.setPayload(jsonBody, "application/json");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
     # 06 Example for rb has array inline requestbody.
     #
@@ -86,7 +86,7 @@ public isolated client class Client {
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        return check self.clientEp->put(resourcePath, request);
+        return self.clientEp->put(resourcePath, request);
     }
     # 05 Example for rb has array inline requestbody.
     #
@@ -97,7 +97,7 @@ public isolated client class Client {
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
     # 07 Example for rb has array inline requestbody.
     #
@@ -108,6 +108,6 @@ public isolated client class Client {
         json jsonBody = payload.toJson();
         xml? xmlBody = check xmldata:fromJson(jsonBody);
         request.setPayload(xmlBody, "application/xml");
-        return check self.clientEp->post(resourcePath, request);
+        return self.clientEp->post(resourcePath, request);
     }
 }

--- a/openapi-cli/src/test/resources/generators/client/swagger/return_type/all_return_type_operation.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/return_type/all_return_type_operation.yaml
@@ -103,6 +103,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /products/nocontent:
+    get:
+      summary: without return content type
+      tags:
+        - Products
+      responses:
+        "200":
+          description: An array of products
+
 components:
   securitySchemes:
     apikey:

--- a/openapi-cli/src/test/resources/generators/client/swagger/return_type/no_content_type.yaml
+++ b/openapi-cli/src/test/resources/generators/client/swagger/return_type/no_content_type.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.0
+info:
+  version: 0.0.0
+  title: Links example
+paths:
+  /users:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '101':
+          description: Switching protocols
+
+  /users02:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '201':
+          description: Created
+  /user3:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '301':
+          description: Moved Permanently
+  /user4:
+    post:
+      description: This status code will be generate with previous approach till we address the error status code.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '401':
+          description: Unauthorized
+
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        image:
+          type: string
+          format: byte
+        name:
+          type: string

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorConstants.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorConstants.java
@@ -407,4 +407,6 @@ public class GeneratorConstants {
     public static final String INT = "int";
     public static final String INT_SIGNED32 = "int:Signed32";
     public static final String DECIMAL = "decimal";
+    public static final String RETURN = "return";
+    public static final String ERROR_NILLABLE = "error?";
 }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
@@ -48,6 +48,7 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.PIPE_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
 import static io.ballerina.openapi.core.GeneratorConstants.DEFAULT_RETURN;
 import static io.ballerina.openapi.core.GeneratorConstants.ERROR;
+import static io.ballerina.openapi.core.GeneratorConstants.ERROR_NILLABLE;
 import static io.ballerina.openapi.core.GeneratorConstants.NILLABLE;
 import static io.ballerina.openapi.core.GeneratorUtils.convertOpenAPITypeToBallerina;
 import static io.ballerina.openapi.core.GeneratorUtils.extractReferenceType;
@@ -133,8 +134,8 @@ public class FunctionReturnTypeGenerator {
                 finalReturnType.append(NILLABLE);
             }
             return finalReturnType.toString();
-        } else if (noContentResponseFound){
-            return ERROR + NILLABLE;
+        } else if (noContentResponseFound) {
+            return ERROR_NILLABLE;
         } else {
             return DEFAULT_RETURN;
         }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
@@ -114,10 +114,12 @@ public class FunctionReturnTypeGenerator {
                             // Currently support for first media type
                             break;
                         }
+                    } else {
+                        noContentResponseFound = true;
                     }
                 }
                 if ((statusCode.startsWith("1") || statusCode.startsWith("2") || statusCode.startsWith("3")) &&
-                        response.getContent() == null && response.getHeaders() == null && response.getLinks() == null) {
+                        response.getContent() == null) {
                     noContentResponseFound = true;
                 }
             }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/client/FunctionReturnTypeGenerator.java
@@ -95,6 +95,7 @@ public class FunctionReturnTypeGenerator {
         if (operation.getResponses() != null) {
             ApiResponses responses = operation.getResponses();
             for (Map.Entry<String, ApiResponse> entry : responses.entrySet()) {
+                noContentResponseFound = false;
                 String statusCode = entry.getKey();
                 ApiResponse response = entry.getValue();
                 if (statusCode.startsWith("2")) {
@@ -113,9 +114,11 @@ public class FunctionReturnTypeGenerator {
                             // Currently support for first media type
                             break;
                         }
-                    } else {
-                        noContentResponseFound = true;
                     }
+                }
+                if ((statusCode.startsWith("1") || statusCode.startsWith("2") || statusCode.startsWith("3")) &&
+                        response.getContent() == null && response.getHeaders() == null && response.getLinks() == null) {
+                    noContentResponseFound = true;
                 }
             }
         }
@@ -128,6 +131,8 @@ public class FunctionReturnTypeGenerator {
                 finalReturnType.append(NILLABLE);
             }
             return finalReturnType.toString();
+        } else if (noContentResponseFound){
+            return ERROR + NILLABLE;
         } else {
             return DEFAULT_RETURN;
         }


### PR DESCRIPTION
## Purpose
> $https://github.com/ballerina-platform/ballerina-library/issues/5720

## Automation tests
 - Unit tests - Added
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.
