### PR TITLE
Fix minor issues found in RC testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ apply plugin: "org.javamodularity.moduleplugin"
 apply from: "$rootDir/gradle/javaProject.gradle"
 
 ext.clientNativeVersion = project.clientNativeVersion
-ext.skipClientNativePublish = project.skipClientNativePublish
+ext.clientNativePublish = project.clientNativePublish
 ext.ballerinaLangVersion = project.ballerinaLangVersion
 ext.testngVersion = project.testngVersion
 ext.commonsLang3Version = project.commonsLang3Version

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ apply plugin: "org.javamodularity.moduleplugin"
 apply from: "$rootDir/gradle/javaProject.gradle"
 
 ext.clientNativeVersion = project.clientNativeVersion
+ext.skipClientNativePublish = project.skipClientNativePublish
 ext.ballerinaLangVersion = project.ballerinaLangVersion
 ext.testngVersion = project.testngVersion
 ext.commonsLang3Version = project.commonsLang3Version

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ version=1.9.0-SNAPSHOT
 
 # Client Native Version
 clientNativeVersion=1.0.0-SNAPSHOT
-# Mark this as true to skip publishing the client native artifacts
-skipClientNativePublish=false
+# Mark this as false to skip publishing the client native artifacts
+clientNativePublish=true
 
 #dependency
 ballerinaLangVersion=2201.9.0-20240419-152500-bd530dd2

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,8 @@ version=1.9.0-SNAPSHOT
 
 # Client Native Version
 clientNativeVersion=1.0.0-SNAPSHOT
+# Mark this as true to skip publishing the client native artifacts
+skipClientNativePublish=false
 
 #dependency
 ballerinaLangVersion=2201.9.0-20240419-152500-bd530dd2

--- a/openapi-bal-task-plugin/src/main/java/io/ballerina/openapi/bal/tool/OpenAPICodeGeneratorTool.java
+++ b/openapi-bal-task-plugin/src/main/java/io/ballerina/openapi/bal/tool/OpenAPICodeGeneratorTool.java
@@ -466,16 +466,14 @@ public class OpenAPICodeGeneratorTool implements CodeGeneratorTool {
 
         List<ClientDiagnostic> clientDiagnostic = ballerinaClientGenerator.getDiagnostics();
 
-        if (!clientDiagnostic.isEmpty()) {
-            for (ClientDiagnostic diagnostic : clientDiagnostic) {
-                createDiagnostics(toolContext, diagnostic.getMessage(), diagnostic.getCode(),
-                        diagnostic.getDiagnosticSeverity(), location);
-            }
+        for (ClientDiagnostic diagnostic : clientDiagnostic) {
+            createDiagnostics(toolContext, diagnostic.getMessage(), diagnostic.getCode(),
+                    diagnostic.getDiagnosticSeverity(), location);
+        }
 
-            if (clientDiagnostic.stream().anyMatch(
-                    diagnostic -> diagnostic.getDiagnosticSeverity() == DiagnosticSeverity.ERROR)) {
-                throw new ClientException("Error occurred while generating client");
-            }
+        if (clientDiagnostic.stream().anyMatch(
+                diagnostic -> diagnostic.getDiagnosticSeverity() == DiagnosticSeverity.ERROR)) {
+            throw new ClientException("Error occurred while generating client");
         }
 
         sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, null, CLIENT_FILE_NAME,

--- a/openapi-bal-task-plugin/src/main/java/io/ballerina/openapi/bal/tool/OpenAPICodeGeneratorTool.java
+++ b/openapi-bal-task-plugin/src/main/java/io/ballerina/openapi/bal/tool/OpenAPICodeGeneratorTool.java
@@ -21,6 +21,7 @@ import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import io.ballerina.openapi.bal.tool.Constants.DiagnosticMessages;
 import io.ballerina.openapi.core.generators.client.BallerinaClientGenerator;
 import io.ballerina.openapi.core.generators.client.BallerinaClientGeneratorWithStatusCodeBinding;
+import io.ballerina.openapi.core.generators.client.diagnostic.ClientDiagnostic;
 import io.ballerina.openapi.core.generators.client.exception.ClientException;
 import io.ballerina.openapi.core.generators.client.model.OASClientConfig;
 import io.ballerina.openapi.core.generators.common.TypeHandler;
@@ -46,6 +47,7 @@ import io.ballerina.toml.syntax.tree.Token;
 import io.ballerina.toml.validator.SampleNodeGenerator;
 import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.TextDocument;
 import io.ballerina.tools.text.TextDocuments;
@@ -461,6 +463,21 @@ public class OpenAPICodeGeneratorTool implements CodeGeneratorTool {
         String licenseContent = oasClientConfig.getLicense();
         BallerinaClientGenerator ballerinaClientGenerator = getClientGenerator(oasClientConfig, statusCodeBinding);
         String mainContent = Formatter.format(ballerinaClientGenerator.generateSyntaxTree()).toString();
+
+        List<ClientDiagnostic> clientDiagnostic = ballerinaClientGenerator.getDiagnostics();
+
+        if (!clientDiagnostic.isEmpty()) {
+            for (ClientDiagnostic diagnostic : clientDiagnostic) {
+                createDiagnostics(toolContext, diagnostic.getMessage(), diagnostic.getCode(),
+                        diagnostic.getDiagnosticSeverity(), location);
+            }
+
+            if (clientDiagnostic.stream().anyMatch(
+                    diagnostic -> diagnostic.getDiagnosticSeverity() == DiagnosticSeverity.ERROR)) {
+                throw new ClientException("Error occurred while generating client");
+            }
+        }
+
         sourceFiles.add(new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, null, CLIENT_FILE_NAME,
                 licenseContent == null || licenseContent.isBlank() ? mainContent :
                         licenseContent + System.lineSeparator() + mainContent));
@@ -567,6 +584,12 @@ public class OpenAPICodeGeneratorTool implements CodeGeneratorTool {
         String message = String.format(error.getDescription(), (Object[]) args);
         DiagnosticInfo diagnosticInfo = new DiagnosticInfo(error.getCode(), message,
                 error.getSeverity());
+        toolContext.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo, location));
+    }
+
+    private static void createDiagnostics(ToolContext toolContext, String diagnosticMessage, String diagnosticCode,
+                                          DiagnosticSeverity severity, Location location) {
+        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(diagnosticCode, diagnosticMessage, severity);
         toolContext.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo, location));
     }
 

--- a/openapi-build-extension/src/main/java/io/ballerina/openapi/build/HttpServiceAnalysisTask.java
+++ b/openapi-build-extension/src/main/java/io/ballerina/openapi/build/HttpServiceAnalysisTask.java
@@ -91,18 +91,16 @@ public class HttpServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisC
                 .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));
 
         // if there are any compilation errors, do not proceed
-        if (!isErrorPrinted && hasErrors) {
-            setIsWarningPrinted();
-            PrintStream outStream = System.out;
-            outStream.println("openapi contract generation is skipped because of the following compilation " +
-                    "error(s) in the ballerina package:");
-            return;
-        }
-
         if (hasErrors) {
-
+            if (!isErrorPrinted) {
+                setIsWarningPrinted();
+                PrintStream outStream = System.out;
+                outStream.println("openapi contract generation is skipped because of the following compilation " +
+                        "error(s) in the ballerina package:");
+            }
             return;
         }
+
         Path outPath = project.targetDir();
         Optional<Path> path = currentPackage.project().documentPath(context.documentId());
         Path inputPath = path.orElse(null);

--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/BallerinaCodeGenerator.java
@@ -203,10 +203,8 @@ public class BallerinaCodeGenerator {
         //display diagnostics- client
         List<ClientDiagnostic> clientDiagnostic = clientGenerator.getDiagnostics();
 
-        if (!clientDiagnostic.isEmpty()) {
-            for (ClientDiagnostic diagnostic : clientDiagnostic) {
-                outStream.println(diagnostic.getDiagnosticSeverity() + ":" + diagnostic.getMessage());
-            }
+        for (ClientDiagnostic diagnostic : clientDiagnostic) {
+            outStream.println(diagnostic.getDiagnosticSeverity() + ":" + diagnostic.getMessage());
         }
         printDiagnostic(diagnostics);
         writeGeneratedSources(newGenFiles, srcPath, implPath, GEN_BOTH);
@@ -434,10 +432,8 @@ public class BallerinaCodeGenerator {
         }
 
         List<ClientDiagnostic> clientDiagnostic = clientGenerator.getDiagnostics();
-        if (!clientDiagnostic.isEmpty()) {
-            for (ClientDiagnostic diagnostic : clientDiagnostic) {
-                outStream.println(diagnostic.getDiagnosticSeverity() + ":" + diagnostic.getMessage());
-            }
+        for (ClientDiagnostic diagnostic : clientDiagnostic) {
+            outStream.println(diagnostic.getDiagnosticSeverity() + ":" + diagnostic.getMessage());
         }
         printDiagnostic(diagnosticList);
         return sourceFiles;

--- a/openapi-client-native/build.gradle
+++ b/openapi-client-native/build.gradle
@@ -119,7 +119,8 @@ publishing {
 tasks.withType(PublishToMavenRepository) {
     onlyIf {
         (repository == publishing.repositories.GitHub && publication == publishing.publications.GitHub) ||
-                (repository == publishing.repositories.WSO2Nexus && publication == publishing.publications.WSO2Nexus)
+                (repository == publishing.repositories.WSO2Nexus && publication == publishing.publications.WSO2Nexus
+                 && (clientNativeVersion.endsWith('-SNAPSHOT') || !skipClientNativePublish))
     }
 }
 

--- a/openapi-client-native/build.gradle
+++ b/openapi-client-native/build.gradle
@@ -120,7 +120,7 @@ tasks.withType(PublishToMavenRepository) {
     onlyIf {
         (repository == publishing.repositories.GitHub && publication == publishing.publications.GitHub) ||
                 (repository == publishing.repositories.WSO2Nexus && publication == publishing.publications.WSO2Nexus
-                 && (clientNativeVersion.endsWith('-SNAPSHOT') || !skipClientNativePublish))
+                 && (clientNativeVersion.endsWith('-SNAPSHOT') || clientNativePublish))
     }
 }
 

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/common/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/common/GeneratorUtils.java
@@ -995,24 +995,26 @@ public class GeneratorUtils {
         }
 
         Map<String, Schema> properties = new HashMap<>();
-        List<String> requiredField = new ArrayList<>();
+        List<String> requiredFields = new ArrayList<>();
         for (Map.Entry<String, Header> headerEntry : headers.entrySet()) {
             String headerName = headerEntry.getKey();
             Header header = headerEntry.getValue();
             Schema headerTypeSchema = getValidatedHeaderSchema(header.getSchema());
             properties.put(headerName, headerTypeSchema);
             if (header.getRequired() != null && header.getRequired()) {
-                requiredField.add(headerName);
+                requiredFields.add(headerName);
             }
         }
 
-        if (properties.isEmpty() || requiredField.isEmpty()) {
+        if (properties.isEmpty()) {
             return null;
         }
 
         ObjectSchema headersSchema = new ObjectSchema();
         headersSchema.setProperties(properties);
-        headersSchema.setRequired(requiredField);
+        if (!requiredFields.isEmpty()) {
+            headersSchema.setRequired(requiredFields);
+        }
         headersSchema.setAdditionalProperties(false);
         return headersSchema;
     }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/common/GeneratorUtils.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/common/GeneratorUtils.java
@@ -1089,7 +1089,9 @@ public class GeneratorUtils {
                 generatedTypes.put(mediaTypeToken.toString(), mediaTypeToken);
             }
         } else {
-            diagnosticList.add(new CommonDiagnostic(OAS_COMMON_101));
+            if (!bodyTypeSchema.isEmpty()) {
+                diagnosticList.add(new CommonDiagnostic(OAS_COMMON_101));
+            }
             return TypeHandler.getInstance().createTypeInclusionRecord(code, null,
                     TypeHandler.getInstance().generateHeaderType(headersTypeSchema), method);
         }

--- a/openapi-core/src/main/java/io/ballerina/openapi/core/generators/common/diagnostic/CommonDiagnosticMessages.java
+++ b/openapi-core/src/main/java/io/ballerina/openapi/core/generators/common/diagnostic/CommonDiagnosticMessages.java
@@ -29,8 +29,6 @@ import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 public enum CommonDiagnosticMessages {
     OAS_COMMON_101("OAS_COMMON_101", "Responses with 204 status code cannot have a body.",
             DiagnosticSeverity.WARNING),
-    OAS_COMMON_102("OAS_COMMON_102", "Responses with 204 cannot have a body.",
-            DiagnosticSeverity.WARNING),
     OAS_COMMON_201("OAS_COMMON_201", "Invalid reference value : %s\nBallerina " +
             "only supports local reference values.", DiagnosticSeverity.ERROR),
     OAS_COMMON_202("OAS_COMMON_202", "Unsupported OAS data type `%s`", DiagnosticSeverity.ERROR),


### PR DESCRIPTION
## Purpose
> $Subject

- Add a property to skip publishing client native artifacts to WSO2 nexus. With this change, we have to enable this in the `gradle.properties` file, if we want to publish the artifacts with release workflow. If we do not need to release we need to mark it as `true`
- Fix optional response header mapping in the status code response. Without this change, when we have non-required headers in status code response, it is map to `map<string|string[]>`. With this change, the optional headers will be mapped as nilable record fields
- Fix printing `Responses with 204 status code cannot have a body` warning for response which does not define a request body schema
- Removed unused `OAS_COMMON_102` from the common diagnostics
- Print the client warning/error diagnostics when bal commands are executed with openAPI tool integration