### PR TITLE
Fix test failure due to double quotes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ clientNativeVersion=1.3.0
 clientNativePublish=false
 
 #dependency
-ballerinaLangVersion=2201.13.0
+ballerinaLangVersion=2201.13.4
 testngVersion=7.6.1
 slf4jVersion=1.7.30
 commonsLang3Version=3.14.0

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/examples/response_example/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/examples/response_example/result.yaml
@@ -48,7 +48,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
 components:
   schemas:
     ErrorPayload:

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation/result.yaml
@@ -33,13 +33,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
         "400":
           description: BadRequest
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
 components:
   schemas:
     ErrorPayload:

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_with_base_path/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_with_base_path/result.yaml
@@ -33,13 +33,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
         "400":
           description: BadRequest
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
 components:
   schemas:
     ErrorPayload:

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_without_base_path/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_non_openapi_annotation_without_base_path/result.yaml
@@ -33,13 +33,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
         "400":
           description: BadRequest
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
 components:
   schemas:
     ErrorPayload:

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_bal_ext/result_0.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_bal_ext/result_0.yaml
@@ -21,7 +21,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Student'
+                  $ref: "#/components/schemas/Student"
 components:
   schemas:
     BasicStudent:
@@ -40,12 +40,12 @@ components:
       type: object
       description: Date in proleptic Gregorian calendar.
       allOf:
-        - $ref: '#/components/schemas/DateFields'
-        - $ref: '#/components/schemas/OptionalTimeOfDayFields'
+        - $ref: "#/components/schemas/DateFields"
+        - $ref: "#/components/schemas/OptionalTimeOfDayFields"
         - type: object
           properties:
             utcOffset:
-              $ref: '#/components/schemas/ZoneOffset'
+              $ref: "#/components/schemas/ZoneOffset"
     DateFields:
       required:
         - day
@@ -73,7 +73,7 @@ components:
           type: integer
           format: int64
         second:
-          $ref: '#/components/schemas/Seconds'
+          $ref: "#/components/schemas/Seconds"
       description: TimeOfDay with all the fields beign optional.
     Seconds:
       type: number
@@ -82,7 +82,7 @@ components:
     Student:
       type: object
       allOf:
-        - $ref: '#/components/schemas/BasicStudent'
+        - $ref: "#/components/schemas/BasicStudent"
         - required:
             - subjects
           type: object
@@ -90,7 +90,7 @@ components:
             subjects:
               type: array
               items:
-                $ref: '#/components/schemas/Subject'
+                $ref: "#/components/schemas/Subject"
           additionalProperties: false
     Subject:
       required:
@@ -105,7 +105,7 @@ components:
           type: integer
           format: int64
         examDate:
-          $ref: '#/components/schemas/Date'
+          $ref: "#/components/schemas/Date"
       additionalProperties: false
     ZoneOffset:
       required:

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_bal_ext/result_1.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_bal_ext/result_1.yaml
@@ -21,7 +21,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Student'
+                  $ref: "#/components/schemas/Student"
 components:
   schemas:
     BasicStudent:
@@ -47,12 +47,12 @@ components:
       type: object
       description: Date in proleptic Gregorian calendar.
       allOf:
-        - $ref: '#/components/schemas/DateFields'
-        - $ref: '#/components/schemas/OptionalTimeOfDayFields'
+        - $ref: "#/components/schemas/DateFields"
+        - $ref: "#/components/schemas/OptionalTimeOfDayFields"
         - type: object
           properties:
             utcOffset:
-              $ref: '#/components/schemas/ZoneOffset'
+              $ref: "#/components/schemas/ZoneOffset"
       x-ballerina-type:
         orgName: ballerina
         pkgName: time
@@ -94,7 +94,7 @@ components:
           type: integer
           format: int64
         second:
-          $ref: '#/components/schemas/Seconds'
+          $ref: "#/components/schemas/Seconds"
       description: TimeOfDay with all the fields beign optional.
       x-ballerina-type:
         orgName: ballerina
@@ -117,7 +117,7 @@ components:
     Student:
       type: object
       allOf:
-        - $ref: '#/components/schemas/BasicStudent'
+        - $ref: "#/components/schemas/BasicStudent"
         - required:
             - subjects
           type: object
@@ -125,7 +125,7 @@ components:
             subjects:
               type: array
               items:
-                $ref: '#/components/schemas/Subject'
+                $ref: "#/components/schemas/Subject"
           additionalProperties: false
     Subject:
       required:
@@ -140,7 +140,7 @@ components:
           type: integer
           format: int64
         examDate:
-          $ref: '#/components/schemas/Date'
+          $ref: "#/components/schemas/Date"
       additionalProperties: false
     ZoneOffset:
       required:

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_examples/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_examples/result.yaml
@@ -30,13 +30,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
         "400":
           description: BadRequest
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
     post:
       operationId: postUsersId
       parameters:
@@ -61,7 +61,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/User'
+              $ref: "#/components/schemas/User"
             examples:
               john:
                 value:
@@ -84,13 +84,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
         "400":
           description: BadRequest
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
   /users:
     get:
       operationId: getUsers
@@ -100,7 +100,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Users'
+                $ref: "#/components/schemas/Users"
   /developers:
     post:
       operationId: postDevelopers
@@ -135,7 +135,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
   /developers/new:
     post:
       operationId: postDevelopersNew
@@ -169,7 +169,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
   /users/{id}/address:
     get:
       operationId: getUsersIdAddress
@@ -186,13 +186,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Address'
+                $ref: "#/components/schemas/Address"
         "400":
           description: BadRequest
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorPayload'
+                $ref: "#/components/schemas/ErrorPayload"
 components:
   schemas:
     Address:
@@ -259,7 +259,7 @@ components:
           format: int64
           example: 30
         address:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
         friends:
           type: array
           example:
@@ -269,7 +269,7 @@ components:
                 street: 10 Downing Street
                 city: London
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
       additionalProperties: false
     Users:
       type: array
@@ -280,4 +280,4 @@ components:
             street: 10 Downing Street
             city: London
       items:
-        $ref: '#/components/schemas/User'
+        $ref: "#/components/schemas/User"

--- a/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_with_included_test/result.yaml
+++ b/openapi-integration-tests/src/test/resources/ballerina_sources/project_openapi_with_included_test/result.yaml
@@ -21,7 +21,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Pod'
+                  $ref: "#/components/schemas/Pod"
   /Services:
     get:
       operationId: getServices
@@ -33,7 +33,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Service'
+                  $ref: "#/components/schemas/Service"
 components:
   schemas:
     Metadata:
@@ -50,17 +50,17 @@ components:
     Pod:
       type: object
       allOf:
-        - $ref: '#/components/schemas/Resource'
+        - $ref: "#/components/schemas/Resource"
         - required:
             - spec
           type: object
           properties:
             kind:
               allOf:
-                - $ref: '#/components/schemas/ResourceKind'
+                - $ref: "#/components/schemas/ResourceKind"
               default: Pod
             spec:
-              $ref: '#/components/schemas/PodSpec'
+              $ref: "#/components/schemas/PodSpec"
     PodSpec:
       required:
         - nodeName
@@ -71,7 +71,7 @@ components:
     Resource:
       type: object
       allOf:
-        - $ref: '#/components/schemas/ResourceBase'
+        - $ref: "#/components/schemas/ResourceBase"
         - required:
             - spec
           type: object
@@ -80,7 +80,7 @@ components:
               type: object
               properties: {}
             status:
-              $ref: '#/components/schemas/Status'
+              $ref: "#/components/schemas/Status"
     ResourceBase:
       required:
         - group
@@ -94,9 +94,9 @@ components:
         version:
           type: string
         kind:
-          $ref: '#/components/schemas/ResourceKind'
+          $ref: "#/components/schemas/ResourceKind"
         metadata:
-          $ref: '#/components/schemas/Metadata'
+          $ref: "#/components/schemas/Metadata"
     ResourceKind:
       type: string
       enum:
@@ -105,17 +105,17 @@ components:
     Service:
       type: object
       allOf:
-        - $ref: '#/components/schemas/Resource'
+        - $ref: "#/components/schemas/Resource"
         - required:
             - spec
           type: object
           properties:
             kind:
               allOf:
-                - $ref: '#/components/schemas/ResourceKind'
+                - $ref: "#/components/schemas/ResourceKind"
               default: Service
             spec:
-              $ref: '#/components/schemas/ServiceSpec'
+              $ref: "#/components/schemas/ServiceSpec"
     ServiceSpec:
       required:
         - clusterIP


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

 The quoting style change (' → " for $ref values) is coming from SnakeYAML — a transitive dependency of swagger-core. The ballerinaLangVersion bump from 2201.13.0 → 2201.13.4 and latest likely pulled in a newer version of SnakeYAML (or jackson-dataformat-yaml) transitively, which changed how strings starting with # get quoted in YAML output.

This is needed to sync the 2201.13.x PR to master(https://github.com/ballerina-platform/ballerina-lang/pull/44602/) 

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes test failures related to quote handling in OpenAPI schema references by standardizing the formatting of JSON Pointer references across test resource files.

## Changes

**Dependency Update:**
- Updated `gradle.properties` to upgrade the Ballerina language version from `2201.13.0` to `2201.13.4`

**Test Resource Updates:**
- Standardized the formatting of `$ref` values in OpenAPI YAML test resources across multiple test cases by converting single-quoted JSON Pointer references to double-quoted format
- Affected test resource files include:
  - `response_example/result.yaml`
  - `project_non_openapi_annotation/result.yaml`
  - `project_non_openapi_annotation_with_base_path/result.yaml`
  - `project_non_openapi_annotation_without_base_path/result.yaml`
  - `project_openapi_bal_ext/result_0.yaml` and `result_1.yaml`
  - `project_openapi_examples/result.yaml`
  - `project_openapi_with_included_test/result.yaml`

The quote formatting changes ensure consistency in how schema references are represented across the generated OpenAPI YAML outputs and resolve the underlying test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->