### PR TITLE
Add an option to disable ballerinaToOpenAPI publish

### DIFF
--- a/ballerina-to-openapi/build.gradle
+++ b/ballerina-to-openapi/build.gradle
@@ -165,4 +165,11 @@ publishing {
     }
 }
 
+tasks.withType(PublishToMavenRepository) {
+    onlyIf {
+        (ballerinaToOpenAPIPublish.endsWith('-SNAPSHOT') || ballerinaToOpenAPIPublish.toBoolean()) &&
+                (repository == publishing.repositories.GitHub && publication == publishing.publications.GitHub)
+    }
+}
+
 publish.dependsOn build

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ apply from: "$rootDir/gradle/javaProject.gradle"
 
 ext.clientNativeVersion = project.clientNativeVersion
 ext.clientNativePublish = project.clientNativePublish
+ext.ballerinaToOpenAPIPublish = project.ballerinaToOpenAPIPublish
 ext.ballerinaLangVersion = project.ballerinaLangVersion
 ext.testngVersion = project.testngVersion
 ext.commonsLang3Version = project.commonsLang3Version

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ group=io.ballerina
 version=2.3.2-SNAPSHOT
 
 ballerinaToOpenAPIVersion=2.3.1
+ballerinaToOpenAPIPublish=false
 
 spotbugsPluginVersion=6.0.18
 shadowJarPluginVersion=8.1.1


### PR DESCRIPTION
## Purpose

In some scenarios where we do not do any changes to the `ballerina-to-openapi` package, we need skip release this particular package