### PR TITLE
[Update 12] Introduce a new API to convert a Ballerina Type Symbol to a Json Schema(String Format)

### DIFF
--- a/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/diagnostic/DiagnosticMessages.java
+++ b/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/diagnostic/DiagnosticMessages.java
@@ -111,7 +111,9 @@ public enum DiagnosticMessages {
     OAS_CONVERTOR_138("OAS_CONVERTOR_138", "Failed to find the package to obtain the OpenAPI definition from the " +
             "service contract type: '%s'", DiagnosticSeverity.ERROR),
     OAS_CONVERTOR_139("OAS_CONVERTOR_139", "Failed to find the OpenAPI definition resource for the " +
-            "service contract type: '%s'", DiagnosticSeverity.ERROR);
+            "service contract type: '%s'", DiagnosticSeverity.ERROR),
+    OAS_CONVERTOR_140("OAS_CONVERTOR_140", "Failed to resolve recursive references for `expand: true` option",
+            DiagnosticSeverity.ERROR);
 
     private final String code;
     private final String description;

--- a/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/model/AdditionalData.java
+++ b/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/model/AdditionalData.java
@@ -20,6 +20,7 @@ package io.ballerina.openapi.service.mapper.model;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.openapi.service.mapper.diagnostic.OpenAPIMapperDiagnostic;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -35,4 +36,8 @@ public record AdditionalData(SemanticModel semanticModel,
                              ModuleMemberVisitor moduleMemberVisitor,
                              List<OpenAPIMapperDiagnostic> diagnostics,
                              boolean enableBallerinaExt) {
+
+    public AdditionalData(SemanticModel semanticModel, ModuleMemberVisitor moduleMemberVisitor) {
+        this(semanticModel, moduleMemberVisitor, new ArrayList<>(), false);
+    }
 }

--- a/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/model/AdditionalData.java
+++ b/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/model/AdditionalData.java
@@ -29,15 +29,30 @@ import java.util.List;
  * @param moduleMemberVisitor - The module member visitor.
  * @param diagnostics - The list of diagnostics.
  * @param enableBallerinaExt - The flag to enable ballerina extension in the type schema.
+ * @param enableExpansion - The flag to enable expansion in the reference type schema.
+ * @param visitedTypes - The list of visited types.
  *
  * @since 1.9.0
  */
 public record AdditionalData(SemanticModel semanticModel,
                              ModuleMemberVisitor moduleMemberVisitor,
                              List<OpenAPIMapperDiagnostic> diagnostics,
-                             boolean enableBallerinaExt) {
+                             boolean enableBallerinaExt,
+                             boolean enableExpansion,
+                             List<String> visitedTypes) {
 
     public AdditionalData(SemanticModel semanticModel, ModuleMemberVisitor moduleMemberVisitor) {
-        this(semanticModel, moduleMemberVisitor, new ArrayList<>(), false);
+        this(semanticModel, moduleMemberVisitor, new ArrayList<>(), false, false, new ArrayList<>());
+    }
+
+    public AdditionalData(SemanticModel semanticModel, ModuleMemberVisitor moduleMemberVisitor,
+                          List<OpenAPIMapperDiagnostic> diagnostics, boolean enableBallerinaExt) {
+        this(semanticModel, moduleMemberVisitor, diagnostics, enableBallerinaExt, false, new ArrayList<>());
+    }
+
+    public AdditionalData(SemanticModel semanticModel, ModuleMemberVisitor moduleMemberVisitor,
+                          List<OpenAPIMapperDiagnostic> diagnostics, boolean enableBallerinaExt,
+                          boolean enableExpansion) {
+        this(semanticModel, moduleMemberVisitor, diagnostics, enableBallerinaExt, enableExpansion, new ArrayList<>());
     }
 }

--- a/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/RecordTypeMapper.java
+++ b/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/RecordTypeMapper.java
@@ -121,11 +121,21 @@ public class RecordTypeMapper extends AbstractTypeMapper {
             // Type inclusion in a record is a TypeReferenceType and the referred type is a RecordType
             if (typeInclusion.typeKind() == TypeDescKind.TYPE_REFERENCE &&
                     ((TypeReferenceTypeSymbol) typeInclusion).typeDescriptor().typeKind() == TypeDescKind.RECORD) {
-                Schema includedRecordSchema = new Schema();
-                includedRecordSchema.set$ref(getTypeName(typeInclusion));
+                Schema includedRecordSchema;
+                if (additionalData.enableExpansion()) {
+                    if (additionalData.visitedTypes().contains(MapperCommonUtils.getTypeName(typeInclusion))) {
+                        ExceptionDiagnostic error = new ExceptionDiagnostic(DiagnosticMessages.OAS_CONVERTOR_140);
+                        additionalData.diagnostics().add(error);
+                        continue;
+                    }
+                    includedRecordSchema = TypeMapperImpl.getTypeSchema(typeInclusion, components, additionalData);
+                } else {
+                    includedRecordSchema = new Schema();
+                    includedRecordSchema.set$ref(getTypeName(typeInclusion));
+                    TypeMapperImpl.createComponentMapping((TypeReferenceTypeSymbol) typeInclusion,
+                            components, additionalData);
+                }
                 allOfSchemaList.add(includedRecordSchema);
-                TypeMapperImpl.createComponentMapping((TypeReferenceTypeSymbol) typeInclusion,
-                        components, additionalData);
 
                 RecordTypeSymbol includedRecordTypeSymbol = (RecordTypeSymbol) ((TypeReferenceTypeSymbol) typeInclusion)
                         .typeDescriptor();

--- a/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/ReferenceTypeMapper.java
+++ b/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/ReferenceTypeMapper.java
@@ -21,6 +21,8 @@ import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.openapi.service.mapper.diagnostic.DiagnosticMessages;
+import io.ballerina.openapi.service.mapper.diagnostic.ExceptionDiagnostic;
 import io.ballerina.openapi.service.mapper.model.AdditionalData;
 import io.ballerina.openapi.service.mapper.utils.MapperCommonUtils;
 import io.swagger.v3.oas.models.Components;
@@ -57,6 +59,15 @@ public class ReferenceTypeMapper extends AbstractTypeMapper {
                                    AdditionalData additionalData) {
         if (isBuiltInSubTypes(typeSymbol)) {
             return SimpleTypeMapper.getTypeSchema(typeSymbol.typeDescriptor(), additionalData);
+        }
+        if (additionalData.enableExpansion()) {
+            if (additionalData.visitedTypes().contains(MapperCommonUtils.getTypeName(typeSymbol))) {
+                ExceptionDiagnostic error = new ExceptionDiagnostic(DiagnosticMessages.OAS_CONVERTOR_140);
+                additionalData.diagnostics().add(error);
+                return null;
+            }
+            additionalData.visitedTypes().add(MapperCommonUtils.getTypeName(typeSymbol));
+            return TypeMapperImpl.getTypeSchema(getReferredType(typeSymbol), components, additionalData);
         }
         if (!AbstractTypeMapper.hasMapping(components, typeSymbol)) {
             createComponentMapping(typeSymbol, components, additionalData);

--- a/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/ReferenceTypeMapper.java
+++ b/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/ReferenceTypeMapper.java
@@ -84,7 +84,7 @@ public class ReferenceTypeMapper extends AbstractTypeMapper {
             if (referencedType.typeKind().equals(TypeDescKind.TYPE_REFERENCE)) {
                 return getReferredType(referencedType);
             } else {
-                return typeSymbol;
+                return referencedType;
             }
         }
         if (typeSymbol.typeKind().equals(TypeDescKind.INTERSECTION)) {

--- a/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/TypeMapper.java
+++ b/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/TypeMapper.java
@@ -56,4 +56,6 @@ public interface TypeMapper {
         }
         schema.setDefault(defaultValue);
     }
+
+    String getJsonSchemaString(TypeSymbol typeSymbol);
 }

--- a/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/extension/BallerinaTypeExtensioner.java
+++ b/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/extension/BallerinaTypeExtensioner.java
@@ -46,34 +46,49 @@ public final class BallerinaTypeExtensioner {
     }
 
     public static void removeExtensions(OpenAPI openAPI) {
-        removeExtensionsFromSchemas(openAPI, (extensions, orgName, moduleName) -> true);
+        removeExtensionsFromOpenAPI(openAPI, (extensions, orgName, moduleName) -> true);
     }
 
     public static void removeCurrentModuleTypeExtensions(OpenAPI openAPI, ModuleID moduleID) {
         String orgName = moduleID.orgName();
         String moduleName = moduleID.moduleName();
 
-        removeExtensionsFromSchemas(openAPI, (extensions, org, mod) -> fromSameModule(extensions, orgName,
+        removeExtensionsFromOpenAPI(openAPI, (extensions, org, mod) -> fromSameModule(extensions, orgName,
                 moduleName));
     }
 
-    private static void removeExtensionsFromSchemas(OpenAPI openAPI, ExtensionRemovalCondition condition) {
+    private static void removeExtensionsFromOpenAPI(OpenAPI openAPI, ExtensionRemovalCondition condition) {
         Components components = openAPI.getComponents();
         if (Objects.isNull(components)) {
             return;
         }
+        removeExtensionFromComponents(components, condition);
+    }
 
+    public static void removeExtensionFromComponents(Components components) {
+        removeExtensionFromComponents(components, (extensions, orgName, moduleName) -> true);
+    }
+
+    private static void removeExtensionFromComponents(Components components, ExtensionRemovalCondition condition) {
         Map<String, Schema> schemas = components.getSchemas();
         if (Objects.isNull(schemas)) {
             return;
         }
 
         schemas.forEach((key, schema) -> {
-            Map<?, ?> extensions = schema.getExtensions();
-            if (Objects.nonNull(extensions) && condition.shouldRemove(extensions, null, null)) {
-                extensions.remove(X_BALLERINA_TYPE);
-            }
+            removeExtensionFromSchema(schema, condition);
         });
+    }
+
+    public static void removeExtensionFromSchema(Schema schema) {
+        removeExtensionFromSchema(schema, (extensions, orgName, moduleName) -> true);
+    }
+
+    private static void removeExtensionFromSchema(Schema schema, ExtensionRemovalCondition condition) {
+        Map<?, ?> extensions = schema.getExtensions();
+        if (Objects.nonNull(extensions) && condition.shouldRemove(extensions, null, null)) {
+            extensions.remove(X_BALLERINA_TYPE);
+        }
     }
 
     @FunctionalInterface

--- a/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/extension/BallerinaTypeExtensioner.java
+++ b/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/type/extension/BallerinaTypeExtensioner.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -88,6 +89,22 @@ public final class BallerinaTypeExtensioner {
         Map<?, ?> extensions = schema.getExtensions();
         if (Objects.nonNull(extensions) && condition.shouldRemove(extensions, null, null)) {
             extensions.remove(X_BALLERINA_TYPE);
+        }
+        Map<String, Schema> properties = schema.getProperties();
+        if (Objects.nonNull(properties)) {
+            properties.values().forEach(value -> removeExtensionFromSchema(value, condition));
+        }
+        List<Schema> allOfSchemas = schema.getAllOf();
+        if (Objects.nonNull(allOfSchemas)) {
+            allOfSchemas.forEach(value -> removeExtensionFromSchema(value, condition));
+        }
+        List<Schema> oneOfSchemas = schema.getOneOf();
+        if (Objects.nonNull(oneOfSchemas)) {
+            oneOfSchemas.forEach(value -> removeExtensionFromSchema(value, condition));
+        }
+        List<Schema> anyOfSchemas = schema.getAnyOf();
+        if (Objects.nonNull(anyOfSchemas)) {
+            anyOfSchemas.forEach(value -> removeExtensionFromSchema(value, condition));
         }
     }
 

--- a/openapi-client-native/ballerina-tests/Dependencies.toml
+++ b/openapi-client-native/ballerina-tests/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.11.0-20241121-075100-c4c87cbc"
+distribution-version = "2201.11.0"
 
 [[package]]
 org = "ballerina"
@@ -84,7 +84,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.13.0"
+version = "2.13.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},


### PR DESCRIPTION
## Purpose

> $Subject

> **Note:** This is only supported for the `anydata` types, for other types an unsupported operation exception will be thrown.

Additionally, we have supported enable expansion option which will replace the definition references by inline schemas which will make the definition obsolete. Please note that this will only work for types which does not have cyclic references.