### PR TITLE
Fix intermittent test failures through shared Ballerina environment

### DIFF
--- a/openapi-cli/src/main/java/io/ballerina/openapi/cmd/OASContractGenerator.java
+++ b/openapi-cli/src/main/java/io/ballerina/openapi/cmd/OASContractGenerator.java
@@ -33,6 +33,7 @@ import io.ballerina.projects.Module;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.directory.ProjectLoader;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
@@ -61,12 +62,17 @@ public class OASContractGenerator {
     private List<OpenAPIMapperDiagnostic> diagnostics = new ArrayList<>();
     private PrintStream outStream = System.out;
     private Boolean ballerinaExtension = false;
+    private ProjectEnvironmentBuilder environmentBuilder = null;
 
     /**
      * Initialize constructor.
      */
     public OASContractGenerator() {
 
+    }
+
+    public void setEnvironmentBuilder(ProjectEnvironmentBuilder environmentBuilder) {
+        this.environmentBuilder = environmentBuilder;
     }
 
     public void setBallerinaExtension(Boolean ballerinaExtension) {
@@ -89,7 +95,9 @@ public class OASContractGenerator {
     public void generateOAS3DefinitionsAllService(Path servicePath, Path outPath, String serviceName,
                                                   Boolean needJson) {
         // Load project instance for single ballerina file
-        project = ProjectLoader.load(servicePath).project();
+        project = environmentBuilder != null
+                ? ProjectLoader.load(servicePath, environmentBuilder).project()
+                : ProjectLoader.load(servicePath).project();
         DiagnosticResult diagnosticsFromCodeGenAndModify = project.currentPackage().runCodeGenAndModifyPlugins();
         boolean hasErrorsFromCodeGenAndModify = diagnosticsFromCodeGenAndModify.diagnostics().stream()
                 .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/TestUtils.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/TestUtils.java
@@ -23,8 +23,6 @@ import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
-import io.ballerina.projects.environment.Environment;
-import io.ballerina.projects.environment.EnvironmentBuilder;
 import org.testng.Assert;
 
 import java.io.File;
@@ -43,18 +41,7 @@ import java.util.stream.Stream;
 public class TestUtils {
 
     private static final Path RES_DIR = Paths.get("src/test/resources/ballerina-to-openapi/").toAbsolutePath();
-    private static final ProjectEnvironmentBuilder SHARED_ENV_BUILDER = createSharedEnvironmentBuilder();
-
-    private static ProjectEnvironmentBuilder createSharedEnvironmentBuilder() {
-        String ballerinaHome = System.getProperty("ballerina.home");
-        if (ballerinaHome == null || ballerinaHome.isBlank()) {
-            return null;
-        }
-        Environment environment = EnvironmentBuilder.getBuilder()
-                .setBallerinaHome(Paths.get(ballerinaHome))
-                .build();
-        return ProjectEnvironmentBuilder.getBuilder(environment);
-    }
+    private static final ProjectEnvironmentBuilder SHARED_ENV_BUILDER = ProjectEnvironmentBuilder.getDefaultBuilder();
 
     private static String getStringFromGivenBalFile(Path expectedServiceFile, String s) throws IOException {
         Stream<String> expectedServiceLines = Files.lines(expectedServiceFile.resolve(s));

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/TestUtils.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/TestUtils.java
@@ -22,6 +22,9 @@ import io.ballerina.openapi.service.mapper.diagnostic.OpenAPIMapperDiagnostic;
 import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
 import org.testng.Assert;
 
 import java.io.File;
@@ -40,6 +43,18 @@ import java.util.stream.Stream;
 public class TestUtils {
 
     private static final Path RES_DIR = Paths.get("src/test/resources/ballerina-to-openapi/").toAbsolutePath();
+    private static final ProjectEnvironmentBuilder SHARED_ENV_BUILDER = createSharedEnvironmentBuilder();
+
+    private static ProjectEnvironmentBuilder createSharedEnvironmentBuilder() {
+        String ballerinaHome = System.getProperty("ballerina.home");
+        if (ballerinaHome == null || ballerinaHome.isBlank()) {
+            return null;
+        }
+        Environment environment = EnvironmentBuilder.getBuilder()
+                .setBallerinaHome(Paths.get(ballerinaHome))
+                .build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
 
     private static String getStringFromGivenBalFile(Path expectedServiceFile, String s) throws IOException {
         Stream<String> expectedServiceLines = Files.lines(expectedServiceFile.resolve(s));
@@ -64,6 +79,7 @@ public class TestUtils {
                                                                       List<String> yamlFiles) throws IOException {
         Path tempDir = Files.createTempDirectory("bal-to-openapi-test-out-" + System.nanoTime());
         OASContractGenerator openApiConverter = new OASContractGenerator();
+        openApiConverter.setEnvironmentBuilder(SHARED_ENV_BUILDER);
         try {
             openApiConverter.generateOAS3DefinitionsAllService(ballerinaFilePath, tempDir, null, false);
             for (String yamlFile : yamlFiles) {
@@ -91,6 +107,7 @@ public class TestUtils {
     public static List<OpenAPIMapperDiagnostic> compareWithGeneratedFile(OASContractGenerator openApiConverter,
                                                                          Path ballerinaFilePath, String yamlFile)
             throws IOException {
+        openApiConverter.setEnvironmentBuilder(SHARED_ENV_BUILDER);
         Path tempDir = Files.createTempDirectory("bal-to-openapi-test-out-" + System.nanoTime());
         try {
             String expectedYamlContent = getStringFromGivenBalFile(RES_DIR.resolve("expected_gen"), yamlFile);


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8825

This pull request improves test stability in the openapi-tools test suite by addressing intermittent failures caused by resource contention during test execution.

### Problem

The test suite (approximately 890 tests in a single JVM) was experiencing sporadic failures where OpenAPI specification generation would silently fail. Root cause analysis revealed that each test was independently resolving and loading the `ballerina/http` package from the distribution repository, creating I/O contention and intermittent failures under continuous integration load.

### Solution

Implemented an environment sharing strategy across the test suite:

- **OASContractGenerator**: Added a `setEnvironmentBuilder()` method that allows tests to inject a shared `ProjectEnvironmentBuilder`. When provided, the generator uses the shared environment during project loading; otherwise it falls back to the default behavior.

- **TestUtils**: Creates a single shared `ProjectEnvironmentBuilder` instance (initialized from the `ballerina.home` system property) at class load time and configures all `OASContractGenerator` instances used in tests to utilize this shared environment.

### Result
The package repository is now populated once and reused throughout the entire test suite execution, eliminating redundant dependency resolution and the associated I/O contention. This delivers more stable and reliable test execution with fewer intermittent failures.