### PR TITLE
[master] Fix for service and client generation when OAS include parameterized path segmentes in paths

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
@@ -106,9 +106,9 @@ public class BallerinaCodeGenerator {
         OpenAPI openAPIDef = GeneratorUtils.normalizeOpenAPI(openAPIPath, !isResource);
         checkOpenAPIVersion(openAPIDef);
         // Generate service
-        String concatTitle = serviceName.toLowerCase(Locale.ENGLISH);
-        String srcFile = concatTitle + "_service.bal";
-        List<String> complexPaths = GeneratorUtils.collectComplexPaths(openAPIDef);
+        String serviceTitle = serviceName.toLowerCase(Locale.ENGLISH);
+        String srcFile = String.format("%s_service.bal", serviceTitle);
+        List<String> complexPaths = GeneratorUtils.getComplexPaths(openAPIDef);
         if (!complexPaths.isEmpty()) {
             isResource = false;
             outStream.println("remote function(s) will be generated for client and the service generation can not be " +
@@ -358,7 +358,7 @@ public class BallerinaCodeGenerator {
         OpenAPI openAPIDef = GeneratorUtils.normalizeOpenAPI(openAPI, !isResource);
         checkOpenAPIVersion(openAPIDef);
         // Validate the service generation
-        List<String> complexPaths = GeneratorUtils.collectComplexPaths(openAPIDef);
+        List<String> complexPaths = GeneratorUtils.getComplexPaths(openAPIDef);
         if (!complexPaths.isEmpty()) {
             outStream.println("remote function(s) will be generated for client due to the given openapi definition" +
                     " contains following complex path(s):");
@@ -446,7 +446,7 @@ public class BallerinaCodeGenerator {
             openAPIDef.getInfo().setTitle(serviceName);
         }
         // Validate the service generation
-        List<String> complexPaths = GeneratorUtils.collectComplexPaths(openAPIDef);
+        List<String> complexPaths = GeneratorUtils.getComplexPaths(openAPIDef);
         if (!complexPaths.isEmpty()) {
             outStream.println("service generation can not be done due to the given openapi definition contains" +
                     " following complex path(s):");

--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
@@ -108,26 +108,14 @@ public class BallerinaCodeGenerator {
         // Generate service
         String concatTitle = serviceName.toLowerCase(Locale.ENGLISH);
         String srcFile = concatTitle + "_service.bal";
-        OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
-                .withOpenAPI(openAPIDef)
-                .withFilters(filter)
-                .withNullable(nullable)
-                .withGenerateServiceType(generateServiceType)
-                .withGenerateWithoutDataBinding(generateWithoutDataBinding)
-                .build();
-        BallerinaServiceGenerator serviceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
-        String serviceContent = Formatter.format
-                (serviceGenerator.generateSyntaxTree()).toSourceCode();
-        sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, srcPackage, srcFile,
-                (licenseHeader.isBlank() ? DEFAULT_FILE_HEADER : licenseHeader) + serviceContent));
-
-        if (generateServiceType) {
-            BallerinaServiceObjectGenerator ballerinaServiceObjectGenerator = new
-                    BallerinaServiceObjectGenerator(serviceGenerator.getFunctionList());
-            String serviceType = Formatter.format(ballerinaServiceObjectGenerator.generateSyntaxTree()).toSourceCode();
-            sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, srcPackage,
-                    "service_type.bal", (licenseHeader.isBlank() ? DO_NOT_MODIFY_FILE_HEADER :
-                    licenseHeader) + serviceType));
+        List<String> complexPaths = GeneratorUtils.collectComplexPaths(openAPIDef);
+        if (!complexPaths.isEmpty()) {
+            isResource = false;
+            outStream.println("remote function(s) will be generated for client and the service generation can not be " +
+                    "proceed due to the given openapi definition contains following complex path(s):");
+            for (String path: complexPaths) {
+                outStream.println(path);
+            }
         }
         // Generate client.
         // Generate ballerina client remote.
@@ -154,10 +142,35 @@ public class BallerinaCodeGenerator {
         //Update type definition list
         List<TypeDefinitionNode> preGeneratedTypeDefNodes = new ArrayList<>(
                 clientGenerator.getBallerinaAuthConfigGenerator().getAuthRelatedTypeDefinitionNodes());
-        List<TypeDefinitionNode> typeInclusionRecords = serviceGenerator.getTypeInclusionRecords();
         List<TypeDefinitionNode> typeDefinitionNodeList = clientGenerator.getTypeDefinitionNodeList();
-        preGeneratedTypeDefNodes.addAll(typeInclusionRecords);
         preGeneratedTypeDefNodes.addAll(typeDefinitionNodeList);
+        String serviceContent = "";
+        if (complexPaths.isEmpty()) {
+            OASServiceMetadata oasServiceMetadata = new OASServiceMetadata.Builder()
+                    .withOpenAPI(openAPIDef)
+                    .withFilters(filter)
+                    .withNullable(nullable)
+                    .withGenerateServiceType(generateServiceType)
+                    .withGenerateWithoutDataBinding(generateWithoutDataBinding)
+                    .build();
+            BallerinaServiceGenerator serviceGenerator = new BallerinaServiceGenerator(oasServiceMetadata);
+            serviceContent = Formatter.format
+                    (serviceGenerator.generateSyntaxTree()).toSourceCode();
+            sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, srcPackage, srcFile,
+                    (licenseHeader.isBlank() ? DEFAULT_FILE_HEADER : licenseHeader) + serviceContent));
+
+            if (generateServiceType) {
+                BallerinaServiceObjectGenerator ballerinaServiceObjectGenerator = new
+                        BallerinaServiceObjectGenerator(serviceGenerator.getFunctionList());
+                String serviceType = Formatter.format(ballerinaServiceObjectGenerator.generateSyntaxTree()).
+                        toSourceCode();
+                sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, srcPackage,
+                        "service_type.bal", (licenseHeader.isBlank() ? DO_NOT_MODIFY_FILE_HEADER :
+                        licenseHeader) + serviceType));
+            }
+            List<TypeDefinitionNode> typeInclusionRecords = serviceGenerator.getTypeInclusionRecords();
+            preGeneratedTypeDefNodes.addAll(typeInclusionRecords);
+        }
 
         // Generate ballerina types.
         // Generate ballerina records to represent schemas.
@@ -222,7 +235,9 @@ public class BallerinaCodeGenerator {
         Path srcPath = Paths.get(outPath);
         Path implPath = CodegenUtils.getImplPath(srcPackage, srcPath);
         List<GenSrcFile> genFiles = generateClientFiles(Paths.get(definitionPath), filter, nullable, isResource);
-        writeGeneratedSources(genFiles, srcPath, implPath, GEN_CLIENT);
+        if (!genFiles.isEmpty()) {
+            writeGeneratedSources(genFiles, srcPath, implPath, GEN_CLIENT);
+        }
     }
 
     /**
@@ -244,6 +259,9 @@ public class BallerinaCodeGenerator {
         Path implPath = CodegenUtils.getImplPath(srcPackage, srcPath);
         List<GenSrcFile> genFiles = generateBallerinaService(Paths.get(definitionPath), serviceName,
                 filter, nullable, generateServiceType, generateWithoutDataBinding);
+        if (genFiles.isEmpty()) {
+            return;
+        }
         writeGeneratedSources(genFiles, srcPath, implPath, GEN_SERVICE);
     }
 
@@ -339,6 +357,16 @@ public class BallerinaCodeGenerator {
         // Normalize OpenAPI definition
         OpenAPI openAPIDef = GeneratorUtils.normalizeOpenAPI(openAPI, !isResource);
         checkOpenAPIVersion(openAPIDef);
+        // Validate the service generation
+        List<String> complexPaths = GeneratorUtils.collectComplexPaths(openAPIDef);
+        if (!complexPaths.isEmpty()) {
+            outStream.println("remote function(s) will be generated for client due to the given openapi definition" +
+                    " contains following complex path(s):");
+            for (String path: complexPaths) {
+                outStream.println(path);
+            }
+            isResource = false;
+        }
         // Generate ballerina service and resources.
         OASClientConfig.Builder clientMetaDataBuilder = new OASClientConfig.Builder();
         OASClientConfig oasClientConfig = clientMetaDataBuilder
@@ -417,7 +445,16 @@ public class BallerinaCodeGenerator {
         } else {
             openAPIDef.getInfo().setTitle(serviceName);
         }
-
+        // Validate the service generation
+        List<String> complexPaths = GeneratorUtils.collectComplexPaths(openAPIDef);
+        if (!complexPaths.isEmpty()) {
+            outStream.println("service generation can not be done due to the given openapi definition contains" +
+                    " following complex path(s):");
+            for (String path: complexPaths) {
+                outStream.println(path);
+            }
+            return new ArrayList<>();
+        }
         List<GenSrcFile> sourceFiles = new ArrayList<>();
         String concatTitle = serviceName == null ?
                 openAPIDef.getInfo().getTitle().toLowerCase(Locale.ENGLISH) :

--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
@@ -82,7 +82,7 @@ public class BallerinaCodeGenerator {
     private String licenseHeader = "";
     private boolean includeTestFiles;
 
-    private static final PrintStream outStream = System.err;
+    private static final PrintStream outStream = System.out;
 
     /**
      * Generates ballerina source for provided Open API Definition in {@code definitionPath}.

--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
@@ -111,8 +111,9 @@ public class BallerinaCodeGenerator {
         List<String> complexPaths = GeneratorUtils.getComplexPaths(openAPIDef);
         if (!complexPaths.isEmpty()) {
             isResource = false;
-            outStream.println("remote function(s) will be generated for client and the service generation can not be " +
-                    "proceed due to the given openapi definition contains following complex path(s):");
+            outStream.println("WARNING: remote function(s) will be generated for client and the service" +
+                    " generation can not be proceed due to the given openapi definition contains following" +
+                    " complex path(s):");
             for (String path: complexPaths) {
                 outStream.println(path);
             }
@@ -360,8 +361,8 @@ public class BallerinaCodeGenerator {
         // Validate the service generation
         List<String> complexPaths = GeneratorUtils.getComplexPaths(openAPIDef);
         if (!complexPaths.isEmpty()) {
-            outStream.println("remote function(s) will be generated for client due to the given openapi definition" +
-                    " contains following complex path(s):");
+            outStream.println("WARNING: remote function(s) will be generated for client due to the given openapi " +
+                    "definition contains following complex path(s):");
             for (String path: complexPaths) {
                 outStream.println(path);
             }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
@@ -704,7 +704,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         OpenApiCmd cmd = new OpenApiCmd(standardOut, tmpDir, false);
         new CommandLine(cmd).parseArgs(args);
         cmd.execute();
-        Assert.assertTrue(outputStream.toString().contains("remote function(s) will be generated for client " +
+        Assert.assertTrue(outputStream.toString().contains("WARNING: remote function(s) will be generated for client " +
                 "due to the given openapi definition contains following complex path(s):" + System.lineSeparator() +
                 "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo" + System.lineSeparator() +
                 "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom" + System.lineSeparator() +
@@ -724,7 +724,7 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         OpenApiCmd cmd = new OpenApiCmd(standardOut, tmpDir, false);
         new CommandLine(cmd).parseArgs(args);
         cmd.execute();
-        Assert.assertTrue(outputStream.toString().contains("remote function(s) will be generated for client" +
+        Assert.assertTrue(outputStream.toString().contains("WARNING: remote function(s) will be generated for client" +
                 " and the service generation can not be proceed due to the given openapi definition contains" +
                 " following complex path(s):" + System.lineSeparator() +
                 "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo" + System.lineSeparator() +

--- a/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
@@ -29,8 +29,10 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import picocli.CommandLine;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -43,10 +45,14 @@ import java.util.stream.Stream;
 public class OpenAPICmdTest extends OpenAPICommandTest {
 
     private static final String LINE_SEPARATOR = System.lineSeparator();
+    private final PrintStream standardOut = System.out;
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
 
     @BeforeTest(description = "This will create a new ballerina project for testing below scenarios.")
     public void setupBallerinaProject() throws IOException {
         super.setup();
+        System.setOut(new PrintStream(outputStream));
     }
 
     @Test(description = "Test openapi command with help flag")
@@ -650,9 +656,89 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
                 equals("..\\..\\dir2\\dir3\\dir4\\test.txt"));
     }
 
+    @Test(description = "service generation for the parameterized path in OAS")
+    public void testForComplexPathInService() {
+        Path yamlContract = resourceDir.resolve(Paths.get("complexPath.yaml"));
+        String[] args = {"--input", yamlContract.toString(), "-o", this.tmpDir.toString(), "--mode", "service"};
+        OpenApiCmd cmd = new OpenApiCmd(standardOut, tmpDir, false);
+        new CommandLine(cmd).parseArgs(args);
+        cmd.execute();
+        Assert.assertTrue(outputStream.toString().contains("service generation can not be done due to the given" +
+                " openapi definition contains following complex path(s):\n" +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo\n" +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom\n" +
+                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo\n" +
+                "/payroll/v1/workers/{associateoid}/organizational-pay-statements/{payStatementId}/images/" +
+                "{imageId}.{imageExtension}\n" +
+                "/v3/ClientGroups/GetClientGroupByUserDefinedIdentifier(UserDefinedIdentifier=" +
+                "'{userDefinedIdentifier}')\n" +
+                "/companies({company_id})/items({item_id})"));
+    }
+
+    @Test(description = "service type generation for the parameterized path in OAS")
+    public void testForComplexPathInServiceType() {
+        Path yamlContract = resourceDir.resolve(Paths.get("complexPath.yaml"));
+        String[] args = {"--input", yamlContract.toString(), "-o", this.tmpDir.toString(), "--mode", "service",
+                "--with-service-type"};
+        OpenApiCmd cmd = new OpenApiCmd(standardOut, tmpDir, false);
+        new CommandLine(cmd).parseArgs(args);
+        cmd.execute();
+        Assert.assertTrue(outputStream.toString().contains("service generation can not be done due to the " +
+                "given openapi definition contains following complex path(s):\n" +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo\n" +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom\n" +
+                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo\n" +
+                "/payroll/v1/workers/{associateoid}/organizational-pay-statements/{payStatementId}/images/" +
+                "{imageId}.{imageExtension}\n" +
+                "/v3/ClientGroups/GetClientGroupByUserDefinedIdentifier(UserDefinedIdentifier='" +
+                "{userDefinedIdentifier}')\n" +
+                "/companies({company_id})/items({item_id})"));
+    }
+
+    @Test(description = "client generation for the parameterized path in OAS")
+    public void testForComplexPathInClient() {
+        Path yamlContract = resourceDir.resolve(Paths.get("complexPath.yaml"));
+        String[] args = {"--input", yamlContract.toString(), "-o", this.tmpDir.toString(), "--mode", "client"};
+        OpenApiCmd cmd = new OpenApiCmd(standardOut, tmpDir, false);
+        new CommandLine(cmd).parseArgs(args);
+        cmd.execute();
+        Assert.assertTrue(outputStream.toString().contains("remote function(s) will be generated for client " +
+                "due to the given openapi definition contains following complex path(s):\n" +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo\n" +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom\n" +
+                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo\n" +
+                "/payroll/v1/workers/{associateoid}/organizational-pay-statements/{payStatementId}/images/" +
+                "{imageId}.{imageExtension}\n" +
+                "/v3/ClientGroups/GetClientGroupByUserDefinedIdentifier(UserDefinedIdentifier=" +
+                "'{userDefinedIdentifier}')\n" +
+                "/companies({company_id})/items({item_id})\n" +
+                "Client generated successfully."));
+    }
+
+    @Test(description = "both client and service generation for the parameterized path in OAS")
+    public void testForComplexPathInBothClientAndService() {
+        Path yamlContract = resourceDir.resolve(Paths.get("complexPath.yaml"));
+        String[] args = {"--input", yamlContract.toString(), "-o", this.tmpDir.toString()};
+        OpenApiCmd cmd = new OpenApiCmd(standardOut, tmpDir, false);
+        new CommandLine(cmd).parseArgs(args);
+        cmd.execute();
+        Assert.assertTrue(outputStream.toString().contains("remote function(s) will be generated for client" +
+                " and the service generation can not be proceed due to the given openapi definition contains" +
+                " following complex path(s):\n" +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo\n" +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom\n" +
+                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo\n" +
+                "/payroll/v1/workers/{associateoid}/organizational-pay-statements/{payStatementId}/images/" +
+                "{imageId}.{imageExtension}\n" +
+                "/v3/ClientGroups/GetClientGroupByUserDefinedIdentifier(UserDefinedIdentifier=" +
+                "'{userDefinedIdentifier}')\n" +
+                "/companies({company_id})/items({item_id})\n" +
+                "Following files were created."));
+    }
+
     @AfterTest
     public void clean() {
         System.setErr(null);
-        System.setOut(null);
+        System.setOut(standardOut);
     }
 }

--- a/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/cmd/OpenAPICmdTest.java
@@ -663,16 +663,18 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         OpenApiCmd cmd = new OpenApiCmd(standardOut, tmpDir, false);
         new CommandLine(cmd).parseArgs(args);
         cmd.execute();
-        Assert.assertTrue(outputStream.toString().contains("service generation can not be done due to the given" +
-                " openapi definition contains following complex path(s):\n" +
-                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo\n" +
-                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom\n" +
-                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo\n" +
+        String expectedOutput = "service generation can not be done due to the given" +
+                " openapi definition contains following complex path(s):" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo" + System.lineSeparator() +
                 "/payroll/v1/workers/{associateoid}/organizational-pay-statements/{payStatementId}/images/" +
-                "{imageId}.{imageExtension}\n" +
+                "{imageId}.{imageExtension}" + System.lineSeparator() +
                 "/v3/ClientGroups/GetClientGroupByUserDefinedIdentifier(UserDefinedIdentifier=" +
-                "'{userDefinedIdentifier}')\n" +
-                "/companies({company_id})/items({item_id})"));
+                "'{userDefinedIdentifier}')" + System.lineSeparator() +
+                "/companies({company_id})/items({item_id})";
+
+        Assert.assertTrue(outputStream.toString().contains(expectedOutput));
     }
 
     @Test(description = "service type generation for the parameterized path in OAS")
@@ -684,14 +686,14 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         new CommandLine(cmd).parseArgs(args);
         cmd.execute();
         Assert.assertTrue(outputStream.toString().contains("service generation can not be done due to the " +
-                "given openapi definition contains following complex path(s):\n" +
-                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo\n" +
-                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom\n" +
-                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo\n" +
+                "given openapi definition contains following complex path(s):" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo" + System.lineSeparator() +
                 "/payroll/v1/workers/{associateoid}/organizational-pay-statements/{payStatementId}/images/" +
-                "{imageId}.{imageExtension}\n" +
+                "{imageId}.{imageExtension}" + System.lineSeparator() +
                 "/v3/ClientGroups/GetClientGroupByUserDefinedIdentifier(UserDefinedIdentifier='" +
-                "{userDefinedIdentifier}')\n" +
+                "{userDefinedIdentifier}')" + System.lineSeparator() +
                 "/companies({company_id})/items({item_id})"));
     }
 
@@ -703,15 +705,15 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         new CommandLine(cmd).parseArgs(args);
         cmd.execute();
         Assert.assertTrue(outputStream.toString().contains("remote function(s) will be generated for client " +
-                "due to the given openapi definition contains following complex path(s):\n" +
-                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo\n" +
-                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom\n" +
-                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo\n" +
+                "due to the given openapi definition contains following complex path(s):" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo" + System.lineSeparator() +
                 "/payroll/v1/workers/{associateoid}/organizational-pay-statements/{payStatementId}/images/" +
-                "{imageId}.{imageExtension}\n" +
+                "{imageId}.{imageExtension}" + System.lineSeparator() +
                 "/v3/ClientGroups/GetClientGroupByUserDefinedIdentifier(UserDefinedIdentifier=" +
-                "'{userDefinedIdentifier}')\n" +
-                "/companies({company_id})/items({item_id})\n" +
+                "'{userDefinedIdentifier}')" + System.lineSeparator() +
+                "/companies({company_id})/items({item_id})" + System.lineSeparator() +
                 "Client generated successfully."));
     }
 
@@ -724,15 +726,15 @@ public class OpenAPICmdTest extends OpenAPICommandTest {
         cmd.execute();
         Assert.assertTrue(outputStream.toString().contains("remote function(s) will be generated for client" +
                 " and the service generation can not be proceed due to the given openapi definition contains" +
-                " following complex path(s):\n" +
-                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo\n" +
-                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom\n" +
-                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo\n" +
+                " following complex path(s):" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom" + System.lineSeparator() +
+                "/v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo" + System.lineSeparator() +
                 "/payroll/v1/workers/{associateoid}/organizational-pay-statements/{payStatementId}/images/" +
-                "{imageId}.{imageExtension}\n" +
+                "{imageId}.{imageExtension}" + System.lineSeparator() +
                 "/v3/ClientGroups/GetClientGroupByUserDefinedIdentifier(UserDefinedIdentifier=" +
-                "'{userDefinedIdentifier}')\n" +
-                "/companies({company_id})/items({item_id})\n" +
+                "'{userDefinedIdentifier}')" + System.lineSeparator() +
+                "/companies({company_id})/items({item_id})" + System.lineSeparator() +
                 "Following files were created."));
     }
 

--- a/openapi-cli/src/test/resources/complexPath.yaml
+++ b/openapi-cli/src/test/resources/complexPath.yaml
@@ -1,0 +1,139 @@
+openapi: 3.0.0
+info:
+  title: Formstack API
+  version: "2.0"
+servers:
+  - url: https://www.formstack.com/api/v2
+
+paths:
+  /v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo:
+    post:
+      operationId: post1
+      parameters:
+        - in: path
+          name: spreadsheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Successful response
+  /v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyFrom:
+    post:
+      operationId: post2
+      parameters:
+        - in: path
+          name: spreadsheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Successful response
+  /v4/spreadsheets/{spreadsheetId}.{sheetId}/sheets/{sheetId}:copyTo:
+    post:
+      operationId: post3
+      parameters:
+        - in: path
+          name: spreadsheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Successful response
+  /payroll/v1/workers/{associateoid}/organizational-pay-statements/{payStatementId}/images/{imageId}.{imageExtension}:
+    post:
+      operationId: post4
+      parameters:
+        - in: path
+          name: associateoid
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: payStatementId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: imageId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: imageExtension
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Successful response
+  /v3/ClientGroups/GetClientGroupByUserDefinedIdentifier(UserDefinedIdentifier='{userDefinedIdentifier}'):
+    post:
+      operationId: post5
+      parameters:
+        - in: path
+          name: userDefinedIdentifier
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Successful response
+  /companies({company_id})/items({item_id}):
+    post:
+      operationId: post6
+      parameters:
+        - in: path
+          name: company_id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: item_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Successful response

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -1182,7 +1182,7 @@ public class GeneratorUtils {
      * @param openAPI - openAPI definition.
      * @return List of complex paths
      */
-    public static List<String> collectComplexPaths(OpenAPI openAPI) {
+    public static List<String> getComplexPaths(OpenAPI openAPI) {
         //Check given openapi has complex path
         List<String> complexPathList = new ArrayList<>();
         if (openAPI.getPaths() != null) {

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -1175,4 +1175,23 @@ public class GeneratorUtils {
         }
         return type;
     }
+
+    /**
+     *  Filter the complex paths.
+     *
+     * @param openAPI
+     * @return
+     */
+    public static List<String> collectComplexPaths(OpenAPI openAPI) {
+        //Check given openapi has complex path
+        List<String> complexPathList = new ArrayList<>();
+        if (openAPI.getPaths() != null) {
+            for (Map.Entry<String, PathItem> path : openAPI.getPaths().entrySet()) {
+                if (isComplexURL(path.getKey())) {
+                    complexPathList.add(path.getKey());
+                }
+            }
+        }
+        return complexPathList;
+    }
 }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/GeneratorUtils.java
@@ -1177,10 +1177,10 @@ public class GeneratorUtils {
     }
 
     /**
-     *  Filter the complex paths.
+     *  Collect the complex paths in the OAS definition.
      *
-     * @param openAPI
-     * @return
+     * @param openAPI - openAPI definition.
+     * @return List of complex paths
      */
     public static List<String> collectComplexPaths(OpenAPI openAPI) {
         //Check given openapi has complex path


### PR DESCRIPTION
## Purpose
> https://github.com/ballerina-platform/ballerina-library/issues/4850
Solution:

- It has been concluded during our discussion regarding the specification that remote functions should be generated for the OpenAPI contract that includes handling complex URLs such as parameterized sub-segments, as discussed here: https://github.com/ballerina-platform/ballerina-spec/issues/1238. within the tool, the fix will be to automatically fall in back to generate a remote function for the entire yaml by providing a warning message.

- For the service resource functions, we are not going to generate resource functions for the given contract.
## Automation tests
 - Unit tests - Added
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.