### PR TITLE
[master]Fix the `openapi:ServiceInfo` annotation is not supported in the service contract type 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ ext.stdlibGrpcVersion = project.stdlibGrpcVersion
 ext.stdlibWebsubVersion = project.stdlibWebsubVersion
 ext.stdlibConstraintVersion = project.stdlibConstraintVersion
 ext.stdlibWebsocketVersion = project.stdlibWebsocketVersion
+ext.stdlibDataJsonDataVersion = project.stdlibDataJsonDataVersion
 ext.jacocoVersion = project.jacocoVersion
 ext.puppycrawlCheckstyleVersion = project.puppycrawlCheckstyleVersion
 
@@ -136,6 +137,7 @@ subprojects {
         ballerinaStdLibs "io.ballerina.stdlib:websub-ballerina:${stdlibWebsubVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:websocket-ballerina:${stdlibWebsocketVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:constraint-ballerina:${stdlibConstraintVersion}"
+        ballerinaStdLibs "io.ballerina.lib:data.jsondata-ballerina:${stdlibDataJsonDataVersion}"
 
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ clientNativeVersion=1.0.1-SNAPSHOT
 clientNativePublish=false
 
 #dependency
-ballerinaLangVersion=2201.10.0
+ballerinaLangVersion=2201.11.0-20241008-112400-81975006
 testngVersion=7.6.1
 slf4jVersion=1.7.30
 org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
@@ -45,11 +45,12 @@ stdlibUuidVersion=1.8.0
 
 # Stdlib Level 04
 stdlibAuthVersion=2.12.0
+stdlibDataJsonDataVersion=0.3.0-20241105-101100-661d11f
 stdlibJwtVersion=2.13.0
 stdlibOAuth2Version=2.12.0
 
 # Stdlib Level 05
-stdlibHttpVersion=2.12.1-20240922-195800-82c5e76
+stdlibHttpVersion=2.13.0-20241106-120000-d375c3b
 
 # Stdlib Level 06
 stdlibGrpcVersion=1.12.0

--- a/module-ballerina-openapi/annotation.bal
+++ b/module-ballerina-openapi/annotation.bal
@@ -103,7 +103,8 @@ public type Examples readonly & record {|
 public const annotation ResourceInformation ResourceInfo on object function;
 
 # Annotation for additional OpenAPI information of a Ballerina service.
-public annotation ServiceInformation ServiceInfo on service;
+public annotation ServiceInformation ServiceInfo on service, type;
+
 // # Annotation for additional OpenAPI configurations of a Ballerina client.
 // public const annotation ClientConfiguration ClientConfig on source client;
 

--- a/openapi-client-native/ballerina-tests/Dependencies.toml
+++ b/openapi-client-native/ballerina-tests/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.10.0"
+distribution-version = "2201.11.0-20241008-112400-81975006"
 
 [[package]]
 org = "ballerina"
@@ -63,6 +63,15 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "data.jsondata"
+version = "0.3.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.object"}
+]
+
+[[package]]
+org = "ballerina"
 name = "file"
 version = "1.10.0"
 dependencies = [
@@ -75,12 +84,13 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.12.2"
+version = "2.13.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "data.jsondata"},
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -297,7 +307,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/openapi-client-native/ballerina-tests/Dependencies.toml
+++ b/openapi-client-native/ballerina-tests/Dependencies.toml
@@ -75,7 +75,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.12.0"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/openapi-integration-tests/src/test/java/io/ballerina/openapi/cmd/BallerinaToOpenAPICLINegativeTests.java
+++ b/openapi-integration-tests/src/test/java/io/ballerina/openapi/cmd/BallerinaToOpenAPICLINegativeTests.java
@@ -99,6 +99,27 @@ public class BallerinaToOpenAPICLINegativeTests extends OpenAPITest {
         assertOnErrorStream(process, out);
     }
 
+    @Test(description = "Generate with openapi serviceConfig annotation to service contract type " +
+            "and service declaration")
+    public void openapiServiceConfigForServiceContractTypeWithServiceDeclaration() throws IOException,
+            InterruptedException {
+        String balFilePath = "project_openapi_info_with_service_contract_type_and_declaration/service_file.bal";
+        List<String> buildArgs = new LinkedList<>();
+        buildArgs.add(0, "openapi");
+        buildArgs.add("-i");
+        buildArgs.add(balFilePath);
+        buildArgs.add("-o");
+        buildArgs.add(tmpDir.toString());
+
+        Process process = getProcess(buildArgs, TEST_RESOURCE);
+        //Thread for wait out put generate
+        Thread.sleep(5000);
+        // compare generated file has not included constraint annotation for scenario record field.
+        Assert.assertTrue(Files.exists(TEST_RESOURCE.resolve("service_contract_openapi.yaml")));
+        Assert.assertTrue(Files.exists(TEST_RESOURCE.resolve("v1_openapi.yaml")));
+        process.waitFor();
+    }
+
     @AfterClass
     public void cleanUp() throws IOException {
         TestUtil.cleanDistribution();

--- a/openapi-integration-tests/src/test/java/io/ballerina/openapi/cmd/BallerinaToOpenAPITests.java
+++ b/openapi-integration-tests/src/test/java/io/ballerina/openapi/cmd/BallerinaToOpenAPITests.java
@@ -178,6 +178,13 @@ public class BallerinaToOpenAPITests extends OpenAPITest {
                 "project_openapi_bal_ext/result_1.yaml", true);
     }
 
+    @Test(description = "Generate with openapi serviceConfig annotation to service contract type")
+    public void openapiServiceConfigForServiceContractType() throws IOException, InterruptedException {
+        executeCommand("project_openapi_info_with_service_contract_type/service_file.bal",
+                "v1_openapi.yaml",
+                "project_openapi_info_with_service_contract_type/result.yaml", true);
+    }
+
     @AfterClass
     public void cleanUp() throws IOException {
         TestUtil.cleanDistribution();

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type/Ballerina.toml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org= "ballerina"
+name= "openapi_service_contract"
+version= "2.0.0"

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type/result.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.1
+info:
+  title: Pet Store
+  description: API system description
+  termsOfService: http://mock-api-doc
+  contact:
+    name: sumudu
+    url: http://mock-api-contact
+    email: sumudu@abc.com
+  license:
+    name: ABC
+    url: http://abc.com
+  version: 1.0.0
+servers:
+  - url: "http://{server}:{port}/v1"
+    variables:
+      server:
+        default: localhost
+      port:
+        default: "8080"
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type/service_file.bal
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type/service_file.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/openapi;
+
+@openapi:ServiceInfo {
+    version: "1.0.0",
+    title: "Pet store",
+    description: "API system description",
+    email: "sumudu@abc.com",
+    contactName: "sumudu",
+    contactURL: "http://mock-api-contact",
+    termsOfService: "http://mock-api-doc",
+    licenseName: "ABC",
+    licenseURL: "http://abc.com"
+}
+@http:ServiceConfig {basePath: "/v1"}
+type OASServiceType service object {
+    *http:ServiceContract;
+    resource function get users() returns string[];
+};

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type_and_declaration/Ballerina.toml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type_and_declaration/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org= "ballerina"
+name= "openapi_service_contract"
+version= "2.0.0"

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type_and_declaration/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type_and_declaration/result.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.1
+info:
+  title: Pet Store
+  description: API system description
+  termsOfService: http://mock-api-doc
+  contact:
+    name: sumudu
+    url: http://mock-api-contact
+    email: sumudu@abc.com
+  license:
+    name: ABC
+    url: http://abc.com
+  version: 1.0.0
+servers:
+  - url: "http://{server}:{port}/v1"
+    variables:
+      server:
+        default: localhost
+      port:
+        default: "8080"
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type_and_declaration/service_file.bal
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_info_with_service_contract_type_and_declaration/service_file.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/openapi;
+
+@openapi:ServiceInfo {
+    version: "1.0.0",
+    title: "Pet store",
+    description: "API system description",
+    email: "sumudu@abc.com",
+    contactName: "sumudu",
+    contactURL: "http://mock-api-contact",
+    termsOfService: "http://mock-api-doc",
+    licenseName: "ABC",
+    licenseURL: "http://abc.com"
+}
+@http:ServiceConfig {basePath: "/v1"}
+type OASServiceType service object {
+    *http:ServiceContract;
+    resource function get users() returns string[];
+};


### PR DESCRIPTION
## Purpose
> Fix https://github.com/ballerina-platform/ballerina-library/issues/7334

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests - add
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.