### PR TITLE
Fix OpenAPI schema generation for request interceptors without nil

### DIFF
--- a/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/interceptor/types/Interceptor.java
+++ b/ballerina-to-openapi/src/main/java/io/ballerina/openapi/service/mapper/interceptor/types/Interceptor.java
@@ -90,7 +90,7 @@ public abstract class Interceptor extends Resource {
 
     protected void setReturnType(TypeSymbol returnType) {
         TypeSymbol effectiveReturnType;
-        if (isSubTypeOfDefaultInterceptorReturnType(returnType, semanticModel)) {
+        if (isContinuationReturnType(returnType, semanticModel)) {
             continueExecution = true;
             effectiveReturnType = getEffectiveReturnType(returnType, semanticModel);
         } else {
@@ -104,6 +104,11 @@ public abstract class Interceptor extends Resource {
         extractErrorAndNonErrorReturnTypes(effectiveReturnType);
     }
 
+    private boolean isContinuationReturnType(TypeSymbol typeSymbol, SemanticModel semanticModel) {
+        return isSubTypeOfDefaultInterceptorReturnType(typeSymbol, semanticModel) ||
+                getType().equals(InterceptorType.REQUEST) && containsHttpNextServiceType(typeSymbol, semanticModel);
+    }
+
     private boolean isSubTypeOfDefaultInterceptorReturnType(TypeSymbol typeSymbol, SemanticModel semanticModel) {
         Optional<Symbol> optNextServiceType = semanticModel.types().getTypeByName(BALLERINA, HTTP,
                 EMPTY, NEXT_SERVICE);
@@ -114,6 +119,20 @@ public abstract class Interceptor extends Resource {
         UnionTypeSymbol defaultInterceptorReturnType = semanticModel.types().builder().UNION_TYPE.withMemberTypes(
                 nextServiceType.typeDescriptor(), semanticModel.types().NIL).build();
         return defaultInterceptorReturnType.subtypeOf(typeSymbol);
+    }
+
+    private boolean containsHttpNextServiceType(TypeSymbol typeSymbol, SemanticModel semanticModel) {
+        if (isSubTypeOfHttpNextServiceType(typeSymbol, semanticModel)) {
+            return true;
+        }
+        if (typeSymbol instanceof TypeReferenceTypeSymbol typeReference) {
+            return containsHttpNextServiceType(typeReference.typeDescriptor(), semanticModel);
+        }
+        if (typeSymbol instanceof UnionTypeSymbol unionType) {
+            return unionType.userSpecifiedMemberTypes().stream()
+                    .anyMatch(memberType -> containsHttpNextServiceType(memberType, semanticModel));
+        }
+        return false;
     }
 
     private boolean isSubTypeOfHttpNextServiceType(TypeSymbol typeSymbol, SemanticModel semanticModel) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ group=io.ballerina
 version=2.4.2-SNAPSHOT
 
 ballerinaToOpenAPIVersion=2.4.0
-ballerinaToOpenAPIPublish=false
+ballerinaToOpenAPIPublish=true
 
 # Plugin Versions
 spotbugsPluginVersion=6.0.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
 group=io.ballerina
 version=2.4.2-SNAPSHOT
 
-ballerinaToOpenAPIVersion=2.4.0
+ballerinaToOpenAPIVersion=2.4.1-SNAPSHOT
 ballerinaToOpenAPIPublish=true
 
 # Plugin Versions

--- a/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/InterceptorTests.java
+++ b/openapi-cli/src/test/java/io/ballerina/openapi/generators/openapi/InterceptorTests.java
@@ -68,6 +68,13 @@ public class InterceptorTests {
         compareWithGeneratedFile(ballerinaFilePath, "interceptors/request_interceptors/interceptors11.yaml");
     }
 
+    @Test(description = "Test request interceptor return type with NextService and without nil")
+    public void testRequestInterceptorWithoutNilReturn() throws IOException {
+        Path ballerinaFilePath = INTERCEPTOR_DIR.resolve("request_interceptors/interceptors12.bal");
+        compareWithGeneratedFile(ballerinaFilePath,
+                "interceptors/request_interceptors/interceptors12.yaml");
+    }
+
     @Test(description = "Test with response interceptor")
     public void testResponseInterceptor() throws IOException {
         for (int i = 0; i <= 5; i++) {

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/interceptors/request_interceptors/interceptors12.yaml
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/expected_gen/interceptors/request_interceptors/interceptors12.yaml
@@ -1,0 +1,73 @@
+openapi: 3.0.1
+info:
+  title: PayloadV
+  version: 0.0.0
+servers:
+  - url: "{server}:{port}/payloadV"
+    variables:
+      server:
+        default: http://localhost
+      port:
+        default: "9090"
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      responses:
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorPayload"
+        "401":
+          description: Unauthorized
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FooResponse"
+components:
+  schemas:
+    Bar:
+      required:
+        - message
+      type: object
+      properties:
+        message:
+          type: string
+      additionalProperties: false
+    ErrorPayload:
+      required:
+        - message
+        - method
+        - path
+        - reason
+        - status
+        - timestamp
+      type: object
+      properties:
+        timestamp:
+          type: string
+        status:
+          type: integer
+          format: int64
+        reason:
+          type: string
+        message:
+          type: string
+        path:
+          type: string
+        method:
+          type: string
+    FooResponse:
+      required:
+        - bars
+      type: object
+      properties:
+        bars:
+          type: array
+          items:
+            $ref: "#/components/schemas/Bar"
+      additionalProperties: false

--- a/openapi-cli/src/test/resources/ballerina-to-openapi/interceptors/request_interceptors/interceptors12.bal
+++ b/openapi-cli/src/test/resources/ballerina-to-openapi/interceptors/request_interceptors/interceptors12.bal
@@ -1,0 +1,32 @@
+import ballerina/http;
+
+type Bar record {|
+    string message;
+|};
+
+type FooResponse record {|
+    Bar[] bars;
+|};
+
+service class RequestInterceptor {
+    *http:RequestInterceptor;
+
+    resource function 'default [string... path](http:RequestContext ctx)
+            returns http:NextService|http:Unauthorized|error {
+        return http:UNAUTHORIZED;
+    }
+}
+
+service http:InterceptableService /payloadV on new http:Listener(9090) {
+
+    public function createInterceptors() returns RequestInterceptor {
+        return new RequestInterceptor();
+    }
+
+    resource function get foo() returns FooResponse|http:InternalServerError {
+        FooResponse response = {
+            bars: []
+        };
+        return response;
+    }
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Fix: https://github.com/wso2-enterprise/wso2-integration-internal/issues/5218
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed OpenAPI schema generation for request interceptors with return types that include `http:NextService` without `nil`.
- Added coverage for direct, referenced, and union-based continuation return types.
- Added an interceptor test fixture and expected OpenAPI definition.
- Updated the `ballerina-to-openapi` package version and enabled publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->