### PR TITLE
[1.8.x] Remove unused types from generated `types.bal` in service generation

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
@@ -167,11 +167,10 @@ public class BallerinaCodeGenerator {
         SyntaxTree schemaSyntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
         String schemaContent = Formatter.format(schemaSyntaxTree).toSourceCode();
 
-        if (filter.getTags().size() > 0) {
-            // Remove unused records and enums when generating the client by the tags given.
-            schemaContent = GeneratorUtils.removeUnusedEntities(schemaSyntaxTree, clientContent, schemaContent,
-                    serviceContent);
-        }
+        // Remove unused records and enums when generating the client and service.
+        schemaContent = GeneratorUtils.removeUnusedEntities(schemaSyntaxTree, clientContent, schemaContent,
+                serviceContent);
+
         if (!schemaContent.isBlank()) {
             sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.MODEL_SRC, srcPackage, TYPE_FILE_NAME,
                     (licenseHeader.isBlank() ? DEFAULT_FILE_HEADER : licenseHeader) + schemaContent));
@@ -439,8 +438,10 @@ public class BallerinaCodeGenerator {
                 ballerinaServiceGenerator.getTypeInclusionRecords());
         BallerinaTypesGenerator ballerinaSchemaGenerator = new BallerinaTypesGenerator(
                 openAPIDef, nullable, preGeneratedTypeDefNodes);
-        String schemaContent = Formatter.format(
-                ballerinaSchemaGenerator.generateSyntaxTree()).toSourceCode();
+        SyntaxTree schemaSyntaxTree = ballerinaSchemaGenerator.generateSyntaxTree();
+        String schemaContent = Formatter.format(schemaSyntaxTree).toString();
+        schemaContent = GeneratorUtils.removeUnusedEntities(schemaSyntaxTree, mainContent, schemaContent,
+                null);
         if (!schemaContent.isBlank() && !generateWithoutDataBinding) {
             sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, srcPackage, TYPE_FILE_NAME,
                     (licenseHeader.isBlank() ? DEFAULT_FILE_HEADER : licenseHeader) + schemaContent));

--- a/openapi-cli/src/test/resources/expected_gen/licenses/schema_for_both_service_client.bal
+++ b/openapi-cli/src/test/resources/expected_gen/licenses/schema_for_both_service_client.bal
@@ -61,16 +61,6 @@ public type ProxyConfig record {|
 
 public type Pets Pet[];
 
-public type Error record {
-    int code;
-    string message;
-};
-
-public type Dog record {
-    *Pet;
-    boolean bark?;
-};
-
 public type Pet record {
     int id;
     string name;

--- a/openapi-cli/src/test/resources/expected_gen/licenses/schema_for_service.bal
+++ b/openapi-cli/src/test/resources/expected_gen/licenses/schema_for_service.bal
@@ -3,16 +3,6 @@
 
 public type Pets Pet[];
 
-public type Error record {
-    int code;
-    string message;
-};
-
-public type Dog record {
-    *Pet;
-    boolean bark?;
-};
-
 public type Pet record {
     int id;
     string name;

--- a/openapi-cli/src/test/resources/expected_gen/licenses/schema_with_user_given_license.bal
+++ b/openapi-cli/src/test/resources/expected_gen/licenses/schema_with_user_given_license.bal
@@ -60,16 +60,6 @@ public type ProxyConfig record {|
 
 public type Pets Pet[];
 
-public type Error record {
-    int code;
-    string message;
-};
-
-public type Dog record {
-    *Pet;
-    boolean bark?;
-};
-
 public type Pet record {
     int id;
     string name;

--- a/openapi-cli/src/test/resources/expected_gen/licenses/types_for_both_service_client_generations.bal
+++ b/openapi-cli/src/test/resources/expected_gen/licenses/types_for_both_service_client_generations.bal
@@ -61,16 +61,6 @@ public type ProxyConfig record {|
 
 public type Pets Pet[];
 
-public type Error record {
-    int code;
-    string message;
-};
-
-public type Dog record {
-    *Pet;
-    boolean bark?;
-};
-
 public type Pet record {
     int id;
     string name;

--- a/openapi-cli/src/test/resources/expected_gen/petstore_schema.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_schema.bal
@@ -61,16 +61,6 @@ public type ProxyConfig record {|
 
 public type Pets Pet[];
 
-public type Error record {
-    int code;
-    string message;
-};
-
-public type Dog record {
-    *Pet;
-    boolean bark?;
-};
-
 public type Pet record {
     int id;
     string name;

--- a/openapi-cli/src/test/resources/expected_gen/petstore_schema_type.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_schema_type.bal
@@ -59,8 +59,6 @@ public type ProxyConfig record {|
     string password = "";
 |};
 
-public type PetArr Pet[];
-
 public type Pet record {
     int petId;
     string name;

--- a/openapi-cli/src/test/resources/expected_gen/petstore_schema_with_license.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_schema_with_license.bal
@@ -60,16 +60,6 @@ public type ProxyConfig record {|
 
 public type Pets Pet[];
 
-public type Error record {
-    int code;
-    string message;
-};
-
-public type Dog record {
-    *Pet;
-    boolean bark?;
-};
-
 public type Pet record {
     int id;
     string name;

--- a/openapi-cli/src/test/resources/expected_gen/petstore_wildcard_types.bal
+++ b/openapi-cli/src/test/resources/expected_gen/petstore_wildcard_types.bal
@@ -4,22 +4,3 @@ public type OkAnydata record {|
     *http:Ok;
     anydata body;
 |};
-
-public type Pets Pet[];
-
-public type Error record {
-    int code;
-    string message;
-};
-
-public type Dog record {
-    *Pet;
-    boolean bark?;
-};
-
-public type Pet record {
-    int id;
-    string name;
-    string tag?;
-    string 'type?;
-};

--- a/openapi-cli/src/test/resources/expected_gen/without-data-binding-type.bal
+++ b/openapi-cli/src/test/resources/expected_gen/without-data-binding-type.bal
@@ -1,0 +1,1 @@
+public type Coupon string;

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -1017,7 +1017,8 @@ public class GeneratorUtils {
                         unusedTypeDefinitionNameList.add(symbol.getName().get());
                     } else if (references.size() == 2) {
                         if (symbol.kind().equals(SymbolKind.TYPE_DEFINITION)) {
-                            handleCyclicRecord(unusedTypeDefinitionNameList, symbol);
+                            TypeDefinitionSymbol typeDef = (TypeDefinitionSymbol) symbol;
+                            handleCyclicType(unusedTypeDefinitionNameList, typeDef);
                         }
                     }
                 }
@@ -1033,10 +1034,10 @@ public class GeneratorUtils {
         return unusedTypeDefinitionNameList;
     }
 
-    private static void handleCyclicRecord(List<String> unusedTypeDefinitionNameList, Symbol symbol) {
-        TypeDefinitionSymbol typeDef = (TypeDefinitionSymbol) symbol;
-        if (typeDef.typeDescriptor().typeKind().equals(TypeDescKind.RECORD)) {
-            RecordTypeSymbol recordTypeSymbol = (RecordTypeSymbol) typeDef.typeDescriptor();
+    private static void handleCyclicType(List<String> unusedTypeDefinitionNameList, TypeDefinitionSymbol symbol) {
+        TypeDescKind typeDescKind = symbol.typeDescriptor().typeKind();
+        if (typeDescKind.equals(TypeDescKind.RECORD)) {
+            RecordTypeSymbol recordTypeSymbol = (RecordTypeSymbol) symbol.typeDescriptor();
             Map<String, RecordFieldSymbol> fields = recordTypeSymbol.fieldDescriptors();
             Collection<RecordFieldSymbol> values = fields.values();
             boolean isCyclic = false;
@@ -1052,6 +1053,8 @@ public class GeneratorUtils {
                 unusedTypeDefinitionNameList.add(symbol.getName().get());
             }
         }
+        //TODO: Handle cyclic type for other ex: array after this fix
+        //https://github.com/ballerina-platform/ballerina-lang/issues/36442
     }
 
     private static void writeFilesTemp(Map<String, String> srcFiles, Path tmpDir) throws IOException {

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -19,8 +19,12 @@
 package io.ballerina.openapi.core;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
+import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.syntax.tree.AbstractNodeFactory;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
 import io.ballerina.compiler.syntax.tree.BuiltinSimpleNameReferenceNode;
@@ -95,6 +99,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -890,7 +895,7 @@ public class GeneratorUtils {
         tempSourceFiles.put(CLIENT_FILE_NAME, clientContent);
         tempSourceFiles.put(TYPE_FILE_NAME, schemaContent);
         if (serviceContent != null) {
-            tempSourceFiles.put(SERVICE_FILE_NAME, schemaContent);
+            tempSourceFiles.put(SERVICE_FILE_NAME, serviceContent);
         }
         List<String> unusedTypeDefinitionNameList = getUnusedTypeDefinitionNameList(tempSourceFiles);
         while (unusedTypeDefinitionNameList.size() > 0) {
@@ -998,15 +1003,22 @@ public class GeneratorUtils {
         List<String> unusedTypeDefinitionNameList = new ArrayList<>();
         Path tmpDir = Files.createTempDirectory(".openapi-tmp" + System.nanoTime());
         writeFilesTemp(srcFiles, tmpDir);
-        if (Files.exists(tmpDir.resolve(CLIENT_FILE_NAME)) && Files.exists(tmpDir.resolve(TYPE_FILE_NAME)) &&
+        if ((Files.exists(tmpDir.resolve(CLIENT_FILE_NAME)) || Files.exists(tmpDir.resolve(SERVICE_FILE_NAME)))
+                && Files.exists(tmpDir.resolve(TYPE_FILE_NAME)) &&
                 Files.exists(tmpDir.resolve(BALLERINA_TOML))) {
-            SemanticModel semanticModel = getSemanticModel(tmpDir.resolve(CLIENT_FILE_NAME));
+            SemanticModel semanticModel = Files.exists(tmpDir.resolve(CLIENT_FILE_NAME)) ?
+                    getSemanticModel(tmpDir.resolve(CLIENT_FILE_NAME)) :
+                    getSemanticModel(tmpDir.resolve(SERVICE_FILE_NAME));
             List<Symbol> symbols = semanticModel.moduleSymbols();
             for (Symbol symbol : symbols) {
                 if (symbol.kind().equals(SymbolKind.TYPE_DEFINITION) || symbol.kind().equals(SymbolKind.ENUM)) {
                     List<Location> references = semanticModel.references(symbol);
                     if (references.size() == 1) {
                         unusedTypeDefinitionNameList.add(symbol.getName().get());
+                    } else if (references.size() == 2) {
+                        if (symbol.kind().equals(SymbolKind.TYPE_DEFINITION)) {
+                            handleCyclicRecord(unusedTypeDefinitionNameList, symbol);
+                        }
                     }
                 }
             }
@@ -1019,6 +1031,27 @@ public class GeneratorUtils {
             }
         }));
         return unusedTypeDefinitionNameList;
+    }
+
+    private static void handleCyclicRecord(List<String> unusedTypeDefinitionNameList, Symbol symbol) {
+        TypeDefinitionSymbol typeDef = (TypeDefinitionSymbol) symbol;
+        if (typeDef.typeDescriptor().typeKind().equals(TypeDescKind.RECORD)) {
+            RecordTypeSymbol recordTypeSymbol = (RecordTypeSymbol) typeDef.typeDescriptor();
+            Map<String, RecordFieldSymbol> fields = recordTypeSymbol.fieldDescriptors();
+            Collection<RecordFieldSymbol> values = fields.values();
+            boolean isCyclic = false;
+            for (RecordFieldSymbol field: values) {
+                if (field.typeDescriptor().getName().isPresent()) {
+                    if (field.typeDescriptor().getName().get().trim().equals(symbol.getName().get().trim())) {
+                        isCyclic = true;
+                        break;
+                    }
+                }
+            }
+            if (isCyclic) {
+                unusedTypeDefinitionNameList.add(symbol.getName().get());
+            }
+        }
     }
 
     private static void writeFilesTemp(Map<String, String> srcFiles, Path tmpDir) throws IOException {

--- a/openapi-integration-tests/src/test/resources/service/return/ballerina/multiple_mediatype_for_one_response_code.bal
+++ b/openapi-integration-tests/src/test/resources/service/return/ballerina/multiple_mediatype_for_one_response_code.bal
@@ -10,15 +10,3 @@ public type User record {
     string firstName?;
     string lastName?;
 };
-
-public type PetForm record {
-    string userName;
-    string firstName?;
-    string lastName?;
-};
-
-public type Pet record {
-    string userName;
-    string firstName?;
-    string lastName?;
-};

--- a/openapi-integration-tests/src/test/resources/service/return/ballerina/response_has_inline_record.bal
+++ b/openapi-integration-tests/src/test/resources/service/return/ballerina/response_has_inline_record.bal
@@ -5,27 +5,9 @@ public type BadRequestInline_response_400 record {|
     Inline_response_400 body;
 |};
 
-public type User record {
-    string userName;
-    string firstName?;
-    string lastName?;
-};
-
-public type PetForm record {
-    string userName;
-    string firstName?;
-    string lastName?;
-};
-
 public type Inline_response_400 record {
     # The error ID.
     int id?;
     # The error name.
     string errorType?;
-};
-
-public type Pet record {
-    string userName;
-    string firstName?;
-    string lastName?;
 };


### PR DESCRIPTION
## Purpose
> Related PR: https://github.com/ballerina-platform/openapi-tools/pull/1578
Fix: https://github.com/ballerina-platform/ballerina-library/issues/5731

This fix will be available with the 2201.8.5 version onwards 
## Automation tests
 - Unit tests - added
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage